### PR TITLE
feat: go coverage badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,9 +102,9 @@ jobs:
         with:
           profile: cover.out
           local-prefix: github.com/org/project
-          threshold-file: 80
-          threshold-package: 80
-          threshold-total: 90
+            #threshold-file: 10
+            #threshold-package: 10
+            #threshold-total: 10
     
       - name: make coverage badge
         uses: action-badges/core@0.2.2


### PR DESCRIPTION
## Purpose

As long as the project is not public accessible, we can't onboard It in sonarcloud. However I want to make the test coverage visible and the easiest way that comes into my mind is with a simple badge.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check

Verify that the following are valid

* Coverage badge in README.md

## Other Information
<!-- Add any other helpful information that may be needed here. -->