### PR TITLE
chore: markdown files on root level shall not trigger test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ name: Terraform Provider Tests
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - '*.md'
   push:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
+      - '*.md'
   workflow_dispatch:    
 
 # Testing only needs permissions to read the repository contents.


### PR DESCRIPTION
## Purpose

I don't see a reason why changes to the developer documentation or readme should trigger the test pipeline. Thus deactivating it

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check

Verify that the following are valid

* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->