### PR TITLE
feat(subaccount): support update

### DIFF
--- a/internal/btpcli/client_test.go
+++ b/internal/btpcli/client_test.go
@@ -247,9 +247,9 @@ func TestV2Client_Execute(t *testing.T) {
 	t.Run("custom idp: request header `X-CPCLI-CustomIdp` must be set", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "my.custom.idp", r.Header.Get(HeaderCLICustomIDP))
-            w.Header().Set(HeaderCLIBackendStatus, fmt.Sprintf("%d", 201))
-            w.Header().Set(HeaderCLIBackendMediaType, "backend/mediatype")
-            fmt.Fprintf(w, "{}")
+			w.Header().Set(HeaderCLIBackendStatus, fmt.Sprintf("%d", 201))
+			w.Header().Set(HeaderCLIBackendMediaType, "backend/mediatype")
+			fmt.Fprintf(w, "{}")
 		}))
 		defer srv.Close()
 
@@ -265,9 +265,9 @@ func TestV2Client_Execute(t *testing.T) {
 			},
 		}
 
-        _, err := uut.Execute(context.TODO(), NewGetRequest("subaccount/role", map[string]string{}))
+		_, err := uut.Execute(context.TODO(), NewGetRequest("subaccount/role", map[string]string{}))
 
-        assert.NoError(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -59,6 +59,13 @@ func (f *accountsSubaccountFacade) Create(ctx context.Context, displayName strin
 	}))
 }
 
+func (f *accountsSubaccountFacade) Update(ctx context.Context, subaccountId string, displayName string) (cis.SubaccountResponseObject, *CommandResponse, error) { // TODO switch to object
+	return doExecute[cis.SubaccountResponseObject](f.cliClient, ctx, NewUpdateRequest(f.getCommand(), map[string]string{
+		"subaccount":  subaccountId,
+		"displayName": displayName,
+	}))
+}
+
 func (f *accountsSubaccountFacade) Delete(ctx context.Context, subaccountId string) (cis.SubaccountResponseObject, *CommandResponse, error) {
 	return doExecute[cis.SubaccountResponseObject](f.cliClient, ctx, NewDeleteRequest(f.getCommand(), map[string]string{
 		"subaccount":  subaccountId,

--- a/internal/btpcli/facade_accounts_subaccount_test.go
+++ b/internal/btpcli/facade_accounts_subaccount_test.go
@@ -106,6 +106,34 @@ func TestAccountsSubaccountFacade_Create(t *testing.T) {
 	})
 }
 
+func TestAccountsSubaccountFacade_Update(t *testing.T) {
+	command := "accounts/subaccount"
+
+	subaccountId := "6aa64c2f-38c1-49a9-b2e8-cf9fea769b7f"
+	displayName := "my-account"
+
+	t.Run("constructs the CLI params correctly", func(t *testing.T) {
+		var srvCalled bool
+
+		uut, srv := prepareClientFacadeForTest(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			srvCalled = true
+
+			assertCall(t, r, command, ActionUpdate, map[string]string{
+				"subaccount":  subaccountId,
+				"displayName": displayName,
+			})
+
+		}))
+		defer srv.Close()
+
+		_, res, err := uut.Accounts.Subaccount.Update(context.TODO(), subaccountId, displayName)
+
+		if assert.True(t, srvCalled) && assert.NoError(t, err) {
+			assert.Equal(t, 200, res.StatusCode)
+		}
+	})
+}
+
 func TestAccountsSubaccountFacade_Delete(t *testing.T) {
 	command := "accounts/subaccount"
 


### PR DESCRIPTION
## Purpose
Adds support for updating the displayName of a subaccount.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* create a subaccount using hcl
* change the `name` attribute
* run `terraform apply` again

## What to Check

Verify that the following are valid

* check the cockpit for the updated account

## Other Information
<!-- Add any other helpful information that may be needed here. -->