### PR TITLE
fix: make remote user explicit to change UID of files in workspace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,9 +20,8 @@
 	"postCreateCommand": "cp ./assets/provider-config-local.txt ~/.terraformrc",
 	"hostRequirements": {
 		"memory": "4gb"
-	}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"remoteUser": "vscode"
 }


### PR DESCRIPTION
## Purpose

This PR fixes issue #78 when using a devcontainer. To resolve the issue the remote user is explicitly defined in order to override the Uids in the file system (default would be root). Otherwise the symlinking and chmod tasks cannot be executed successfully 

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Open the devcontainer
* Set the env variables BTP_USERNAME and BTP_PASSWORD to your username and password
* Execute `go test ./...`

## What to Check

Verify that the following are valid

* The tests can be executed successfully, Especially the error messages from the issues #78 do not appear.

## Other Information
n/a