### PR TITLE
chore: adding tip to bug report to attach HCL files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,10 @@ body:
   - type: textarea
     attributes:
       label: Steps To Reproduce
-      description: Describe the steps to reproduce the observed behavior.
+      description: |
+        Describe the steps to reproduce the observed behavior.
+
+        Tip: You can attach your HCL files and Terraform scripts here by clicking this area to highlight it and then dragging files in.
       placeholder: |
         1. Go to '...'
         2. Click on '....'


### PR DESCRIPTION
## Purpose

This PR fixes issue #130. The description section of "steps to reproduce" was enhanced that you can also attach HCL files or Terraform scripts to the section to make the analysis more targeted 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code

```
Open an issue of type bug
```

## What to Check

Verify that the following are valid

* The description area shall contain the new tip for guidance

## Other Information

Only testable once the repo is public as the issue templates use the new YAML-based format not supported yet in private repos