### PR TITLE
fix: for 'error strings should not end with punctuation or newlines (…

### DIFF
--- a/internal/provider/datasource_subaccount_service_binding.go
+++ b/internal/provider/datasource_subaccount_service_binding.go
@@ -135,7 +135,7 @@ func (ds *subaccountServiceBindingDataSource) Read(ctx context.Context, req data
 	} else if !data.Name.IsNull() {
 		cliRes, _, err = ds.cli.Services.Binding.GetByName(ctx, data.SubaccountId.ValueString(), data.Name.ValueString())
 	} else {
-		err = fmt.Errorf("neither binding ID, nor binding Name have been provided.")
+		err = fmt.Errorf("neither binding ID, nor binding Name have been provided")
 	}
 
 	if err != nil {

--- a/internal/provider/datasource_subaccount_service_broker.go
+++ b/internal/provider/datasource_subaccount_service_broker.go
@@ -127,7 +127,7 @@ func (ds *subaccountServiceBrokerDataSource) Read(ctx context.Context, req datas
 	} else if !data.Name.IsNull() {
 		cliRes, _, err = ds.cli.Services.Broker.GetByName(ctx, data.SubaccountId.ValueString(), data.Name.ValueString())
 	} else {
-		err = fmt.Errorf("neither broker ID, nor broker Name have been provided.")
+		err = fmt.Errorf("neither broker ID, nor broker Name have been provided")
 	}
 
 	if err != nil {

--- a/internal/provider/datasource_subaccount_service_instance.go
+++ b/internal/provider/datasource_subaccount_service_instance.go
@@ -138,7 +138,7 @@ func (ds *subaccountServiceInstanceDataSource) Read(ctx context.Context, req dat
 	} else if !data.Name.IsNull() {
 		cliRes, _, err = ds.cli.Services.Instance.GetByName(ctx, data.SubaccountId.ValueString(), data.Name.ValueString())
 	} else {
-		err = fmt.Errorf("neither instance ID, nor instance Name have been provided.")
+		err = fmt.Errorf("neither instance ID, nor instance Name have been provided")
 	}
 
 	if err != nil {

--- a/internal/provider/datasource_subaccount_service_offering.go
+++ b/internal/provider/datasource_subaccount_service_offering.go
@@ -160,7 +160,7 @@ func (ds *subaccountServiceOfferingDataSource) Read(ctx context.Context, req dat
 	} else if !data.Name.IsNull() {
 		cliRes, _, err = ds.cli.Services.Offering.GetByName(ctx, data.SubaccountId.ValueString(), data.Name.ValueString())
 	} else {
-		err = fmt.Errorf("neither offering ID, nor offering Name have been provided.")
+		err = fmt.Errorf("neither offering ID, nor offering Name have been provided")
 	}
 
 	if err != nil {

--- a/internal/provider/datasource_subaccount_service_plan.go
+++ b/internal/provider/datasource_subaccount_service_plan.go
@@ -150,7 +150,7 @@ func (ds *subaccountServicePlanDataSource) Read(ctx context.Context, req datasou
 	} else if !data.Name.IsNull() && !data.OfferingName.IsNull() {
 		cliRes, _, err = ds.cli.Services.Plan.GetByName(ctx, data.SubaccountId.ValueString(), data.Name.ValueString(), data.OfferingName.ValueString())
 	} else {
-		err = fmt.Errorf("neither offering ID, nor offering Name have been provided.")
+		err = fmt.Errorf("neither offering ID, nor offering Name have been provided")
 	}
 
 	if err != nil {

--- a/internal/provider/datasource_subaccount_service_platform.go
+++ b/internal/provider/datasource_subaccount_service_platform.go
@@ -128,7 +128,7 @@ func (ds *subaccountServicePlatformDataSource) Read(ctx context.Context, req dat
 	} else if !data.Name.IsNull() {
 		cliRes, _, err = ds.cli.Services.Platform.GetByName(ctx, data.SubaccountId.ValueString(), data.Name.ValueString())
 	} else {
-		err = fmt.Errorf("neither platform ID, nor platform Name have been provided.")
+		err = fmt.Errorf("neither platform ID, nor platform Name have been provided")
 	}
 
 	if err != nil {


### PR DESCRIPTION
…ST1005)'

## Purpose

* Fix for gostatic warnings: "error strings should not end with punctuation or newlines (ST1005)"

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

In VSCode: check problems view

## What to Check

Verify that the following are valid

In VSCode: check problems view -> no messages should appear

## Other Information

n/a