### PR TITLE
chore: add needs-triage label to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug report
 description: File a bug/issue to help us improve
 title: "[BUG]"
-labels: [bug]
+labels: [bug, needs-triage]
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: 💡Feature request
 description: Suggest an idea for this project
 title: "[FEATURE]"
-labels: [enhancement]
+labels: [enhancement, needs-triage]
 body:
   - type: dropdown
     attributes:


### PR DESCRIPTION
## Purpose

This PR adds the label "needs-triage" to the issue templates. This helps us to identify new issues and helps to keep the reporter informed if we already investigated on the issue.

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Workflow
```

## How to Test

Possible after repository is public

```
Create a issue via the templates
```

## What to Check

Verify that the following are valid

* The label "needs-triage" should be assigned automatically

## Other Information

n/a