### PR TITLE
chore: update supported Terraform versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,11 +62,11 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.0.*'
           - '1.1.*'
           - '1.2.*'
           - '1.3.*'
           - '1.4.*'
+          - '1.5.x'
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1


### PR DESCRIPTION
## Purpose

This PR updates the test matrix of supported Terraform versions. According to Terraforms [support period](https://support.hashicorp.com/hc/en-us/articles/360021185113) a major release is supported for two years after GA. 

As a consequence:

* 1.0.x is out of support (GA on 8th of June 2021) => removed it from test matrix
* 1.5.x is a new release (GA on 12th of June) => added to test matrix


## Does this introduce a breaking change?

```
[X] Yes
[ ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Update of test matrix
```

## How to Test

* Test the code

```
Run the test workflow
```

## What to Check

Verify that the following are valid

* All tests should pass

## Other Information

n/a
