### PR TITLE
feat(role_collection_assignment): group names must not be empty

### DIFF
--- a/internal/provider/resource_directory_role_collection_assignment.go
+++ b/internal/provider/resource_directory_role_collection_assignment.go
@@ -66,6 +66,9 @@ func (rs *directoryRoleCollectionAssignmentResource) Schema(_ context.Context, _
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				MarkdownDescription: "The username of the user to assign.",

--- a/internal/provider/resource_globalaccount_role_collection_assignment.go
+++ b/internal/provider/resource_globalaccount_role_collection_assignment.go
@@ -54,6 +54,9 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Schema(_ context.Contex
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				MarkdownDescription: "The name of the user to assign.",

--- a/internal/provider/resource_subaccount_role_collection_assignment.go
+++ b/internal/provider/resource_subaccount_role_collection_assignment.go
@@ -66,6 +66,9 @@ func (rs *subaccountRoleCollectionAssignmentResource) Schema(_ context.Context, 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				MarkdownDescription: "The username of the user to assign.",


### PR DESCRIPTION
## Purpose

Adding more client side validation rules to all the `role_collection_assignment` resources. If a user wants to assign a certain role_collection to a group, group name and role_collection must obviously not be empty.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: validation
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check

Verify that the following are valid

* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->