### PR TITLE
fix(sonarcloud): coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: coverage-report
-          path: cover.out
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: coverage-report
           path: cover.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: coverage-report
+          path: cover.out
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Fixes 

```bash
INFO: Sensor Go Cover sensor for Go coverage [go]
ERROR: Coverage report can't be loaded, report file not found, ignoring this file cover.out.
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* check the scan log ([here](https://github.com/SAP/terraform-provider-btp/actions/runs/5333001472/jobs/9663028325?pr=203#step:5:96)). the error listed above shouldn't appear anymore
* check the coverage [here](https://sonarcloud.io/summary/overall?id=SAP_terraform-provider-btp) once merged

## What to Check

Verify that the following are valid

* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->