### PR TITLE
fix(directory_user): custom idp in test must be postfixed with -platform

### DIFF
--- a/internal/provider/datasource_directory_user_test.go
+++ b/internal/provider/datasource_directory_user_test.go
@@ -53,8 +53,8 @@ func TestDataSourceDirectoryUser(t *testing.T) {
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "user_name", "jenny.doe@test.com"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "origin", "terraformint-platform"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "active", "true"),
-                        resource.TestCheckResourceAttr("data.btp_directory_user.uut", "family_name", "unknown"), //FIXME should be empty, see NGPBUG-357810
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "given_name", "unknown"), //FIXME should be empty, see NGPBUG-357810
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "family_name", "unknown"), //FIXME should be empty, see NGPBUG-357810
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "given_name", "unknown"),  //FIXME should be empty, see NGPBUG-357810
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "id", "2b5382f4-1922-4803-8dcb-5babe097b12b"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "role_collections.#", "0"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "verified", "false"),

--- a/internal/provider/datasource_directory_user_test.go
+++ b/internal/provider/datasource_directory_user_test.go
@@ -27,10 +27,10 @@ func TestDataSourceDirectoryUser(t *testing.T) {
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "directory_id", "05368777-4934-41e8-9f3c-6ec5f4d564b9"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "user_name", "jenny.doe@test.com"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "origin", "ldap"),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "active", "false"),
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "active", "true"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "family_name", ""),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "given_name", ""),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "id", ""),
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "id", "40c72ef9-b901-4b89-91fb-3d283231f7b4"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "role_collections.#", "0"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "verified", "false"),
 					),
@@ -47,15 +47,15 @@ func TestDataSourceDirectoryUser(t *testing.T) {
 			ProtoV6ProviderFactories: getProviders(rec.GetDefaultClient()),
 			Steps: []resource.TestStep{
 				{
-					Config: hclProvider() + hclDatasourceDirectoryUserCustomIdp("uut", "05368777-4934-41e8-9f3c-6ec5f4d564b9", "jenny.doe@test.com", "terraformint"),
+					Config: hclProvider() + hclDatasourceDirectoryUserCustomIdp("uut", "05368777-4934-41e8-9f3c-6ec5f4d564b9", "jenny.doe@test.com", "terraformint-platform"),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "directory_id", "05368777-4934-41e8-9f3c-6ec5f4d564b9"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "user_name", "jenny.doe@test.com"),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "origin", "terraformint"),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "active", "false"),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "family_name", ""),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "given_name", ""),
-						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "id", ""),
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "origin", "terraformint-platform"),
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "active", "true"),
+                        resource.TestCheckResourceAttr("data.btp_directory_user.uut", "family_name", "unknown"), //FIXME should be empty, see NGPBUG-357810
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "given_name", "unknown"), //FIXME should be empty, see NGPBUG-357810
+						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "id", "2b5382f4-1922-4803-8dcb-5babe097b12b"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "role_collections.#", "0"),
 						resource.TestCheckResourceAttr("data.btp_directory_user.uut", "verified", "false"),
 					),

--- a/internal/provider/fixtures/datasource_directory_user.custom_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_user.custom_idp.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -18,8 +18,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 11e7a62b-adb4-032c-9062-ccd5d911dadf
+                - 03ab3fe3-f6e6-f4ef-43a9-eda07ee7e744
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -30,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:26 GMT
+                - Fri, 23 Jun 2023 08:49:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -55,31 +57,33 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 90b386dd-4344-4d34-7557-cc52b041548a
+                - a31236b1-7771-4183-67c9-8c18263a4f7d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 540.694954ms
+        duration: 400.581396ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 125
+        content_length: 134
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint","userName":"jenny.doe@test.com"}}
+            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint-platform","userName":"jenny.doe@test.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - adec189e-6296-12d1-04fa-ba0ec53169fc
+                - e999526d-3120-d981-bfa2-e10ff7e9f68d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -98,14 +102,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"2b5382f4-1922-4803-8dcb-5babe097b12b","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":0,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:27 GMT
+                - Fri, 23 Jun 2023 08:49:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -117,26 +121,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ef96d08e-1e37-4a21-5c69-e9883efd6aec
+                - e1dcabeb-ff8f-426d-49b2-146da6a746a8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 358.847539ms
+        duration: 456.285848ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -148,8 +154,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 28551cb0-606d-cf22-9cd5-dba52ab3e7df
+                - f816bf52-bbd0-b805-c9e2-9b67d16ec07c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -160,18 +168,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:28 GMT
+                - Fri, 23 Jun 2023 08:49:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -185,31 +193,33 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 21b6ac27-88fd-4be2-4680-0d2f07ad639f
+                - a15049e0-71b5-4340-6257-cd2db30432aa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 556.514036ms
+        duration: 555.450657ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 125
+        content_length: 134
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint","userName":"jenny.doe@test.com"}}
+            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint-platform","userName":"jenny.doe@test.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - dbdfff32-9e9c-0796-a2b6-f91f4ad710b4
+                - d54c5482-2199-46c0-900e-822556f0eb4b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -228,14 +238,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"2b5382f4-1922-4803-8dcb-5babe097b12b","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":0,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:29 GMT
+                - Fri, 23 Jun 2023 08:49:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -247,26 +257,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cbadd361-d817-4f65-5ca2-b809677425c0
+                - 6079394c-5c1f-4f62-62cf-360a4573fd38
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 299.534997ms
+        duration: 468.470378ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -278,8 +290,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 1da859cb-6019-5019-4f45-da4e78553d2e
+                - 255c39bc-a31f-9b19-3b3d-42555abb111d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -290,18 +304,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:30 GMT
+                - Fri, 23 Jun 2023 08:49:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -315,31 +329,33 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 33c841df-f272-4d51-6390-fa27f535b77f
+                - 023b203e-7617-406b-5c1d-a9828b5a841a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 486.94901ms
+        duration: 459.884493ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 125
+        content_length: 134
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint","userName":"jenny.doe@test.com"}}
+            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint-platform","userName":"jenny.doe@test.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 553589cc-e998-a5ea-d863-858293d4a022
+                - fbc81cd2-3ac7-31b3-af27-c4817084b127
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -358,14 +374,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"2b5382f4-1922-4803-8dcb-5babe097b12b","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":0,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:31 GMT
+                - Fri, 23 Jun 2023 08:49:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -377,26 +393,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a67d02f8-0c04-4386-4093-987ae624d657
+                - 6844711c-78cd-42d8-4dff-c7e2b518c58d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 383.633517ms
+        duration: 353.269502ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -408,8 +426,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 809a6fef-067e-b76e-d825-0610d233a285
+                - fa583559-150b-79da-d3ea-b4a027f17f9c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -420,18 +440,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:32 GMT
+                - Fri, 23 Jun 2023 08:49:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -445,31 +465,33 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c18b2c58-5a38-4447-7fd5-52768f1a262f
+                - d498b69c-2ffa-4f83-6388-f94450e4780f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 483.820373ms
+        duration: 383.387172ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 125
+        content_length: 134
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint","userName":"jenny.doe@test.com"}}
+            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint-platform","userName":"jenny.doe@test.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 6e3da866-9188-5673-a149-9e2d93a6a81c
+                - b16de49b-6cf5-0095-0ebf-85b7729dc0ab
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -488,14 +510,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"2b5382f4-1922-4803-8dcb-5babe097b12b","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":0,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:33 GMT
+                - Fri, 23 Jun 2023 08:49:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -507,26 +529,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bc096e81-217d-4ccc-48d7-45ff66835a0f
+                - 0399089c-5410-4638-41d2-f28a07f2460f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 274.41133ms
+        duration: 374.741047ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -538,8 +562,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 743723fc-300b-6702-c3d7-9851a979bc85
+                - f00b865e-8674-25bb-7165-49828a9d32e6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -550,18 +576,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:34 GMT
+                - Fri, 23 Jun 2023 08:49:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -575,31 +601,33 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 52208669-3061-4085-4b27-c1d3a937189d
+                - b13096f7-bc52-4818-5342-0a8f97399e8c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 440.355183ms
+        duration: 422.222134ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 125
+        content_length: 134
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint","userName":"jenny.doe@test.com"}}
+            {"paramValues":{"directory":"05368777-4934-41e8-9f3c-6ec5f4d564b9","origin":"terraformint-platform","userName":"jenny.doe@test.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 02f92720-a8b6-4928-4c88-2bc2ec4a804c
+                - 2b0bed56-b5dd-3d39-6dc0-9b0070b80fea
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -618,14 +646,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"2b5382f4-1922-4803-8dcb-5babe097b12b","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":0,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:35 GMT
+                - Fri, 23 Jun 2023 08:49:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -637,26 +665,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4adea084-f3f6-42ff-59c9-bf325f9f4747
+                - 1d682a3f-df59-49e3-4e06-85600ebaf74b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 286.060836ms
+        duration: 392.943509ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -668,8 +698,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 822d90e7-e87d-4eb6-c324-8d599b3f8f46
+                - a4982105-8764-b04f-6fdd-8f01679548a6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -680,18 +712,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:36 GMT
+                - Fri, 23 Jun 2023 08:49:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -705,9 +737,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b0c28050-631a-4b5c-4cea-57b7367e7a66
+                - 26727f29-cbfc-4876-5601-a949810c2a2c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 519.429943ms
+        duration: 408.396123ms

--- a/internal/provider/fixtures/datasource_directory_user.default_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_user.default_idp.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -18,8 +18,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 74628712-4707-21f0-cf99-34ebd9dcb0ea
+                - 8507e7c3-5ccd-b9b9-6fc4-82934d326a3e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -30,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:15 GMT
+                - Fri, 23 Jun 2023 08:48:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -55,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - efb5b675-29b3-4732-79e3-881abdb3ddf9
+                - 1d4d0544-db0b-4cd1-5d0a-18527ca4976d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 775.548126ms
+        duration: 1.130132274s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -78,8 +80,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - b554a217-00ea-97f7-8277-3590ec28a24c
+                - e583010d-734c-b447-2b6b-71d05d6a3414
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -98,14 +102,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":6,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:17 GMT
+                - Fri, 23 Jun 2023 08:48:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -117,26 +121,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9197dd40-d706-4c5e-79be-685b80ecce13
+                - abd5c9a5-0c2b-4b78-6f98-016b06a6d73a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 431.088415ms
+        duration: 423.204036ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -148,8 +154,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 7923868f-d7b2-70ee-c2cf-16ad211c4eb2
+                - cb8de8b7-7b30-1002-5e34-ec948b36be06
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -160,18 +168,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:17 GMT
+                - Fri, 23 Jun 2023 08:48:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -185,12 +193,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 55d19c2a-e2ea-4a0a-413f-eae980d176a8
+                - 524aa065-00c5-438c-4c36-bff9cfc7b46f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 379.540565ms
+        duration: 408.105974ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -208,8 +216,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 04963bc0-cd69-f942-894c-af528fd4b190
+                - 4844883f-2c41-316e-77ff-2a97e9a9887d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -228,14 +238,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":6,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:18 GMT
+                - Fri, 23 Jun 2023 08:48:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -247,26 +257,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 525c09fd-c06c-4ae0-647d-9ca6355a2614
+                - 11e3d7c4-9569-41ef-7576-ca396960939f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 328.012805ms
+        duration: 359.656806ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -278,8 +290,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 07284541-f7ea-dd10-ba88-6b47358b474f
+                - 2322b900-6b39-54ab-e07f-d157e6bb79eb
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -290,18 +304,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:19 GMT
+                - Fri, 23 Jun 2023 08:48:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -315,12 +329,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b146f586-1b25-4a5b-75de-c6a575704325
+                - 5ac4e1ac-9095-4bdc-5a2e-ca207c859b69
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 415.068684ms
+        duration: 596.748368ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -338,8 +352,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 270d2cb0-7fba-02aa-f365-dc78e3f1d75b
+                - 5f68924e-5731-5b74-ae1e-385f48a21f8f
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -358,14 +374,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":6,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:20 GMT
+                - Fri, 23 Jun 2023 08:48:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -377,26 +393,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fb82440a-1376-449c-419a-e371daf427ca
+                - 0b1d8e15-9945-42b2-55e1-1a1af379ca00
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 361.608117ms
+        duration: 423.067387ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -408,8 +426,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - ccddb7a2-4321-7350-61c5-757ed950716f
+                - 88931dd3-7f3b-3e44-4da6-0b8875598311
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -420,18 +440,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:21 GMT
+                - Fri, 23 Jun 2023 08:48:57 GMT
             Expires:
                 - "0"
             Pragma:
@@ -445,12 +465,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f6e60e30-6a97-41ee-47c8-210a5b4fcce4
+                - d330234c-8b83-4421-652f-58e3349a1c5b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 446.95523ms
+        duration: 488.16462ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -468,8 +488,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 429b8cfb-7836-2538-986a-109d68a56351
+                - 574285cf-165a-24de-3c1b-67874d92e33d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -488,14 +510,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":6,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:22 GMT
+                - Fri, 23 Jun 2023 08:48:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -507,26 +529,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9c4e3d74-6e76-46ba-6c49-1e0648367c71
+                - 5aa58a9f-b9fc-4bec-74cc-aaacfcba3bf0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 318.444471ms
+        duration: 429.894282ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -538,8 +562,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - f32d41c5-4274-a568-9a89-467559512754
+                - f186e459-4837-f3fc-9d1d-ef0a71ab80a8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -550,18 +576,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:23 GMT
+                - Fri, 23 Jun 2023 08:48:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -575,12 +601,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 95eeb1b8-6285-43e3-6da9-599ebdcf7aa6
+                - 1520725f-6b9d-4f57-5398-e45f8ee8209a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 559.22294ms
+        duration: 375.666916ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -598,8 +624,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - 76d92aee-cde3-e184-0906-acc3f869c8fc
+                - c2630f00-ba2a-7153-e088-7b00c94734ac
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -618,14 +646,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"error":"No such user: jenny.doe@test.com"}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":6,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:24 GMT
+                - Fri, 23 Jun 2023 08:49:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -637,26 +665,28 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Cpcli-Backend-Mediatype:
-                - application/json
+                - application/json;charset=utf-8
             X-Cpcli-Backend-Status:
-                - "404"
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Cpcli-Replacementrefreshtoken:
                 - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c3a6a224-d207-4211-6173-c049f09e4078
+                - d56672c6-e6a0-491d-7fcc-cac46c1c84f3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 363.365561ms
+        duration: 440.800099ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 113
+        content_length: 115
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -668,8 +698,10 @@ interactions:
         headers:
             Content-Type:
                 - application/json
+            User-Agent:
+                - Terraform/1.3.9 terraform-provider-btp/dev
             X-Correlationid:
-                - b56f0eda-48eb-2b4a-4d4d-b8abdc8e63e1
+                - 5634599b-147a-db98-478c-7884bec08c5e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -680,18 +712,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 139
+        content_length: 143
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "139"
+                - "143"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 02 Jun 2023 13:09:25 GMT
+                - Fri, 23 Jun 2023 08:49:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -705,9 +737,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 40a2cf4b-7a3c-4e3b-7abe-8723abf0eaf8
+                - 0385469d-d31c-4ac6-51d0-7299c97bc5d6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 618.592814ms
+        duration: 425.722758ms


### PR DESCRIPTION
## Purpose

While working on a different issue, I figured out that the tests for directory_user are wrongly setup. The IDP must be postfixed with `-platform` in order to retrieve valid values. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* check the service response in the updated fixtures

## What to Check

Verify that the following are valid

* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->