### PR TITLE
docs: use less abbreviations

### DIFF
--- a/docs/data-sources/directory.md
+++ b/docs/data-sources/directory.md
@@ -49,7 +49,7 @@ data "btp_directory" "by_id" {
 - `labels` (Map of Set of String) Set of words or phrases assigned to the directory.
 - `last_modified` (String) The date and time the resource was last modified in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 - `name` (String) The display name of the directory.
-- `parent_id` (String) The GUID of the directory's parent entity. Typically this is the global account.
+- `parent_id` (String) The ID of the directory's parent entity. Typically this is the global account.
 - `state` (String) The current state of the directory. Possible values are: 
 	 - `OK` The CRUD operation or series of operations completed successfully.
 	 - `STARTED` CRUD operation on an entity has started.
@@ -65,5 +65,5 @@ data "btp_directory" "by_id" {
 	 - `PROCESSING_FAILED` The processing operations failed.
 	 - `DELETION_FAILED` The delete operation failed, and the entity was not deleted.
 	 - `MOVE_FAILED` Entity could not be moved to a different location.
-	 - `MIGRATING` Migrating entity from NEO to CF.
+	 - `MIGRATING` Migrating entity from Neo to Cloud Foundry.
 - `subdomain` (String) Applies only to directories that have the user authorization management feature enabled. The subdomain is part of the path used to access the authorization tenant of the directory.

--- a/docs/data-sources/globalaccount.md
+++ b/docs/data-sources/globalaccount.md
@@ -80,7 +80,7 @@ data "btp_globalaccount" "this" {}
 	 - `PROCESSING_FAILED` The processing operations failed.
 	 - `DELETION_FAILED` The delete operation failed, and the entity was not deleted.
 	 - `MOVE_FAILED` Entity could not be moved to a different location.
-	 - `MIGRATING` Migrating entity from NEO to CF.
+	 - `MIGRATING` Migrating entity from Neo to Cloud Foundry.
 - `subdomain` (String) The subdomain is part of the path used to access the authorization tenant of the global account.
 - `usage` (String) For internal accounts, the intended purpose of the global account. Possible values are: 
 	 - `Development` For development of a service.

--- a/docs/data-sources/subaccount.md
+++ b/docs/data-sources/subaccount.md
@@ -39,7 +39,7 @@ data "btp_subaccount" "my_account" {
 - `last_modified` (String) The date and time the resource was last modified in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 - `name` (String) A descriptive name of the subaccount for customer-facing UIs.
 - `parent_features` (Set of String) The features of parent entity of the subaccount.
-- `parent_id` (String) The GUID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the GUID of the global account.
+- `parent_id` (String) The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.
 - `region` (String) The region in which the subaccount was created.
 - `state` (String) The current state of the subaccount. Possible values are: 
 	 - `OK`

--- a/docs/data-sources/subaccounts.md
+++ b/docs/data-sources/subaccounts.md
@@ -52,7 +52,7 @@ Read-Only:
 - `last_modified` (String) The date and time the resource was last modified in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 - `name` (String) A descriptive name of the subaccount for customer-facing UIs.
 - `parent_features` (Set of String) The features of parent entity of the subaccount.
-- `parent_id` (String) The GUID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the GUID of the global account.
+- `parent_id` (String) The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.
 - `region` (String) The region in which the subaccount was created.
 - `state` (String) The current state of the subaccount. Possible values are: 
 	 - `OK`

--- a/docs/resources/directory.md
+++ b/docs/resources/directory.md
@@ -49,7 +49,7 @@ resource "btp_directory" "child" {
 ### Optional
 
 - `description` (String) A description of the directory.
-- `parent_id` (String) The GUID of the directory's parent entity. Typically this is the global account.
+- `parent_id` (String) The ID of the directory's parent entity. Typically this is the global account.
 - `subdomain` (String) Applies only to directories that have the user authorization management feature enabled. The subdomain becomes part of the path used to access the authorization tenant of the directory. It has to be unique within the defined region.
 
 ### Read-Only
@@ -81,7 +81,7 @@ resource "btp_directory" "child" {
 	 - `PROCESSING_FAILED` The processing operations failed.
 	 - `DELETION_FAILED` The delete operation failed, and the entity was not deleted.
 	 - `MOVE_FAILED` Entity could not be moved to a different location.
-	 - `MIGRATING` Migrating entity from NEO to CF.
+	 - `MIGRATING` Migrating entity from Neo to Cloud Foundry.
 
 ## Import
 

--- a/docs/resources/subaccount.md
+++ b/docs/resources/subaccount.md
@@ -58,7 +58,7 @@ resource "btp_subaccount" "my_project_on_azure" {
 - `beta_enabled` (Boolean) Whether the subaccount can use beta services and applications.
 - `description` (String) A description of the subaccount for customer-facing UIs.
 - `labels` (Map of Set of String) Set of words or phrases assigned to the subaccount.
-- `parent_id` (String) The GUID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the GUID of the global account.
+- `parent_id` (String) The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.
 
 ### Read-Only
 

--- a/internal/provider/datasource_directory.go
+++ b/internal/provider/datasource_directory.go
@@ -89,7 +89,7 @@ __Further documentation:__
 				Computed:            true,
 			},
 			"parent_id": schema.StringAttribute{
-				MarkdownDescription: "The GUID of the directory's parent entity. Typically this is the global account.",
+				MarkdownDescription: "The ID of the directory's parent entity. Typically this is the global account.",
 				Computed:            true,
 			},
 			"state": schema.StringAttribute{
@@ -108,7 +108,7 @@ __Further documentation:__
 					"\n\t - `PROCESSING_FAILED` The processing operations failed." +
 					"\n\t - `DELETION_FAILED` The delete operation failed, and the entity was not deleted." +
 					"\n\t - `MOVE_FAILED` Entity could not be moved to a different location." +
-					"\n\t - `MIGRATING` Migrating entity from NEO to CF.",
+					"\n\t - `MIGRATING` Migrating entity from Neo to Cloud Foundry.",
 				Computed: true,
 			},
 			"subdomain": schema.StringAttribute{

--- a/internal/provider/datasource_globalaccount.go
+++ b/internal/provider/datasource_globalaccount.go
@@ -167,7 +167,7 @@ __Further documentation:__
 					"\n\t - `PROCESSING_FAILED` The processing operations failed." +
 					"\n\t - `DELETION_FAILED` The delete operation failed, and the entity was not deleted." +
 					"\n\t - `MOVE_FAILED` Entity could not be moved to a different location." +
-					"\n\t - `MIGRATING` Migrating entity from NEO to CF.",
+					"\n\t - `MIGRATING` Migrating entity from Neo to Cloud Foundry.",
 				Computed: true,
 			},
 			"created_date": schema.StringAttribute{

--- a/internal/provider/datasource_subaccount.go
+++ b/internal/provider/datasource_subaccount.go
@@ -79,7 +79,7 @@ You must be assigned to the admin or viewer role of the global account, director
 				Computed:            true,
 			},
 			"parent_id": schema.StringAttribute{
-				MarkdownDescription: "The GUID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the GUID of the global account.",
+				MarkdownDescription: "The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.",
 				Computed:            true,
 			},
 			"parent_features": schema.SetAttribute{

--- a/internal/provider/datasource_subaccounts.go
+++ b/internal/provider/datasource_subaccounts.go
@@ -124,7 +124,7 @@ You must be assigned to the admin or viewer role of the global account, director
 							Computed:            true,
 						},
 						"parent_id": schema.StringAttribute{
-							MarkdownDescription: "The GUID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the GUID of the global account.",
+							MarkdownDescription: "The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.",
 							Computed:            true,
 						},
 						"parent_features": schema.SetAttribute{

--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -71,7 +71,7 @@ __Further documentation:__
 				},
 			},
 			"parent_id": schema.StringAttribute{
-				MarkdownDescription: "The GUID of the directory's parent entity. Typically this is the global account.",
+				MarkdownDescription: "The ID of the directory's parent entity. Typically this is the global account.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
@@ -141,7 +141,7 @@ __Further documentation:__
 					"\n\t - `PROCESSING_FAILED` The processing operations failed." +
 					"\n\t - `DELETION_FAILED` The delete operation failed, and the entity was not deleted." +
 					"\n\t - `MOVE_FAILED` Entity could not be moved to a different location." +
-					"\n\t - `MIGRATING` Migrating entity from NEO to CF.",
+					"\n\t - `MIGRATING` Migrating entity from Neo to Cloud Foundry.",
 				Computed: true,
 			},
 		},

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -88,7 +88,7 @@ __Further documentation:__
 				},
 			},
 			"parent_id": schema.StringAttribute{
-				MarkdownDescription: "The GUID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the GUID of the global account.",
+				MarkdownDescription: "The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{


### PR DESCRIPTION
## Purpose

I'm trying to reduce the amount of abbreviations in the docs. E.g. `CF` -> `Cloud Foundry`, `NEO` -> `Neo`, `GUID` can be in most of the cases be simplified with just `ID`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

## What to Check

## Other Information
<!-- Add any other helpful information that may be needed here. -->