### PR TITLE
feat: support custom idp login when recording test fixtures

### DIFF
--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -34,16 +34,16 @@ func NewV2ClientWithHttpClient(client *http.Client, serverURL *url.URL) *v2Clien
 }
 
 const (
-	HeaderCorrelationID              string = "X-CorrelationId"
+	HeaderCorrelationID              string = "X-Correlationid"
 	HeaderIDToken                    string = "X-Id-Token"
-	HeaderCLIFormat                  string = "X-CPCLI-Format"
-	HeaderCLIRefreshToken            string = "X-CPCLI-RefreshToken"
-	HeaderCLIReplacementRefreshToken string = "X-CPCLI-ReplacementRefreshtoken"
-	HeaderCLISubdomain               string = "X-CPCLI-Subdomain"
-	HeaderCLICustomIDP               string = "X-CPCLI-CustomIdp"
-	HeaderCLIBackendStatus           string = "X-CPCLI-Backend-Status"
-	HeaderCLIBackendMessage          string = "X-CPCLI-Backend-Message"
-	HeaderCLIBackendMediaType        string = "X-CPCLI-Backend-MediaType"
+	HeaderCLIFormat                  string = "X-Cpcli-Format"
+	HeaderCLIRefreshToken            string = "X-Cpcli-Refreshtoken"
+	HeaderCLIReplacementRefreshToken string = "X-Cpcli-Replacementrefreshtoken"
+	HeaderCLISubdomain               string = "X-Cpcli-Subdomain"
+	HeaderCLICustomIDP               string = "X-Cpcli-Customidp"
+	HeaderCLIBackendStatus           string = "X-Cpcli-Backend-Status"
+	HeaderCLIBackendMessage          string = "X-Cpcli-Backend-Message"
+	HeaderCLIBackendMediaType        string = "X-Cpcli-Backend-Mediatype"
 )
 
 const cliTargetProtocolVersion string = "v2.38.0"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -76,6 +76,8 @@ func (p *btpcliProvider) Metadata(_ context.Context, _ provider.MetadataRequest,
 }
 
 func (p *btpcliProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	const unableToCreateClient = "unableToCreateClient"
+
 	// Retrieve provider data from configuration
 	var config providerData
 	diags := req.Config.Get(ctx, &config)
@@ -93,7 +95,7 @@ func (p *btpcliProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	u, err := url.Parse(selectedCLIServerURL) // TODO move to NewV2Client
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to create Client", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(unableToCreateClient, fmt.Sprintf("%s", err))
 		return
 	}
 
@@ -103,7 +105,7 @@ func (p *btpcliProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	// User may provide an idp to the provider
 	var idp string
 	if config.IdentityProvider.IsUnknown() {
-		resp.Diagnostics.AddWarning("Unable to create client", "Cannot use unknown value as identity provider")
+		resp.Diagnostics.AddWarning(unableToCreateClient, "Cannot use unknown value as identity provider")
 		return
 	}
 
@@ -116,7 +118,7 @@ func (p *btpcliProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	// User must provide a username to the provider
 	var username string
 	if config.Username.IsUnknown() {
-		resp.Diagnostics.AddWarning("Unable to create client", "Cannot use unknown value as username")
+		resp.Diagnostics.AddWarning(unableToCreateClient, "Cannot use unknown value as username")
 		return
 	}
 
@@ -129,7 +131,7 @@ func (p *btpcliProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	// User must provide a password to the provider
 	var password string
 	if config.Password.IsUnknown() {
-		resp.Diagnostics.AddWarning("Unable to create client", "Cannot use unknown value as password")
+		resp.Diagnostics.AddWarning(unableToCreateClient, "Cannot use unknown value as password")
 		return
 	}
 
@@ -140,12 +142,12 @@ func (p *btpcliProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	}
 
 	if len(username) == 0 || len(password) == 0 {
-		resp.Diagnostics.AddError("Unable to create Client", "globalaccount, username and password must be given.")
+		resp.Diagnostics.AddError(unableToCreateClient, "globalaccount, username and password must be given.")
 		return
 	}
 
 	if _, err = client.Login(ctx, btpcli.NewLoginRequestWithCustomIDP(idp, config.GlobalAccount.ValueString(), username, password)); err != nil {
-		resp.Diagnostics.AddError("Unable to create Client", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(unableToCreateClient, fmt.Sprintf("%s", err))
 		return
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -70,12 +70,18 @@ func setupVCR(t *testing.T, cassetteName string) *recorder.Recorder {
 
 		if strings.Contains(i.Request.URL, "/login/") {
 			i.Request.Body = strings.ReplaceAll(i.Request.Body, intUserPwd, "redacted")
+			// TODO #277 the custom idp and issuer values should be redacted to some special value
+			//      for now the custom idp is replaced by the empty string and the issuer by "accounts.sap.com" to keep
+			//      existing fixtures working that were recorded without selecting a custom idp during login
 			i.Request.Body = strings.ReplaceAll(i.Request.Body, "\"customIdp\":\""+intUserIdp+"\"", "\"customIdp\":\"\"")
 			i.Response.Body = strings.ReplaceAll(i.Response.Body, "\"issuer\":\""+intUserIdp+"\"", "\"issuer\":\"accounts.sap.com\"")
 			i.Response.Body = strings.ReplaceAll(i.Response.Body, "\"issuer\":\""+intUserIdp+".accounts400.ondemand.com\"", "\"issuer\":\"accounts.sap.com\"")
 		}
 
-		if _, exists := i.Request.Headers[http.CanonicalHeaderKey(btpcli.HeaderCLICustomIDP)]; exists {
+		if _, exists := i.Request.Headers[btpcli.HeaderCLICustomIDP]; exists {
+			// TODO #277 the custom idp header value should be redacted to some special value
+			//      for now the header is replaced by the empty string to keep existing fixtures working that were
+			//      recorded without selecting a custom idp during login
 			i.Request.Headers.Set(btpcli.HeaderCLICustomIDP, "")
 		}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add support for setting the identity provider from environment variable BTP_IDP during provider configuration. This is implemented analogously to BTP_USERNAME and BTP_PASSWORD including the required redaction of recorded fixtures. To prevent impact on existing fixtures, identity provider values are replaced by the empty string during redaction.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```

1. go test ./...
2. Try local recording of text fixtures and use a custom idp user by setting all three of the env vars BTP_USERNAME, BTP_PASSWORD, BTP_IDP, setting the latter to the ias tenant 'terraformint'
```

## What to Check

Verify that the following are valid

1. The tests should still be successful
2. The resulting fixtures should not contain any information about the selected idp (ias tenant)

## Other Information
<!-- Add any other helpful information that may be needed here. -->

Also fixes a warning when the username has an unknown value during provider configuration.

Resolves #243
