### PR TITLE
fix(facade): transfer global account value when creating subaccount

### DIFF
--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -48,11 +48,13 @@ type SubaccountCreateInput struct { // TODO support all options
 	Region            string              `btpcli:"region"`
 	Subdomain         string              `btpcli:"subdomain"`
 	UsedForProduction bool                `btpcli:"usedForProduction"`
-	//Globalaccount     string `json:"globalAccount"`
+	Globalaccount     string              `btpcli:"globalAccount"`
 	//SubaccountAdmins  string `json:"subaccountAdmins"`
 }
 
 func (f *accountsSubaccountFacade) Create(ctx context.Context, args *SubaccountCreateInput) (cis.SubaccountResponseObject, CommandResponse, error) {
+
+	args.Globalaccount = f.cliClient.GetGlobalAccountSubdomain()
 
 	params, err := tfutils.ToBTPCLIParamsMap(args)
 

--- a/internal/btpcli/facade_accounts_subaccount_test.go
+++ b/internal/btpcli/facade_accounts_subaccount_test.go
@@ -79,6 +79,7 @@ func TestAccountsSubaccountFacade_Get(t *testing.T) {
 func TestAccountsSubaccountFacade_Create(t *testing.T) {
 	command := "accounts/subaccount"
 
+	globalAccount := "795b53bb-a3f0-4769-adf0-26173282a975"
 	displayName := "my-account"
 	subdomain := "my-account-sub"
 	region := "eu30"
@@ -95,6 +96,7 @@ func TestAccountsSubaccountFacade_Create(t *testing.T) {
 				"region":            region,
 				"betaEnabled":       "false",
 				"usedForProduction": "false",
+				"globalAccount":     globalAccount,
 			})
 
 		}))


### PR DESCRIPTION
## Purpose

* Creating a subaccount linked to a directory leads to an error as the `parentId` parameter is used for connection to subaccount and not automatically set to the global-account value. This PR now sets the parameter explicitly in all creation scenarios
* Fixes #257  

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code

```
Create subaccount under a directory
```

## What to Check

Verify that the following are valid

* Subaccount gets created under directory

## Other Information

n/a