### PR TITLE
fix(documentation): clarify not supported 2FA flow in provider documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ provider "btp" {
 
 - `cli_server_url` (String) The URL of the BTP CLI server (e.g. `https://cpcli.cf.eu10.hana.ondemand.com`).
 - `idp` (String) The identity provider to be used for authentication (default: `sap.default`).
-- `password` (String, Sensitive) Your password. Note that if two-factor authentication is enabled, concatenate your password, followed by the passcode, in a single string.
+- `password` (String, Sensitive) Your password. Note that two-factor authentication is not supported.
 - `username` (String) Your user name, usually an e-mail address.
 
 ## Get Started

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,7 +49,7 @@ func (p *btpcliProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 				Optional:            true,
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "Your password. Note that if two-factor authentication is enabled, concatenate your password, followed by the passcode, in a single string.",
+				MarkdownDescription: "Your password. Note that two-factor authentication is not supported.",
 				Optional:            true,
 				Sensitive:           true,
 			},


### PR DESCRIPTION
## Purpose

* Clarifies that 2FA is not suported
* Closes #261 

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

n/a

## What to Check

Verify that the following are valid

* Check documetation

## Other Information

n/a