### PR TITLE
fix: wrong error message in update of directory resource

### DIFF
--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -307,7 +307,7 @@ func (rs *directoryResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	updatedRes, err := createStateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Creating Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError("API Error Updating Resource Directory", fmt.Sprintf("%s", err))
 	}
 
 	plan, diags = directoryValueFrom(ctx, updatedRes.(cis.DirectoryResponseObject))


### PR DESCRIPTION
## Purpose

* Correction of Sonar Cloud Codesmell concerning error message in `resource_directory.go` ([Link](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&types=CODE_SMELL&id=SAP_terraform-provider-btp&open=AYk_ttKRlKSUjDzpECI)>)
* was indeed a bug (wrong error message in update case)

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code

```
go test ./...
```

## What to Check

Verify that the following are valid

* Test are successful

## Other Information

n/a