### PR TITLE
Add used_in_production arg in subaccount creation and update

### DIFF
--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -53,14 +53,14 @@ type SubaccountCreateInput struct { // TODO support all options
 }
 
 type SubaccountUpdateInput struct {
-	BetaEnabled   bool                `btpcli:"betaEnabled"`
-	Description   string              `btpcli:"description"`
-	Directory     string              `btpcli:"directoryID"`
-	DisplayName   string              `btpcli:"displayName"`
-	Labels        map[string][]string `btpcli:"labels"`
-	SubaccountId  string              `btpcli:"subaccount"`
-	Globalaccount string              `btpcli:"globalAccount"`
-	//	UsedForProduction bool                `btpcli:"usedForProduction"`
+	BetaEnabled       bool                `btpcli:"betaEnabled"`
+	Description       string              `btpcli:"description"`
+	Directory         string              `btpcli:"directoryID"`
+	DisplayName       string              `btpcli:"displayName"`
+	Labels            map[string][]string `btpcli:"labels"`
+	SubaccountId      string              `btpcli:"subaccount"`
+	Globalaccount     string              `btpcli:"globalAccount"`
+	UsedForProduction bool                `btpcli:"usedForProduction"`
 }
 
 func (f *accountsSubaccountFacade) Create(ctx context.Context, args *SubaccountCreateInput) (cis.SubaccountResponseObject, CommandResponse, error) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Closes #273 

With this PR users can now set `used_for_production = UNSET | USED_FOR_PRODUCTION | NOT_USED_FOR_PRODUCTION` when creating subaccounts
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```HCL
resource "btp_subaccount" "subaccount" {
  name = var.display_name
  subdomain = var.subdomain
  region = var.region
  parent_id = var.parent_guid
  used_for_procduction = "NOT_USED_FOR_PRODUCTION"
}
```

## What to Check

Verify that the following are valid

* Verify that the subaccount created has the attribute correctly set
## Other Information
<!-- Add any other helpful information that may be needed here. -->