### PR TITLE
feat: add usage parameter to subaccount resource

### DIFF
--- a/docs/resources/subaccount.md
+++ b/docs/resources/subaccount.md
@@ -59,6 +59,13 @@ resource "btp_subaccount" "my_project_on_azure" {
 - `description` (String) A description of the subaccount for customer-facing UIs.
 - `labels` (Map of Set of String) The set of words or phrases assigned to the subaccount.
 - `parent_id` (String) The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.
+- `usage` (String) Shows whether the subaccount is used for production purposes. This flag can help your cloud operator to take appropriate action when handling incidents that are related to mission-critical accounts in production systems. Do not apply for subaccounts that are used for nonproduction purposes, such as development, testing, and demos. Applying this setting this does not modify the subaccount. Possible values are: 
+
+  | value | description | 
+  | --- | --- | 
+  | `UNSET` | Global account or subaccount admin has not set the production-relevancy flag (default value). | 
+  | `NOT_USED_FOR_PRODUCTION` | The subaccount is not used for production purposes. | 
+  | `USED_FOR_PRODUCTION` | The subaccount is used for production purposes. |
 
 ### Read-Only
 
@@ -94,13 +101,6 @@ resource "btp_subaccount" "my_project_on_azure" {
   | `MIGRATION_FAILED` | The migration of the subaccount failed and the subaccount was not migrated. | 
   | `ROLLBACK_MIGRATION_PROCESSING` | The migration of the subaccount was rolled back and the subaccount is not migrated. | 
   | `SUSPENSION_FAILED` | The suspension operations failed. |
-- `usage` (String) Shows whether the subaccount is used for production purposes. This flag can help your cloud operator to take appropriate action when handling incidents that are related to mission-critical accounts in production systems. Do not apply for subaccounts that are used for nonproduction purposes, such as development, testing, and demos. Applying this setting this does not modify the subaccount. Possible values are: 
-
-  | value | description | 
-  | --- | --- | 
-  | `UNSET` | Global account or subaccount admin has not set the production-relevancy flag (default value). | 
-  | `NOT_USED_FOR_PRODUCTION` | The subaccount is not used for production purposes. | 
-  | `USED_FOR_PRODUCTION` | The subaccount is used for production purposes. |
 
 ## Import
 

--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -53,14 +53,14 @@ type SubaccountCreateInput struct { // TODO support all options
 }
 
 type SubaccountUpdateInput struct {
-	BetaEnabled   bool                `btpcli:"betaEnabled"`
-	Description   string              `btpcli:"description"`
-	Directory     string              `btpcli:"directoryID"`
-	DisplayName   string              `btpcli:"displayName"`
-	Labels        map[string][]string `btpcli:"labels"`
-	SubaccountId  string              `btpcli:"subaccount"`
-	Globalaccount string              `btpcli:"globalAccount"`
-	//	UsedForProduction bool                `btpcli:"usedForProduction"`
+	BetaEnabled       bool                `btpcli:"betaEnabled"`
+	Description       string              `btpcli:"description"`
+	Directory         string              `btpcli:"directoryID"`
+	DisplayName       string              `btpcli:"displayName"`
+	Labels            map[string][]string `btpcli:"labels"`
+	SubaccountId      string              `btpcli:"subaccount"`
+	Globalaccount     string              `btpcli:"globalAccount"`
+	UsedForProduction bool                `btpcli:"usedForProduction"`
 }
 
 func (f *accountsSubaccountFacade) Create(ctx context.Context, args *SubaccountCreateInput) (cis.SubaccountResponseObject, CommandResponse, error) {

--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -59,8 +59,8 @@ type SubaccountUpdateInput struct {
 	DisplayName       string              `btpcli:"displayName"`
 	Labels            map[string][]string `btpcli:"labels"`
 	SubaccountId      string              `btpcli:"subaccount"`
+	UsedForProduction string              `btpcli:"usedForProduction"`
 	Globalaccount     string              `btpcli:"globalAccount"`
-	UsedForProduction bool                `btpcli:"usedForProduction"`
 }
 
 func (f *accountsSubaccountFacade) Create(ctx context.Context, args *SubaccountCreateInput) (cis.SubaccountResponseObject, CommandResponse, error) {
@@ -80,6 +80,7 @@ func (f *accountsSubaccountFacade) Update(ctx context.Context, args *SubaccountU
 
 	args.Globalaccount = f.cliClient.GetGlobalAccountSubdomain()
 
+	// Mapping of all params except for usedForProduction
 	params, err := tfutils.ToBTPCLIParamsMap(args)
 
 	if err != nil {

--- a/internal/btpcli/facade_accounts_subaccount_test.go
+++ b/internal/btpcli/facade_accounts_subaccount_test.go
@@ -129,11 +129,12 @@ func TestAccountsSubaccountFacade_Update(t *testing.T) {
 			srvCalled = true
 
 			assertCall(t, r, command, ActionUpdate, map[string]string{
-				"subaccount":    subaccountId,
-				"displayName":   displayName,
-				"description":   description,
-				"betaEnabled":   "false",
-				"globalAccount": globalAccount,
+				"subaccount":        subaccountId,
+				"displayName":       displayName,
+				"description":       description,
+				"betaEnabled":       "false",
+				"globalAccount":     globalAccount,
+				"usedForProduction": "false",
 			})
 
 		}))

--- a/internal/btpcli/facade_accounts_subaccount_test.go
+++ b/internal/btpcli/facade_accounts_subaccount_test.go
@@ -129,12 +129,11 @@ func TestAccountsSubaccountFacade_Update(t *testing.T) {
 			srvCalled = true
 
 			assertCall(t, r, command, ActionUpdate, map[string]string{
-				"subaccount":        subaccountId,
-				"displayName":       displayName,
-				"description":       description,
-				"betaEnabled":       "false",
-				"globalAccount":     globalAccount,
-				"usedForProduction": "false",
+				"subaccount":    subaccountId,
+				"displayName":   displayName,
+				"description":   description,
+				"betaEnabled":   "false",
+				"globalAccount": globalAccount,
 			})
 
 		}))

--- a/internal/provider/fixtures/resource_subaccount_change_to_used_for_production.yaml
+++ b/internal/provider/fixtures/resource_subaccount_change_to_used_for_production.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4ccb87e0-1575-a7d4-3539-d7418629b047
+                - a0924e12-1adc-48e4-008e-bdede52d9284
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:40 GMT
+                - Thu, 13 Jul 2023 15:38:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 924e00ec-a073-4b87-5e99-239e7e9c5981
+                - 2b3b30c0-2d06-4c2f-79ee-496844d690f4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 559.4555ms
+        duration: 535.2042ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bd4541c1-f43d-1755-c7bb-e8630b3ba2e0
+                - 42d4395f-4d16-7b3f-e5e2-cff006a4e6ae
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:40 GMT
+                - Thu, 13 Jul 2023 15:38:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7c193b54-56c9-4781-5e66-f263a1a03cd4
+                - 89f71b9a-9138-46aa-438c-11bbfcdf7e48
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 390.7556ms
+        duration: 370.7236ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -145,7 +145,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 44bd1c06-c730-0b20-e5ac-e4ae6eeee688
+                - 2ce7d83e-e08c-0189-0889-57805b7835c7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:41 GMT
+                - Thu, 13 Jul 2023 15:38:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 705cfae7-ea78-4f55-5c7e-eec37ef17b61
+                - bbec5045-78e3-46cb-54e9-041c248b54d3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 403.2439ms
+        duration: 413.4496ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -207,7 +207,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b91141a8-7755-0f9d-8036-c56109d04291
+                - ee4f4097-b2a7-5153-e0c6-2b511af255ce
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"N\/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"STARTED","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:41 PM","jobId":"2842541"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"N\/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"STARTED","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:38:44 PM","jobId":"2842564"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:41 GMT
+                - Thu, 13 Jul 2023 15:38:44 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - aa8e855c-5186-4411-5972-267238364e3f
+                - 85c22517-aeba-492a-69ee-eb523d9c87ab
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 421.5091ms
+        duration: 572.181ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -273,7 +273,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -281,7 +281,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 860f1a89-6b4c-1758-d7f4-f777badebfdc
+                - bb7b408c-1e29-ae13-b461-e683a60c12c5
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -300,14 +300,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:42 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:38:45 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:46 GMT
+                - Thu, 13 Jul 2023 15:38:49 GMT
             Expires:
                 - "0"
             Pragma:
@@ -329,12 +329,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8bce2a1f-e0ac-42ac-67f7-78060a0fdda0
+                - c7c91108-5487-48f7-4331-65d380037dc0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 261.269ms
+        duration: 247.6353ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -347,7 +347,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -355,7 +355,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ca02e9b-4e4f-d770-f8cb-1e3dda7fb02c
+                - 415b5171-4a2c-300a-66ce-308bce7fff5d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -374,14 +374,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:42 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:38:45 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:52 GMT
+                - Thu, 13 Jul 2023 15:38:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -403,12 +403,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 692552a0-063e-4a03-7fab-8d150a8373e2
+                - 8aaf8991-164a-4dba-5910-bb3ea14a9617
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 260.5854ms
+        duration: 264.4154ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -421,7 +421,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -429,7 +429,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 75f0fc39-3442-9d6a-39c0-fac0e024048c
+                - 9968c34a-669f-cf9f-d4e1-c1af2ac784d3
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -448,14 +448,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:53 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:38:58 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:02 GMT
+                - Thu, 13 Jul 2023 15:39:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -477,12 +477,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a0ab13bf-5756-4189-6e93-206523d8672b
+                - 087cc9c4-76f7-4f00-7bf3-a6be8ff8ae61
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 275.4646ms
+        duration: 180.2648ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -503,7 +503,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 82c42f93-2313-5632-d042-31e4aa1a653d
+                - c14505e5-9572-a634-6e97-f09c563c7f4f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -525,7 +525,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:02 GMT
+                - Thu, 13 Jul 2023 15:39:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -539,12 +539,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9b695b64-ba04-4653-4414-6f1ccf1e1b43
+                - d551fe99-ddb2-4ac1-6341-af783cb91b8c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 439.1597ms
+        duration: 437.0763ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -565,7 +565,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6e10d7e7-31f5-eedf-66fe-c0e9bf361bc6
+                - b3be1ee6-de1a-ff3d-a45b-ddba04901033
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -587,7 +587,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:03 GMT
+                - Thu, 13 Jul 2023 15:39:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -601,12 +601,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9f31ff3f-8cbd-4d72-5546-da9debc02221
+                - 8da85be6-8105-4c00-40bd-b78e8a158669
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 383.7759ms
+        duration: 404.0756ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -619,7 +619,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -627,7 +627,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - eda63c10-dcfc-479e-d3ef-849796960374
+                - c0c1dcf3-05e1-7b7f-dbdc-9584c86a8e01
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -646,14 +646,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:53 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:38:58 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:03 GMT
+                - Thu, 13 Jul 2023 15:39:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -675,12 +675,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f05b17d3-da82-4d4f-512b-fe57f5ad11e0
+                - 9ccc3b6b-2a9b-4e78-4500-045701de14fa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 198.0958ms
+        duration: 211.4637ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -701,7 +701,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4b7d070a-cf90-f789-bff2-e1b6a60b6446
+                - f6fb0f2c-8c68-2150-2656-ef714f9ea55f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -723,7 +723,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:03 GMT
+                - Thu, 13 Jul 2023 15:39:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -737,12 +737,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e539c8f4-a105-426d-6875-ceb1d9baa7a5
+                - 97a594ba-3dc5-4dbe-4bfb-30dadf286293
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 374.0068ms
+        duration: 431.8743ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -763,7 +763,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 462cc315-4b6d-1c83-12ca-b3aeecad118d
+                - 84ee8b36-f8ec-7cf9-511e-944c21884851
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -785,7 +785,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:04 GMT
+                - Thu, 13 Jul 2023 15:39:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -799,12 +799,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7fa50cf5-2005-4d40-6457-3b5fb0b05a08
+                - ff4b512e-9ea7-41f8-510a-918a48a024d4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 412.9414ms
+        duration: 402.339ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -817,7 +817,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -825,7 +825,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5c62500e-8cfd-36e9-d6a2-a2cba5d7fa7f
+                - 6724c293-1759-d613-728d-f0822fa14aa9
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -844,14 +844,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:53 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:38:58 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:04 GMT
+                - Thu, 13 Jul 2023 15:39:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -873,12 +873,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a4fdf463-572e-41bd-5823-19a1fd1d56d0
+                - bc84bbb4-2102-4bca-744b-bab7af421b68
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 244.4726ms
+        duration: 194.8746ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -899,7 +899,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e862de2a-706e-b455-5dee-2439c8f0e354
+                - 8db8a4b8-464e-ef94-7c91-48a84c3964d2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -921,7 +921,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:05 GMT
+                - Thu, 13 Jul 2023 15:39:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -935,12 +935,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - feb9edf0-adac-40fd-7088-00ca5b3efb78
+                - af30d44a-f99b-47ca-67cf-b838301b1d84
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 417.4113ms
+        duration: 342.1666ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -961,7 +961,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ebac954-923d-2a52-8ca1-d48d94ce6a31
+                - 32ccff87-06ec-7d8c-7bd4-ad489cf52389
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:05 GMT
+                - Thu, 13 Jul 2023 15:39:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -997,25 +997,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f1709b73-fb35-48a0-53a7-73944ee43359
+                - b8a95680-1b3e-42af-6e90-61f48724b699
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 385.6298ms
+        duration: 359.4618ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 223
+        content_length: 250
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"betaEnabled":"false","directoryID":"03760ecf-9d89-4189-a92a-1c7efed09298","displayName":"Integration Test Acc Dyn","globalAccount":"terraformintcanary","subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"betaEnabled":"false","directoryID":"03760ecf-9d89-4189-a92a-1c7efed09298","displayName":"Integration Test Acc Dyn","globalAccount":"terraformintcanary","subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180","usedForProduction":"true"}}
         form: {}
         headers:
             Content-Type:
@@ -1023,7 +1023,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0e3cebde-a390-04d4-e17f-9f7e2842e34e
+                - 555ff4c9-ccf2-fba1-73fc-66c3a7a412a6
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1042,14 +1042,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:39:31 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:05 GMT
+                - Thu, 13 Jul 2023 15:39:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1071,12 +1071,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cf8abdc5-1fa7-40b2-6374-8001218e702d
+                - 75464299-77b2-4992-54ce-beeede970529
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 269.9175ms
+        duration: 380.0512ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1097,7 +1097,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0283450b-a581-e3fa-fa3d-8313a370547e
+                - 54fb5806-b5a1-13c4-44ed-9f7d011de9c7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1119,7 +1119,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:06 GMT
+                - Thu, 13 Jul 2023 15:39:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1133,12 +1133,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2bac9952-67b9-442e-575d-40f7fc67538e
+                - c18996b3-2ae4-46af-510c-6e58f3ee43e0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 382.5616ms
+        duration: 325.5963ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1159,7 +1159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c7de686-126b-c201-15fb-1150cb1e1ecc
+                - 486b2c39-228e-2d60-e98b-f2ee7fdfde24
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1181,7 +1181,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:06 GMT
+                - Thu, 13 Jul 2023 15:39:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1195,12 +1195,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cf89ad53-09e5-47f9-48b3-50323a2e44ac
+                - 9f393d7a-8149-4ed7-68e5-cb5e8159810a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 377.1825ms
+        duration: 362.4139ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1213,7 +1213,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -1221,7 +1221,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fd4a7f1b-a8f5-15d4-6885-8ad08e92dbd7
+                - a1356120-7988-e698-4cd6-bef22ec3d41f
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1240,14 +1240,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:39:31 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:07 GMT
+                - Thu, 13 Jul 2023 15:39:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1269,12 +1269,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 225dfc8c-bb7e-4c3c-7814-a55d0a039f68
+                - b57b512f-2e3d-4e98-71bb-6f94396b1c02
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 205.6651ms
+        duration: 209.9734ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1295,7 +1295,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c25a8231-c96d-aab8-bef4-9bf931505bfc
+                - adcc72b9-424a-3d87-f624-324b2bb488a4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1317,7 +1317,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:07 GMT
+                - Thu, 13 Jul 2023 15:39:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1331,12 +1331,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5eed512d-6989-4286-7cae-dd577f60b90d
+                - c8fd2822-973c-4102-42c1-a33b3e11049e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 411.015ms
+        duration: 347.5464ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1357,7 +1357,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 52087d16-63cc-d34d-b8f3-44bcddfeb856
+                - 6936378a-5ca9-702b-950b-31a055a88aac
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1379,7 +1379,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:08 GMT
+                - Thu, 13 Jul 2023 15:39:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1393,25 +1393,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cae6da02-81e9-4ca6-6b70-c9eccb5f06ba
+                - eb799c62-d9af-4bdb-6d07-beb5eff304fc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 361.6227ms
+        duration: 381.6107ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 70
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"customIdp":"","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"redacted"}
         form: {}
         headers:
             Content-Type:
@@ -1419,16 +1419,10 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c924e3ec-e55d-10ed-1449-1cff86b877ff
-            X-Cpcli-Customidp:
-                - ""
+                - a7369af4-f717-d46b-6157-60495569ee05
             X-Cpcli-Format:
                 - json
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Subdomain:
-                - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/accounts/subaccount?get
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1436,16 +1430,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM"}'
+        content_length: 149
+        uncompressed: false
+        body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:08 GMT
+                - Thu, 13 Jul 2023 15:39:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1456,148 +1452,16 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Backend-Mediatype:
-                - application/json;charset=UTF-8
-            X-Cpcli-Backend-Status:
-                - "200"
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2617f035-dbd5-4175-57b4-a8bd3ae72607
+                - 76cc406f-05ea-4543-6403-0caea29709a3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 195.6936ms
+        duration: 351.606ms
     - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 118
-        transfer_encoding: []
-        trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"customIdp":"","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"redacted"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Terraform/1.5.2 terraform-provider-btp/dev
-            X-Correlationid:
-                - 1a1ef783-9cf4-8969-4e35-660da4889c02
-            X-Cpcli-Format:
-                - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 149
-        uncompressed: false
-        body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
-        headers:
-            Cache-Control:
-                - no-cache, no-store, max-age=0, must-revalidate
-            Content-Length:
-                - "149"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Jul 2023 15:35:08 GMT
-            Expires:
-                - "0"
-            Pragma:
-                - no-cache
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains; preload;
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Vcap-Request-Id:
-                - 9630fd22-3dda-4fdb-517d-79249e81e1b6
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 362.264ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 118
-        transfer_encoding: []
-        trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"customIdp":"","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"redacted"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Terraform/1.5.2 terraform-provider-btp/dev
-            X-Correlationid:
-                - 8bd3c830-038c-87aa-0bea-1ec148d00072
-            X-Cpcli-Format:
-                - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 149
-        uncompressed: false
-        body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
-        headers:
-            Cache-Control:
-                - no-cache, no-store, max-age=0, must-revalidate
-            Content-Length:
-                - "149"
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Jul 2023 15:35:09 GMT
-            Expires:
-                - "0"
-            Pragma:
-                - no-cache
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains; preload;
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Vcap-Request-Id:
-                - e722802f-7367-4c64-45cf-d28105b51236
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 360.8953ms
-    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1609,7 +1473,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","forceDelete":"true","subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"confirm":"true","forceDelete":"true","subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -1617,7 +1481,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5f748bcc-be67-2f19-b7d1-9cb43528200b
+                - e7fc0c26-9519-e745-5f0b-42715ff58bd6
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1636,14 +1500,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Delete subaccount entity","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM","jobId":"2842544"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Delete subaccount entity","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:39:31 PM","jobId":"2842567"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:09 GMT
+                - Thu, 13 Jul 2023 15:39:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1665,12 +1529,160 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3a61e6bb-1994-4fbb-5373-b99e8f2e412a
+                - 0050e958-16e5-4992-4427-b5921f0adabc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 196.0868ms
+        duration: 300.939ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 70
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.2 terraform-provider-btp/dev
+            X-Correlationid:
+                - 2e58c344-d77e-0d71-e0c6-d2402623a305
+            X-Cpcli-Customidp:
+                - ""
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/accounts/subaccount?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:39:35 PM"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 13 Jul 2023 15:39:39 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json;charset=UTF-8
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 406367f7-9f23-412a-6b49-30476e61c267
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 219.4421ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 70
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.2 terraform-provider-btp/dev
+            X-Correlationid:
+                - f2c36369-1428-d0a9-d580-06bfc40d0d0d
+            X-Cpcli-Customidp:
+                - ""
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/accounts/subaccount?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:39:35 PM"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 13 Jul 2023 15:39:45 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json;charset=UTF-8
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - d5f30067-9c6a-41b6-7884-3d7d71f467a4
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 250.3075ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1683,7 +1695,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -1691,7 +1703,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 15f6f9fe-7ff0-2620-9ef1-9852e34bafc3
+                - f94ae3dd-93aa-a62f-01d4-9a745d15ba14
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1710,14 +1722,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:10 PM"}'
+        body: '{"guid":"730b56af-3b7f-42dc-84bf-068a3b124180","technicalName":"730b56af-3b7f-42dc-84bf-068a3b124180","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:38:44 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:39:35 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:14 GMT
+                - Thu, 13 Jul 2023 15:39:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1739,12 +1751,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4c89e626-8e55-45d4-4e03-3a85be2d312f
+                - 52ea6800-e927-46ea-4880-0e2cfbb18d04
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 225.2038ms
+        duration: 224.0745ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1757,7 +1769,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"730b56af-3b7f-42dc-84bf-068a3b124180"}}
         form: {}
         headers:
             Content-Type:
@@ -1765,155 +1777,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 168b1fd1-5493-a920-eaac-8a663594c99b
-            X-Cpcli-Customidp:
-                - ""
-            X-Cpcli-Format:
-                - json
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Subdomain:
-                - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/accounts/subaccount?get
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:10 PM"}'
-        headers:
-            Cache-Control:
-                - no-cache, no-store, max-age=0, must-revalidate
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Jul 2023 15:35:19 GMT
-            Expires:
-                - "0"
-            Pragma:
-                - no-cache
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains; preload;
-            X-Content-Type-Options:
-                - nosniff
-            X-Cpcli-Backend-Mediatype:
-                - application/json;charset=UTF-8
-            X-Cpcli-Backend-Status:
-                - "200"
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
-            X-Frame-Options:
-                - DENY
-            X-Vcap-Request-Id:
-                - 4b6bd1ef-c3b4-4308-6583-79725360a7d2
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 223.1848ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 70
-        transfer_encoding: []
-        trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Terraform/1.5.2 terraform-provider-btp/dev
-            X-Correlationid:
-                - 3c85df7a-0f8e-3471-5004-389ab034f7c5
-            X-Cpcli-Customidp:
-                - ""
-            X-Cpcli-Format:
-                - json
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Subdomain:
-                - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/accounts/subaccount?get
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:10 PM"}'
-        headers:
-            Cache-Control:
-                - no-cache, no-store, max-age=0, must-revalidate
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 13 Jul 2023 15:35:30 GMT
-            Expires:
-                - "0"
-            Pragma:
-                - no-cache
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains; preload;
-            X-Content-Type-Options:
-                - nosniff
-            X-Cpcli-Backend-Mediatype:
-                - application/json;charset=UTF-8
-            X-Cpcli-Backend-Status:
-                - "200"
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
-            X-Frame-Options:
-                - DENY
-            X-Vcap-Request-Id:
-                - d66cd8a4-1511-42bd-709f-bcf751881a73
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 241.6551ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 70
-        transfer_encoding: []
-        trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Terraform/1.5.2 terraform-provider-btp/dev
-            X-Correlationid:
-                - 347f4dae-c930-b2dc-4c44-6338fd9f13c8
+                - bbfedb0b-fb54-5659-d86b-f36c84d8129b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1939,7 +1803,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:40 GMT
+                - Thu, 13 Jul 2023 15:40:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1961,9 +1825,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0ebedd4b-b254-46d0-55f5-eef55d77f097
+                - 32281e56-c21f-43f1-7bd3-cb22f120de1c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.5695ms
+        duration: 275.0035ms

--- a/internal/provider/fixtures/resource_subaccount_used_for_production.yaml
+++ b/internal/provider/fixtures/resource_subaccount_used_for_production.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4ccb87e0-1575-a7d4-3539-d7418629b047
+                - a91f278e-41bc-f156-077b-c2fe137e7696
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:40 GMT
+                - Thu, 13 Jul 2023 15:36:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 924e00ec-a073-4b87-5e99-239e7e9c5981
+                - c3e41083-dbe1-4865-6593-040a67c1dbdd
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 559.4555ms
+        duration: 590.9872ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -83,7 +83,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bd4541c1-f43d-1755-c7bb-e8630b3ba2e0
+                - 27fe7afc-804d-25ad-678e-51a8813e6532
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:40 GMT
+                - Thu, 13 Jul 2023 15:36:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7c193b54-56c9-4781-5e66-f263a1a03cd4
+                - 501466f6-7adf-4f5f-4beb-866e6051c9f1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 390.7556ms
+        duration: 435.8414ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -145,7 +145,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 44bd1c06-c730-0b20-e5ac-e4ae6eeee688
+                - b5b8f229-b61b-9c4c-2531-0cffab30a3c8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:41 GMT
+                - Thu, 13 Jul 2023 15:36:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,25 +181,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 705cfae7-ea78-4f55-5c7e-eec37ef17b61
+                - 422727de-a6ee-4604-6fc5-7c55f9b4264d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 403.2439ms
+        duration: 426.7021ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 173
+        content_length: 200
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"betaEnabled":"false","displayName":"integration-test-acc-dyn","globalAccount":"terraformintcanary","region":"eu12","subdomain":"integration-test-acc-dyn"}}
+            {"paramValues":{"betaEnabled":"false","displayName":"integration-test-acc-dyn","globalAccount":"terraformintcanary","region":"eu12","subdomain":"integration-test-acc-dyn","usedForProduction":"true"}}
         form: {}
         headers:
             Content-Type:
@@ -207,7 +207,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b91141a8-7755-0f9d-8036-c56109d04291
+                - 0c06e5e6-ae8e-d65d-9c67-844ffb895b58
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"N\/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"STARTED","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:41 PM","jobId":"2842541"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"N\/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"STARTED","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:36:53 PM","jobId":"2842549"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:41 GMT
+                - Thu, 13 Jul 2023 15:36:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - aa8e855c-5186-4411-5972-267238364e3f
+                - dc330d56-f3a4-43ed-46b4-bbe55fcc2630
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 421.5091ms
+        duration: 549.2522ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -273,7 +273,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -281,7 +281,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 860f1a89-6b4c-1758-d7f4-f777badebfdc
+                - 86691fae-72c0-b89a-1bab-574af1d1ab8d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -300,14 +300,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:42 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:36:54 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:46 GMT
+                - Thu, 13 Jul 2023 15:36:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -329,12 +329,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8bce2a1f-e0ac-42ac-67f7-78060a0fdda0
+                - 0bde44df-bd6e-4cdb-47fb-746b161f11fc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 261.269ms
+        duration: 350.1112ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -347,7 +347,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -355,7 +355,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ca02e9b-4e4f-d770-f8cb-1e3dda7fb02c
+                - 0e9790cf-b549-34e9-4c52-c646d654aee1
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -374,14 +374,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:42 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"N/A","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"CREATING","stateMessage":"Creating subaccount tenant.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:36:54 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:34:52 GMT
+                - Thu, 13 Jul 2023 15:37:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -403,12 +403,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 692552a0-063e-4a03-7fab-8d150a8373e2
+                - d5bedf49-5e5c-46a3-6a5a-9be9ebff7598
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 260.5854ms
+        duration: 332.4044ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -421,7 +421,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -429,7 +429,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 75f0fc39-3442-9d6a-39c0-fac0e024048c
+                - 28905a00-8ea9-ff56-3d31-811c2dec0087
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -448,14 +448,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:53 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:08 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:02 GMT
+                - Thu, 13 Jul 2023 15:37:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -477,12 +477,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a0ab13bf-5756-4189-6e93-206523d8672b
+                - a5869638-227b-468a-65a7-e28f1814f2aa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 275.4646ms
+        duration: 237.5703ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -503,7 +503,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 82c42f93-2313-5632-d042-31e4aa1a653d
+                - baf05486-f973-c7e4-8ebf-ba50ca112bb0
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -525,7 +525,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:02 GMT
+                - Thu, 13 Jul 2023 15:37:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -539,12 +539,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9b695b64-ba04-4653-4414-6f1ccf1e1b43
+                - 9cbfb2c9-1e6e-4064-46c2-377371a78034
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 439.1597ms
+        duration: 485.2988ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -565,7 +565,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6e10d7e7-31f5-eedf-66fe-c0e9bf361bc6
+                - 6cb9620b-f958-707e-e751-dea23c3a7e77
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -587,7 +587,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:03 GMT
+                - Thu, 13 Jul 2023 15:37:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -601,12 +601,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9f31ff3f-8cbd-4d72-5546-da9debc02221
+                - 0207e608-e3e7-40d2-72ba-87976646fd18
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 383.7759ms
+        duration: 367.5581ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -619,7 +619,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -627,7 +627,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - eda63c10-dcfc-479e-d3ef-849796960374
+                - 11b5271d-815f-bfc8-7249-4de4094fc771
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -646,14 +646,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:53 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:08 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:03 GMT
+                - Thu, 13 Jul 2023 15:37:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -675,12 +675,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f05b17d3-da82-4d4f-512b-fe57f5ad11e0
+                - 83d7d49c-2da0-4f47-4d10-e1b497bae2d2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 198.0958ms
+        duration: 207.5956ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -701,7 +701,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4b7d070a-cf90-f789-bff2-e1b6a60b6446
+                - fa05d9f4-1844-d955-e2f4-c2d0a33f401b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -723,7 +723,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:03 GMT
+                - Thu, 13 Jul 2023 15:37:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -737,12 +737,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e539c8f4-a105-426d-6875-ceb1d9baa7a5
+                - f6c5d1ab-80a2-4ec0-4bc1-a62f0fa7b870
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 374.0068ms
+        duration: 410.379ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -763,7 +763,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 462cc315-4b6d-1c83-12ca-b3aeecad118d
+                - c6709dff-18b8-8dc4-7075-139c7bfdea79
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -785,7 +785,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:04 GMT
+                - Thu, 13 Jul 2023 15:37:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -799,12 +799,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7fa50cf5-2005-4d40-6457-3b5fb0b05a08
+                - 256e6705-8917-46fd-423b-3ca9694bbf51
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 412.9414ms
+        duration: 445.7962ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -817,7 +817,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -825,7 +825,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5c62500e-8cfd-36e9-d6a2-a2cba5d7fa7f
+                - c86e67c3-a5e2-3079-cfec-0e0bb74f48b1
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -844,14 +844,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:34:53 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"integration-test-acc-dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:08 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:04 GMT
+                - Thu, 13 Jul 2023 15:37:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -873,12 +873,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a4fdf463-572e-41bd-5823-19a1fd1d56d0
+                - 6eacdd34-8a13-4cc9-6efc-71e1716ff9f1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 244.4726ms
+        duration: 228.6118ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -899,7 +899,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e862de2a-706e-b455-5dee-2439c8f0e354
+                - a7ee6139-9edf-4649-67ef-19e1e408d92b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -921,7 +921,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:05 GMT
+                - Thu, 13 Jul 2023 15:37:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -935,12 +935,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - feb9edf0-adac-40fd-7088-00ca5b3efb78
+                - 196f5d1d-0bad-474b-6da8-4080033814fc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 417.4113ms
+        duration: 402.1099ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -961,7 +961,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ebac954-923d-2a52-8ca1-d48d94ce6a31
+                - c9aee952-6b89-7be9-7924-7128541ef5a3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:05 GMT
+                - Thu, 13 Jul 2023 15:37:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -997,25 +997,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f1709b73-fb35-48a0-53a7-73944ee43359
+                - 49506786-788a-42fa-723f-5baaf98bb6de
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 385.6298ms
+        duration: 380.7866ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 223
+        content_length: 250
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"betaEnabled":"false","directoryID":"03760ecf-9d89-4189-a92a-1c7efed09298","displayName":"Integration Test Acc Dyn","globalAccount":"terraformintcanary","subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"betaEnabled":"false","directoryID":"03760ecf-9d89-4189-a92a-1c7efed09298","displayName":"Integration Test Acc Dyn","globalAccount":"terraformintcanary","subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e","usedForProduction":"true"}}
         form: {}
         headers:
             Content-Type:
@@ -1023,7 +1023,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0e3cebde-a390-04d4-e17f-9f7e2842e34e
+                - 0c65d77a-fe16-d4b2-060c-41f01c698322
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1042,14 +1042,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:26 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:05 GMT
+                - Thu, 13 Jul 2023 15:37:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1071,12 +1071,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cf8abdc5-1fa7-40b2-6374-8001218e702d
+                - 1fa6176d-21f5-4343-4717-1ad27c57060f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 269.9175ms
+        duration: 348.0224ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1097,7 +1097,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0283450b-a581-e3fa-fa3d-8313a370547e
+                - 0ee44a0c-ff3f-b149-e0ad-1485859312ec
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1119,7 +1119,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:06 GMT
+                - Thu, 13 Jul 2023 15:37:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1133,12 +1133,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2bac9952-67b9-442e-575d-40f7fc67538e
+                - 8a9b5802-58e0-45d0-41be-c504e52d363e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 382.5616ms
+        duration: 397.2601ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1159,7 +1159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c7de686-126b-c201-15fb-1150cb1e1ecc
+                - c875e27b-b51e-950e-929d-79624ea08a9b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1181,7 +1181,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:06 GMT
+                - Thu, 13 Jul 2023 15:37:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1195,12 +1195,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cf89ad53-09e5-47f9-48b3-50323a2e44ac
+                - 01647a85-0ac1-4b03-5da1-72af70e8ad85
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 377.1825ms
+        duration: 386.5323ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1213,7 +1213,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1221,7 +1221,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fd4a7f1b-a8f5-15d4-6885-8ad08e92dbd7
+                - 37b7e658-5222-146d-615b-7c9741d85439
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1240,14 +1240,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:26 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:07 GMT
+                - Thu, 13 Jul 2023 15:37:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1269,12 +1269,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 225dfc8c-bb7e-4c3c-7814-a55d0a039f68
+                - cb6db027-bb27-4435-4503-2f41d848b0ae
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 205.6651ms
+        duration: 234.3509ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1295,7 +1295,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c25a8231-c96d-aab8-bef4-9bf931505bfc
+                - 2279bc19-742e-0639-980e-b4564fa29624
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1317,7 +1317,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:07 GMT
+                - Thu, 13 Jul 2023 15:37:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1331,12 +1331,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5eed512d-6989-4286-7cae-dd577f60b90d
+                - a63350d8-84d1-4a77-5750-cef914ca628a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 411.015ms
+        duration: 376.8397ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1357,7 +1357,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 52087d16-63cc-d34d-b8f3-44bcddfeb856
+                - 4fd71ed7-35f8-adb6-20e6-d610575a79a3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1379,7 +1379,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:08 GMT
+                - Thu, 13 Jul 2023 15:37:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1393,12 +1393,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cae6da02-81e9-4ca6-6b70-c9eccb5f06ba
+                - 35e9da2c-e6a2-4a2c-7b4e-1fb962d87ee3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 361.6227ms
+        duration: 385.3039ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1411,7 +1411,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1419,7 +1419,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c924e3ec-e55d-10ed-1449-1cff86b877ff
+                - 2971abd5-0f3e-ca39-7fca-a51322063b51
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1438,14 +1438,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"OK","stateMessage":"Subaccount created.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:26 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:08 GMT
+                - Thu, 13 Jul 2023 15:37:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1467,12 +1467,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2617f035-dbd5-4175-57b4-a8bd3ae72607
+                - 07bb6b45-c656-4aaa-4c94-1c3a90621866
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 195.6936ms
+        duration: 216.4573ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1493,7 +1493,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1a1ef783-9cf4-8969-4e35-660da4889c02
+                - df46e73c-cede-cea1-b288-ee8f51fa8294
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1515,7 +1515,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:08 GMT
+                - Thu, 13 Jul 2023 15:37:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1529,12 +1529,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9630fd22-3dda-4fdb-517d-79249e81e1b6
+                - 5a7e2078-a4ea-4bdb-5076-1ddba36229d1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 362.264ms
+        duration: 444.742ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1555,7 +1555,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 8bd3c830-038c-87aa-0bea-1ec148d00072
+                - 59d53f13-8b70-f3c2-de85-5f6438c39263
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1577,7 +1577,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:09 GMT
+                - Thu, 13 Jul 2023 15:37:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1591,12 +1591,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e722802f-7367-4c64-45cf-d28105b51236
+                - 752e4de2-e2ac-4dcb-4673-9cc22a8bae8b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 360.8953ms
+        duration: 366.0832ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1609,7 +1609,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","forceDelete":"true","subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"confirm":"true","forceDelete":"true","subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1617,7 +1617,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5f748bcc-be67-2f19-b7d1-9cb43528200b
+                - 471de931-c1c3-a725-c7f0-a3604cdef172
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1636,14 +1636,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Delete subaccount entity","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:05 PM","jobId":"2842544"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Delete subaccount entity","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:26 PM","jobId":"2842552"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:09 GMT
+                - Thu, 13 Jul 2023 15:37:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1665,12 +1665,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3a61e6bb-1994-4fbb-5373-b99e8f2e412a
+                - f0d56ec7-ecf6-4b99-4c29-d4ee0a55b8d2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 196.0868ms
+        duration: 267.3062ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1683,7 +1683,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1691,7 +1691,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 15f6f9fe-7ff0-2620-9ef1-9852e34bafc3
+                - d999ff1c-d7a9-c336-a143-3a0cb7a4676c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1710,14 +1710,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:10 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:30 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:14 GMT
+                - Thu, 13 Jul 2023 15:37:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1739,12 +1739,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4c89e626-8e55-45d4-4e03-3a85be2d312f
+                - 4899a3d9-9ddf-4fbc-4602-bea8a5bc726e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 225.2038ms
+        duration: 293.9272ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1757,7 +1757,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1765,7 +1765,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 168b1fd1-5493-a920-eaac-8a663594c99b
+                - 44702f17-7a57-947d-f9b5-ab7af17a5526
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1784,14 +1784,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:10 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:30 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:19 GMT
+                - Thu, 13 Jul 2023 15:37:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1813,12 +1813,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4b6bd1ef-c3b4-4308-6583-79725360a7d2
+                - 0f39c9b4-3265-4795-5f24-b0516e97f995
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 223.1848ms
+        duration: 221.918ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1831,7 +1831,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1839,7 +1839,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3c85df7a-0f8e-3471-5004-389ab034f7c5
+                - beeb2b42-646c-5672-5c46-24e4dd467653
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1858,14 +1858,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"guid":"60d6d742-b55d-44d1-8f9d-3f401185979f","technicalName":"60d6d742-b55d-44d1-8f9d-3f401185979f","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"UNSET","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:34:41 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:35:10 PM"}'
+        body: '{"guid":"3f99b597-7c8c-4896-839e-236d3c97817e","technicalName":"3f99b597-7c8c-4896-839e-236d3c97817e","displayName":"Integration Test Acc Dyn","globalAccountGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentGUID":"03760ecf-9d89-4189-a92a-1c7efed09298","parentType":"ROOT","region":"eu12","subdomain":"integration-test-acc-dyn","betaEnabled":false,"usedForProduction":"USED_FOR_PRODUCTION","state":"DELETING","stateMessage":"Deleting subaccount.","createdDate":"Jul 13, 2023, 3:36:53 PM","createdBy":"john.doe@int.test","modifiedDate":"Jul 13, 2023, 3:37:30 PM"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:30 GMT
+                - Thu, 13 Jul 2023 15:37:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1887,12 +1887,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d66cd8a4-1511-42bd-709f-bcf751881a73
+                - c43ad981-79c2-4816-7acb-195ed9317e82
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 241.6551ms
+        duration: 226.6189ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1905,7 +1905,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"subaccount":"60d6d742-b55d-44d1-8f9d-3f401185979f"}}
+            {"paramValues":{"subaccount":"3f99b597-7c8c-4896-839e-236d3c97817e"}}
         form: {}
         headers:
             Content-Type:
@@ -1913,7 +1913,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 347f4dae-c930-b2dc-4c44-6338fd9f13c8
+                - 8223afb6-6b51-b621-39fd-6b6292dbd930
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1939,7 +1939,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 13 Jul 2023 15:35:40 GMT
+                - Thu, 13 Jul 2023 15:38:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1961,9 +1961,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0ebedd4b-b254-46d0-55f5-eef55d77f097
+                - 4ee86daa-c829-472c-6b14-cb38f942182b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.5695ms
+        duration: 284.7194ms

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -391,7 +391,7 @@ func mapUsageToUsedForProduction(subaccountUsage string) string {
 	// Options: "" == ignored in request, "true" == boolean true in request, "false" == boolean false in request
 	switch subaccountUsage {
 	case "UNSET":
-		return "false"
+		return ""
 	case "NOT_USED_FOR_PRODUCTION":
 		return "false"
 	case "USED_FOR_PRODUCTION":

--- a/internal/provider/resource_subaccount_test.go
+++ b/internal/provider/resource_subaccount_test.go
@@ -61,6 +61,101 @@ func TestResourceSubaccount(t *testing.T) {
 			},
 		})
 	})
+	t.Run("happy path used for prod", func(t *testing.T) {
+		rec := setupVCR(t, "fixtures/resource_subaccount_used_for_production")
+		defer stopQuietly(rec)
+
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: getProviders(rec.GetDefaultClient()),
+			Steps: []resource.TestStep{
+				{
+					Config: hclProvider() + hclResourceSubaccountUsedForProd("uut", "integration-test-acc-dyn", "eu12", "integration-test-acc-dyn"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "name", "integration-test-acc-dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "description", ""),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "parent_id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "subdomain", "integration-test-acc-dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "created_by", "john.doe@int.test"),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "created_date", regexpValidRFC3999Format),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "last_modified", regexpValidRFC3999Format),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "state", "OK"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "usage", "USED_FOR_PRODUCTION"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "beta_enabled", "false"),
+					),
+				},
+				{
+					//Update name wo change of usage but proivde usage explicitly again
+					Config: hclProvider() + hclResourceSubaccountUsedForProd("uut", "Integration Test Acc Dyn", "eu12", "integration-test-acc-dyn"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "name", "Integration Test Acc Dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "description", ""),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "parent_id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "subdomain", "integration-test-acc-dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "created_by", "john.doe@int.test"),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "created_date", regexpValidRFC3999Format),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "last_modified", regexpValidRFC3999Format),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "state", "OK"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "usage", "USED_FOR_PRODUCTION"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "beta_enabled", "false"),
+					),
+				},
+				{
+					ResourceName:      "btp_subaccount.uut",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("happy path change to used for prod", func(t *testing.T) {
+		rec := setupVCR(t, "fixtures/resource_subaccount_change_to_used_for_production")
+		defer stopQuietly(rec)
+
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: getProviders(rec.GetDefaultClient()),
+			Steps: []resource.TestStep{
+				{
+					Config: hclProvider() + hclResourceSubaccount("uut", "integration-test-acc-dyn", "eu12", "integration-test-acc-dyn"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "name", "integration-test-acc-dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "description", ""),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "parent_id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "subdomain", "integration-test-acc-dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "created_by", "john.doe@int.test"),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "created_date", regexpValidRFC3999Format),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "last_modified", regexpValidRFC3999Format),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "state", "OK"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "usage", "UNSET"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "beta_enabled", "false"),
+					),
+				},
+				{
+					//Update name wo change of usage but proivde usage explicitly again
+					Config: hclProvider() + hclResourceSubaccountUsedForProd("uut", "Integration Test Acc Dyn", "eu12", "integration-test-acc-dyn"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "name", "Integration Test Acc Dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "description", ""),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "parent_id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "subdomain", "integration-test-acc-dyn"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "created_by", "john.doe@int.test"),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "created_date", regexpValidRFC3999Format),
+						resource.TestMatchResourceAttr("btp_subaccount.uut", "last_modified", regexpValidRFC3999Format),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "state", "OK"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "usage", "USED_FOR_PRODUCTION"),
+						resource.TestCheckResourceAttr("btp_subaccount.uut", "beta_enabled", "false"),
+					),
+				},
+			},
+		})
+	})
+
 	t.Run("error path - parent_id not a valid UUID", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			IsUnitTest:               true,
@@ -141,4 +236,16 @@ resource "btp_subaccount" "%s" {
 }`
 
 	return fmt.Sprintf(template, resourceName, parentId, displayName, region, subdomain)
+}
+
+func hclResourceSubaccountUsedForProd(resourceName string, displayName string, region string, subdomain string) string {
+	template := `
+resource "btp_subaccount" "%s" {
+    name      = "%s"
+    region    = "%s"
+    subdomain = "%s"
+	usage     = "USED_FOR_PRODUCTION"
+}`
+
+	return fmt.Sprintf(template, resourceName, displayName, region, subdomain)
 }


### PR DESCRIPTION
## Purpose

* This PR adds the `usage` of a subaccount as optional parameter to the Terraform resource
* It contains some special logic needed to execute the mapping of the CLI parameters consistently to the possible values of the CIS responses/JSON responses from the CLI
* The test fixtures have been re-recorded and enhanced
* The documentation is updated  

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code

```
go test ./...
```

## What to Check

Verify that the following are valid

* Test succed

## Other Information

Based on PR #288  
@Thanhphan1147 once again thanks for your contribution