### PR TITLE
fix: align setup of resource and data source id for testing framework

### DIFF
--- a/docs/resources/directory_role_collection.md
+++ b/docs/resources/directory_role_collection.md
@@ -47,7 +47,7 @@ resource "btp_directory_role_collection" "my_collection" {
 
 ### Read-Only
 
-- `id` (String, Deprecated) The ID of the directory.
+- `id` (String, Deprecated) The combined unique ID of the role collection as used for import operations.
 
 <a id="nestedatt--roles"></a>
 ### Nested Schema for `roles`

--- a/docs/resources/directory_role_collection_assignment.md
+++ b/docs/resources/directory_role_collection_assignment.md
@@ -43,6 +43,6 @@ resource "btp_directory_role_collection_assignment" "directory_viewer_group" {
 
 ### Read-Only
 
-- `id` (String, Deprecated) The ID of the role collection
+- `id` (String, Deprecated) The combined unique ID of the role collection.
 
 

--- a/docs/resources/globalaccount_role_collection_assignment.md
+++ b/docs/resources/globalaccount_role_collection_assignment.md
@@ -40,6 +40,6 @@ resource "btp_globalaccount_role_collection_assignment" "globalaccount_viewer_gr
 
 ### Read-Only
 
-- `id` (String, Deprecated) The ID of the role collection
+- `id` (String, Deprecated) The combined unique ID of the role collection.
 
 

--- a/docs/resources/subaccount_role_collection.md
+++ b/docs/resources/subaccount_role_collection.md
@@ -47,7 +47,7 @@ resource "btp_subaccount_role_collection" "my_collection" {
 
 ### Read-Only
 
-- `id` (String, Deprecated) The ID of the role collection.
+- `id` (String, Deprecated) The combined unique ID of the role collection as used for import operations.
 
 <a id="nestedatt--roles"></a>
 ### Nested Schema for `roles`

--- a/docs/resources/subaccount_role_collection_assignment.md
+++ b/docs/resources/subaccount_role_collection_assignment.md
@@ -43,6 +43,6 @@ resource "btp_subaccount_role_collection_assignment" "subaccount_viewer_group" {
 
 ### Read-Only
 
-- `id` (String, Deprecated) The ID of the role collection
+- `id` (String, Deprecated) The combined unique ID of the role collection.
 
 

--- a/internal/provider/datasource_directory_entitlements.go
+++ b/internal/provider/datasource_directory_entitlements.go
@@ -56,7 +56,7 @@ To view all the resources that a directory and its subdirectories and subaccount
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_entitlements.go
+++ b/internal/provider/datasource_directory_entitlements.go
@@ -56,7 +56,7 @@ To view all the resources that a directory and its subdirectories and subaccount
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_labels.go
+++ b/internal/provider/datasource_directory_labels.go
@@ -58,7 +58,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_labels.go
+++ b/internal/provider/datasource_directory_labels.go
@@ -58,7 +58,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_role.go
+++ b/internal/provider/datasource_directory_role.go
@@ -45,7 +45,7 @@ func (ds *directoryRoleDataSource) Schema(_ context.Context, _ datasource.Schema
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_role_collection.go
+++ b/internal/provider/datasource_directory_role_collection.go
@@ -64,7 +64,7 @@ func (ds *directoryRoleCollectionDataSource) Schema(_ context.Context, _ datasou
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_role_collections.go
+++ b/internal/provider/datasource_directory_role_collections.go
@@ -67,7 +67,7 @@ func (ds *directoryRoleCollectionsDataSource) Schema(_ context.Context, _ dataso
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_roles.go
+++ b/internal/provider/datasource_directory_roles.go
@@ -65,7 +65,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_directory_users.go
+++ b/internal/provider/datasource_directory_users.go
@@ -56,7 +56,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_entitlements.go
+++ b/internal/provider/datasource_globalaccount_entitlements.go
@@ -69,7 +69,7 @@ To view all the resources a global account:
 * Target only the global account in the command line.
 * You must be assigned to either the global account admin or global account viewers role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_entitlements.go
+++ b/internal/provider/datasource_globalaccount_entitlements.go
@@ -69,7 +69,7 @@ To view all the resources a global account:
 * Target only the global account in the command line.
 * You must be assigned to either the global account admin or global account viewers role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_role.go
+++ b/internal/provider/datasource_globalaccount_role.go
@@ -58,7 +58,7 @@ func (ds *globalaccountRoleDataSource) Schema(_ context.Context, _ datasource.Sc
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Gets details about a specific global account role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_role_collection.go
+++ b/internal/provider/datasource_globalaccount_role_collection.go
@@ -61,7 +61,7 @@ func (ds *globalaccountRoleCollectionDataSource) Schema(_ context.Context, _ dat
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_role_collection.go
+++ b/internal/provider/datasource_globalaccount_role_collection.go
@@ -61,7 +61,7 @@ func (ds *globalaccountRoleCollectionDataSource) Schema(_ context.Context, _ dat
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_role_collections.go
+++ b/internal/provider/datasource_globalaccount_role_collections.go
@@ -57,7 +57,7 @@ func (ds *globalaccountRoleCollectionsDataSource) Schema(_ context.Context, _ da
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Gets all role collections.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_roles.go
+++ b/internal/provider/datasource_globalaccount_roles.go
@@ -54,7 +54,7 @@ func (ds *globalaccountRolesDataSource) Schema(_ context.Context, _ datasource.S
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/role-collections-and-roles-in-global-accounts-directories-and-subaccounts>`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_trust_configurations.go
+++ b/internal/provider/datasource_globalaccount_trust_configurations.go
@@ -46,7 +46,7 @@ You must be viewer or administrator of the global account.
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/trust-and-federation-with-identity-providers>`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_trust_configurations.go
+++ b/internal/provider/datasource_globalaccount_trust_configurations.go
@@ -46,7 +46,7 @@ You must be viewer or administrator of the global account.
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/trust-and-federation-with-identity-providers>`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_users.go
+++ b/internal/provider/datasource_globalaccount_users.go
@@ -48,7 +48,7 @@ func (ds *globalaccountUsersDataSource) Schema(_ context.Context, _ datasource.S
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/user-and-member-management>`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_globalaccount_users.go
+++ b/internal/provider/datasource_globalaccount_users.go
@@ -48,7 +48,7 @@ func (ds *globalaccountUsersDataSource) Schema(_ context.Context, _ datasource.S
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/user-and-member-management>`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_regions.go
+++ b/internal/provider/datasource_regions.go
@@ -71,7 +71,7 @@ func (ds *regionsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 __Tip:__
 You must be assigned to the global account admin or viewer role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_regions.go
+++ b/internal/provider/datasource_regions.go
@@ -71,7 +71,7 @@ func (ds *regionsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 __Tip:__
 You must be assigned to the global account admin or viewer role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_apps.go
+++ b/internal/provider/datasource_subaccount_apps.go
@@ -69,7 +69,7 @@ func (ds *subaccountAppsDataSource) Schema(_ context.Context, _ datasource.Schem
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_entitlements.go
+++ b/internal/provider/datasource_subaccount_entitlements.go
@@ -48,7 +48,7 @@ func (ds *subaccountEntitlementsDataSource) Schema(_ context.Context, _ datasour
 To get all entitlements and quota assigned to a specific subaccount:
 * You must be assigned to either the subaccount admin or subaccount viewer role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_entitlements.go
+++ b/internal/provider/datasource_subaccount_entitlements.go
@@ -48,7 +48,7 @@ func (ds *subaccountEntitlementsDataSource) Schema(_ context.Context, _ datasour
 To get all entitlements and quota assigned to a specific subaccount:
 * You must be assigned to either the subaccount admin or subaccount viewer role.`,
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_environment_instances.go
+++ b/internal/provider/datasource_subaccount_environment_instances.go
@@ -79,7 +79,7 @@ You must be assigned to the subaccount admin or viewer role.`,
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_environment_instances.go
+++ b/internal/provider/datasource_subaccount_environment_instances.go
@@ -79,7 +79,7 @@ You must be assigned to the subaccount admin or viewer role.`,
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_environments.go
+++ b/internal/provider/datasource_subaccount_environments.go
@@ -72,7 +72,7 @@ You must be assigned to the subaccount admin or viewer role.`,
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_environments.go
+++ b/internal/provider/datasource_subaccount_environments.go
@@ -72,7 +72,7 @@ You must be assigned to the subaccount admin or viewer role.`,
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_labels.go
+++ b/internal/provider/datasource_subaccount_labels.go
@@ -58,7 +58,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_labels.go
+++ b/internal/provider/datasource_subaccount_labels.go
@@ -58,7 +58,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_role.go
+++ b/internal/provider/datasource_subaccount_role.go
@@ -67,7 +67,7 @@ func (ds *subaccountRoleDataSource) Schema(_ context.Context, _ datasource.Schem
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_role_collection.go
+++ b/internal/provider/datasource_subaccount_role_collection.go
@@ -64,7 +64,7 @@ func (ds *subaccountRoleCollectionDataSource) Schema(_ context.Context, _ dataso
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_role_collections.go
+++ b/internal/provider/datasource_subaccount_role_collections.go
@@ -68,7 +68,7 @@ func (ds *subaccountRoleCollectionsDataSource) Schema(_ context.Context, _ datas
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_roles.go
+++ b/internal/provider/datasource_subaccount_roles.go
@@ -65,7 +65,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_service_bindings.go
+++ b/internal/provider/datasource_subaccount_service_bindings.go
@@ -68,7 +68,7 @@ func (ds *subaccountServiceBindingsDataSource) Schema(_ context.Context, _ datas
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_service_instances.go
+++ b/internal/provider/datasource_subaccount_service_instances.go
@@ -68,7 +68,7 @@ func (ds *subaccountServiceInstancesDataSource) Schema(_ context.Context, _ data
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_service_offerings.go
+++ b/internal/provider/datasource_subaccount_service_offerings.go
@@ -73,7 +73,7 @@ func (ds *subaccountServiceOfferingsDataSource) Schema(_ context.Context, _ data
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_service_plans.go
+++ b/internal/provider/datasource_subaccount_service_plans.go
@@ -72,7 +72,7 @@ func (ds *subaccountServicePlansDataSource) Schema(_ context.Context, _ datasour
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_subscriptions.go
+++ b/internal/provider/datasource_subaccount_subscriptions.go
@@ -88,7 +88,7 @@ You must be assigned to the subaccount admin or viewer role.`,
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_trust_configurations.go
+++ b/internal/provider/datasource_subaccount_trust_configurations.go
@@ -56,7 +56,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_users.go
+++ b/internal/provider/datasource_subaccount_users.go
@@ -56,7 +56,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccount_users.go
+++ b/internal/provider/datasource_subaccount_users.go
@@ -56,7 +56,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` attribute instead",
 				MarkdownDescription: "The ID of the subaccount.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccounts.go
+++ b/internal/provider/datasource_subaccounts.go
@@ -80,7 +80,7 @@ You must be assigned to the admin or viewer role of the global account, director
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/datasource_subaccounts.go
+++ b/internal/provider/datasource_subaccounts.go
@@ -80,7 +80,7 @@ You must be assigned to the admin or viewer role of the global account, director
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `btp_globalaccount` datasource instead",
 				MarkdownDescription: "The ID of the global account.",
 				Computed:            true,

--- a/internal/provider/fixtures/resource_directory_role_collection.error_import.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.error_import.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2da785fa-0917-1467-a2bc-8e072dad5a67
+                - ebf4120a-adf7-d4b8-c2c5-6f26f762623e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:30 GMT
+                - Thu, 20 Jul 2023 06:39:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 47322d95-c13e-4cd3-4add-266c8404f0c0
+                - 032239d9-cb98-4804-741c-bf0ef6ef1a1a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 433.623827ms
+        duration: 370.5254ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3a10fdb5-64f3-59ea-aa85-362ecd9f0f21
+                - b18a77af-acab-3adb-fbef-54f20ebf00bc
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:31 GMT
+                - Thu, 20 Jul 2023 06:39:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 67a4d4cb-20e1-4a4f-4d07-c6df7dcf4694
+                - 487bfb2b-b849-405d-4a98-42e0d730b376
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 231.955479ms
+        duration: 390.3468ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 76186fff-48ad-0799-5143-ff68d834c01d
+                - 124739db-302f-d88d-d41e-88b23822d941
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:31 GMT
+                - Thu, 20 Jul 2023 06:39:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1fe056f2-37a5-4eb1-6178-97f3270d4c33
+                - 54f1c18e-afc4-47e5-5750-1c5d260e17e5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 209.040546ms
+        duration: 368.8268ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f6a9497c-b0aa-5711-259e-1477a3ac617f
+                - 4ae97c90-2739-c062-9ed2-a0c627fcd374
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:31 GMT
+                - Thu, 20 Jul 2023 06:39:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 92fde023-36dd-4a3a-5e0b-a268b40db9fd
+                - b39b692d-13bc-4442-792a-b51047fce75e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 329.946886ms
+        duration: 271.1328ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 10c3e003-eb42-fcb1-0dac-933f9cf3bf5c
+                - d877b28b-6b1f-4bf1-6c05-046c89328bed
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:32 GMT
+                - Thu, 20 Jul 2023 06:39:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,18 +327,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 672e3dd9-7ee6-45a1-459b-08112c95a17d
+                - d17ce333-ab2a-4603-4603-caec028c296f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 247.824472ms
+        duration: 263.0159ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6807c9c8-9add-c59c-007b-c9af48426db4
+                - ed16afaf-6eab-f7d1-db0f-de5ca40dd3b8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -364,18 +364,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:32 GMT
+                - Thu, 20 Jul 2023 06:39:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -389,18 +389,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e40b5b41-b122-4e19-7b75-35998276f254
+                - 2fb84ec6-c074-44a1-62eb-fade12b3934b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 188.175338ms
+        duration: 382.6062ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -413,9 +413,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f631d3aa-46ce-6829-ac0d-a0f9ad6b1409
+                - 6424fe67-649d-65a0-0e79-5f557d89caa4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -426,18 +426,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:33 GMT
+                - Thu, 20 Jul 2023 06:39:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -451,12 +451,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fbe18f11-4e3f-4988-51eb-2606286746a9
+                - 1c16ce82-64b7-410c-5aec-38ddddefc476
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 363.243233ms
+        duration: 348.4224ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -475,9 +475,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bbe524c6-4177-45da-5d28-d97b0c183123
+                - 009e5ff6-5f59-eb6d-521d-c6fa447feda0
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -503,7 +503,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:33 GMT
+                - Thu, 20 Jul 2023 06:39:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -525,18 +525,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5c1d23ec-6890-4ed5-689d-5a0589451f60
+                - e6f2d642-f68c-482e-7d67-4d9441a1bcb1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 300.677232ms
+        duration: 280.6728ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -549,9 +549,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 981fb9ed-bd69-5dfe-baee-a03094e54959
+                - 0149113d-a44f-d62c-a9f9-a2bc978b56a8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -562,18 +562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:33 GMT
+                - Thu, 20 Jul 2023 06:39:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -587,18 +587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 242289c5-218f-4a58-5176-8b957b6da49b
+                - f3c33697-631c-4358-6fd2-1e3753e50f0c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 214.21994ms
+        duration: 335.496ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -611,9 +611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0ef5c85c-0da6-6826-3883-672aba55aecb
+                - 16824705-bacc-4619-d74d-2202fd2ea32b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -624,18 +624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:34 GMT
+                - Thu, 20 Jul 2023 06:39:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -649,18 +649,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 587f8315-ca65-4d3e-620f-1d336390ee97
+                - 45303e04-c590-441d-5324-47eda67e8590
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 212.404384ms
+        duration: 382.3849ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -673,9 +673,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 62a22a09-886d-408b-af5d-c1a3cb2c3565
+                - 54897c68-ee24-09d5-24c7-62b6a79dd187
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -686,18 +686,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:34 GMT
+                - Thu, 20 Jul 2023 06:39:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -711,18 +711,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4ff6230b-7fa7-42aa-5d6e-906b8039bf53
+                - 007008c5-52c9-46d4-6833-a1e5f1b862be
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 213.005689ms
+        duration: 301.3969ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -735,9 +735,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2a7bebd5-a820-6699-6e5b-8a241202922f
+                - b04fa9f7-5874-f6ac-3d98-442b1e40496b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -748,18 +748,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:34 GMT
+                - Thu, 20 Jul 2023 06:39:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -773,12 +773,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 944d41fb-3a70-46bb-5ee3-f6d9fc8734b5
+                - e5bc5fac-d8eb-4338-7fb6-f9159dee9dd3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 187.803749ms
+        duration: 386.2293ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -797,9 +797,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 97a601f0-77d4-cb10-e2d0-841f11e252c8
+                - 653649a7-255c-ce25-269d-585c4af5fe72
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -825,7 +825,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:35 GMT
+                - Thu, 20 Jul 2023 06:39:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -845,9 +845,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4abe4861-33c1-435e-5b9d-211bf4718a33
+                - b2d72c9c-94b3-43ef-5611-1150f9c92983
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 394.827832ms
+        duration: 257.2185ms

--- a/internal/provider/fixtures/resource_directory_role_collection.multiple_roles.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.multiple_roles.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 680d9861-9b3f-6571-ef41-6dff29c51490
+                - 48a7aa7d-ab6d-0029-e7c8-4e3cc1e2426b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:09 GMT
+                - Thu, 20 Jul 2023 06:38:45 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - baffb79d-8012-42c9-76c7-3920ba9bd449
+                - aeb79d3f-6365-40e4-5082-53e560f9d740
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 423.745215ms
+        duration: 382.7496ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f524aced-7ec8-cc62-5c9e-bebcdc5e01b2
+                - 11be6da8-671e-7ca1-27d0-9087b0a6f498
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:10 GMT
+                - Thu, 20 Jul 2023 06:38:45 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 25e618f9-05e3-43c7-7544-d3d9b33a1cf2
+                - 080ef89f-5248-438b-4068-914ca7191d0f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 291.334824ms
+        duration: 446.2464ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 718bd10e-100a-b527-f535-d2a50bf2ae97
+                - b8361f36-22b6-e6b6-edc3-cd4f3a2bf28f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:10 GMT
+                - Thu, 20 Jul 2023 06:38:46 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 52236c93-dfb9-4736-7618-13d8f8c00a8c
+                - 613a90c2-3483-4958-7094-41d2eae3a623
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 262.456042ms
+        duration: 408.6979ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 69ce1b78-7fc3-86b5-2406-3f9fda35edf1
+                - 05ab7833-7e06-eb50-9cf4-e61991bdb94c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:10 GMT
+                - Thu, 20 Jul 2023 06:38:46 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 35c9fd17-5a28-49f8-4c5f-6fbb8da694a9
+                - cd95a314-b810-4dcf-6d76-8d88529f91ec
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 346.166078ms
+        duration: 279.7778ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a89bce41-7faa-2a12-44b6-e82d40c61143
+                - 9abaf9c0-208d-5927-e1ec-b526b3c8d8f9
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:11 GMT
+                - Thu, 20 Jul 2023 06:38:46 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,12 +327,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0798c831-4bce-4f86-48af-9cde0bea9e2d
+                - 7bed8b77-a78c-4683-4462-29d1c93f8ebe
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 304.927973ms
+        duration: 278.0819ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - edabc3f8-50dc-a1f6-799b-a88152a4f78d
+                - 07f11cce-7a2b-2140-0e77-c22615069831
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -379,7 +379,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:11 GMT
+                - Thu, 20 Jul 2023 06:38:46 GMT
             Expires:
                 - "0"
             Pragma:
@@ -399,18 +399,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f1885e09-b107-4239-6900-d9793d0aafd1
+                - da784ff4-f1a5-4360-719b-191dddff919a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 305.906502ms
+        duration: 261.3116ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -423,9 +423,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 46771048-48e6-9f1a-acd8-b647107ab5b1
+                - f2aa10a4-4f63-b1fb-e9f1-87726aee5885
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -436,18 +436,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:12 GMT
+                - Thu, 20 Jul 2023 06:38:47 GMT
             Expires:
                 - "0"
             Pragma:
@@ -461,18 +461,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b7e648ac-72a4-49e5-7f84-1c3a2d3cb702
+                - e552e356-3b20-4cd6-662f-d3eb2cef129d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 229.368822ms
+        duration: 450.934ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -485,9 +485,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 88540aa2-62e9-8886-50fd-617df1eda671
+                - dc3dd074-7c97-1a42-8451-2b560ee42b01
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -498,18 +498,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:12 GMT
+                - Thu, 20 Jul 2023 06:38:47 GMT
             Expires:
                 - "0"
             Pragma:
@@ -523,12 +523,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1988c9f8-8c47-4ecb-7d8f-c7407bc85fe7
+                - 1b91808e-b401-436f-69c9-740f1e597e26
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 200.754637ms
+        duration: 353.2596ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -547,9 +547,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 600bac2f-f6c7-b58f-06af-6b9b2a8037ef
+                - 73123084-d760-ca61-98f3-8dbd22c30569
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -575,7 +575,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:12 GMT
+                - Thu, 20 Jul 2023 06:38:48 GMT
             Expires:
                 - "0"
             Pragma:
@@ -597,18 +597,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2231c1e4-0e5f-498a-55c8-646d8a9ae4aa
+                - 22cd6059-3a2e-4b99-740c-3c01472f6b7a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 337.021336ms
+        duration: 300.394ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -621,9 +621,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c666e814-f1cf-5814-dcdb-879e75c6943f
+                - 8809bd93-f2aa-54c1-ac97-b5787526b536
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -634,18 +634,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:13 GMT
+                - Thu, 20 Jul 2023 06:38:48 GMT
             Expires:
                 - "0"
             Pragma:
@@ -659,18 +659,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e9fe92ae-2f44-4a4f-5ffb-467225c6414a
+                - 93e60804-e185-494a-7a12-89aea12623a1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 393.386456ms
+        duration: 398.112ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -683,9 +683,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - cc263e29-50cf-28e8-6d3e-c067b09dd698
+                - 1e007eac-9d05-6ec9-4c5e-f43c867d6680
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -696,18 +696,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:13 GMT
+                - Thu, 20 Jul 2023 06:38:49 GMT
             Expires:
                 - "0"
             Pragma:
@@ -721,12 +721,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d974145a-e199-45de-4679-c94d5b2eabb0
+                - e44318fa-4494-4f6d-4c95-f1d04c0d5d07
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 285.92638ms
+        duration: 370.4491ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -745,9 +745,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6ebfc77d-ac5e-b11c-30d6-a1407fc2d05d
+                - d447f19f-b658-7ac3-aa96-696e13f2a835
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -773,7 +773,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:14 GMT
+                - Thu, 20 Jul 2023 06:38:49 GMT
             Expires:
                 - "0"
             Pragma:
@@ -795,18 +795,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c6eae8a4-10bd-4a9d-7625-fd956285fb11
+                - cc7fdf2d-a899-4ccc-4dff-d8211e824102
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 306.198136ms
+        duration: 248.9997ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -819,9 +819,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6c513e83-0b19-cd74-a268-1e79f7140522
+                - 042ef3f2-a469-ea49-207d-1f0a617a34f5
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -832,18 +832,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:14 GMT
+                - Thu, 20 Jul 2023 06:38:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -857,18 +857,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 154dd2db-9841-4738-5fc5-4389ce7fca8b
+                - a8449359-7962-4e91-5b39-b47b87c31a72
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 348.589635ms
+        duration: 355.7711ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -881,9 +881,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f27a32bf-8808-4530-4d72-87c6b660e6d3
+                - f91a29d0-977b-c581-df06-8a28e2e76474
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -894,18 +894,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:15 GMT
+                - Thu, 20 Jul 2023 06:38:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -919,12 +919,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9161a518-74a3-4ced-6cc7-ad4cc950a85b
+                - f332507f-ba41-4cde-4494-4792513d0fa5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 227.658775ms
+        duration: 361.7885ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -943,9 +943,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - be07d4c6-be6c-d289-4288-5eb9f9c1674f
+                - c0ce5352-54c5-6f6a-5442-b09c482ce504
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -971,7 +971,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:15 GMT
+                - Thu, 20 Jul 2023 06:38:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -991,9 +991,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fbdfb55c-804d-478f-62a4-b9e36b32cd8c
+                - 9ba97164-1aca-46a1-6fbd-d76671dfaa78
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 353.366291ms
+        duration: 248.2746ms

--- a/internal/provider/fixtures/resource_directory_role_collection.no_description.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.no_description.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7ec384fe-4cfb-9969-744e-61f11267b618
+                - 51f4e1a9-108b-0d14-77ee-73be507f54fe
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:55 GMT
+                - Thu, 20 Jul 2023 06:38:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f5beaec3-1af4-4706-6f09-92d11a694668
+                - 090fc4ff-0360-407b-5b38-16b079268887
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 715.13451ms
+        duration: 721.0081ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 43a443bd-7d99-b048-179e-e73d13d86098
+                - 8a1f57dc-aabe-808c-5887-59d43c912f33
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:56 GMT
+                - Thu, 20 Jul 2023 06:38:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 848c5c77-9939-45ac-4104-a130dea29c59
+                - 61093252-ab92-41f9-6a86-10eb8841e0d9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 473.047012ms
+        duration: 426.9009ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 52d0e77b-c069-9b75-60a5-bfc7c7b491c2
+                - 14127e7d-8497-087e-eee3-e246f5baa07f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:57 GMT
+                - Thu, 20 Jul 2023 06:38:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 27ea5780-a84b-4a90-7806-45165cfe5b74
+                - 77034d6d-8b43-4c68-4177-e67fb8a9eef9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 320.988853ms
+        duration: 384.3725ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 83bcd70d-3c3b-f752-668a-039389b7d125
+                - fcb18a9c-7245-6b86-520a-5506b13ad0f9
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:57 GMT
+                - Thu, 20 Jul 2023 06:38:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ec867cd3-7876-4e91-6e21-8269614e32f6
+                - 264b16ac-38d3-450d-46d3-fefbe4eba799
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 374.559408ms
+        duration: 470.5254ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9765fc30-9061-47fe-d7ed-9afe706f490b
+                - 71e51cf5-d079-b51a-004c-6f885e865cd6
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:57 GMT
+                - Thu, 20 Jul 2023 06:38:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,18 +327,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7a965596-aa54-47a3-5796-6b58f77899da
+                - 648b5314-f014-4298-648c-398eb2184614
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 512.792037ms
+        duration: 482.6037ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e345e3aa-3ecc-f948-8b2a-0a1445cc647a
+                - 5790ee3d-88bb-7cc5-f92e-3202377777c3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -364,18 +364,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:58 GMT
+                - Thu, 20 Jul 2023 06:38:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -389,18 +389,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e4ae4d58-e180-4804-7fd8-9123ac547765
+                - 2f600cd6-459d-483f-6535-a7aa68b476fd
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 212.020669ms
+        duration: 400.6712ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -413,9 +413,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3cbe8e70-43e2-4727-dc65-b97a21788a62
+                - 545d2671-0f56-682f-3890-f750427b9170
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -426,18 +426,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:58 GMT
+                - Thu, 20 Jul 2023 06:38:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -451,12 +451,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fef5adc4-ab1b-4372-5116-438e701c8ab0
+                - a41ab0db-320e-4771-65b7-2938f47328e9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 374.550138ms
+        duration: 393.6753ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -475,9 +475,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 81710eb9-1d8e-4ba9-841d-f952b2fafeab
+                - 41f88db3-9987-8da4-efa8-cb647ec5e261
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -503,7 +503,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:59 GMT
+                - Thu, 20 Jul 2023 06:38:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -525,18 +525,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 01d3514c-5087-4577-6d69-2e6155446982
+                - f6b5a59d-5b25-41a7-77a3-723c2ca3ced4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 407.918836ms
+        duration: 281.4431ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -549,9 +549,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3412b9ad-1ac7-7c64-b5bd-c6189a8598ec
+                - 6cadaf18-0526-a464-ce60-e884044b82dc
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -562,18 +562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:35:59 GMT
+                - Thu, 20 Jul 2023 06:38:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -587,18 +587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 52a7f324-7bca-49a4-6fd2-e8c2aab66860
+                - 0d56ec5a-2194-4259-6bc6-5a55759d10a2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 301.253151ms
+        duration: 389.4685ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -611,9 +611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d7716014-1085-577f-2d6a-2fe2ffbf9031
+                - 34207695-e600-602f-bf8e-3a8e6b551a90
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -624,18 +624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:00 GMT
+                - Thu, 20 Jul 2023 06:38:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -649,12 +649,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fe3631cd-57a4-4470-7419-f694314e9f91
+                - ec516a0e-5b4e-4ccb-77c4-10df36443582
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 267.788677ms
+        duration: 377.0696ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -673,9 +673,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1edced46-c4a7-a796-be42-8d514d0f3c3b
+                - de5ce4a5-9b0b-1ff4-d965-6042d36c6ffb
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -701,7 +701,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:01 GMT
+                - Thu, 20 Jul 2023 06:38:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -723,18 +723,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c2c2eaf1-1e7c-4018-4306-af82fac4efb2
+                - 317b20b2-021f-49e3-73eb-e549f2e1ff94
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 694.952935ms
+        duration: 306.763ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -747,9 +747,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d1355025-f35d-2b6d-8be4-154d2ab6926b
+                - a8c83cec-aa8e-4a4e-4b7a-e8df56fbc1e5
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -760,18 +760,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:01 GMT
+                - Thu, 20 Jul 2023 06:38:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -785,18 +785,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e884f9ef-1b63-4d25-4e4b-641179f1b969
+                - 5e9c9113-415d-4491-5c6d-29451835fb34
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 347.58128ms
+        duration: 408.0215ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -809,9 +809,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d6100d5e-c014-8df6-99a8-1dae5ad44689
+                - 1178d293-822a-c45f-70bd-7bd0d5f5d1ff
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -822,18 +822,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:02 GMT
+                - Thu, 20 Jul 2023 06:38:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -847,12 +847,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 35948864-c34c-4304-4e31-b6c8df28a3e0
+                - 5a1b5321-5e3e-44ad-7b26-6c480bb62ff7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 323.806685ms
+        duration: 364.0588ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -871,9 +871,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b9cbb37a-ee4e-1e81-3012-c2c4437ec811
+                - de9332fb-c768-3c47-9b86-e7d6f514a58b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -899,7 +899,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:02 GMT
+                - Thu, 20 Jul 2023 06:38:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -919,9 +919,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b800dbec-3426-45a5-6914-8a9b1135b773
+                - 144070d6-dbb0-4e91-5408-e33d237efdd2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 406.279812ms
+        duration: 402.0424ms

--- a/internal/provider/fixtures/resource_directory_role_collection.update.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.update.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1a6231ec-cbac-f709-c433-ae1c35ca6861
+                - 5079abe4-3015-71c2-4d42-863bf0cd70e3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:16 GMT
+                - Thu, 20 Jul 2023 06:38:51 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b0b2b585-e15b-43dd-7d04-0f3d80f5f537
+                - d3844713-233f-4b4e-41ef-c30bea3113af
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 391.484934ms
+        duration: 382.8626ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 14602f5f-a935-0122-4181-ce97f7817d8b
+                - f49df7a1-b7d0-a3de-b996-e101f426b35a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:16 GMT
+                - Thu, 20 Jul 2023 06:38:51 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a6919f53-2723-491f-7c6a-733245720ad3
+                - ab57bf15-7850-4043-5821-c7c32fc85537
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 400.104056ms
+        duration: 342.9294ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f7e1c8d1-818d-c251-381c-e2f8eea8e4f9
+                - 92a86011-ceaa-648f-1f69-4c74acbca487
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:17 GMT
+                - Thu, 20 Jul 2023 06:38:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bad146b0-aabe-443e-50ac-889161797af7
+                - a1eee2c3-ec53-4c9d-5519-d502baa1dd73
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 311.103814ms
+        duration: 359.0841ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a32073da-117c-d3be-8bee-4f14e54eb3d6
+                - 33bac36c-e2e3-9dd4-8273-5f39dc2dd3ce
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:17 GMT
+                - Thu, 20 Jul 2023 06:38:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cade1950-4d78-45e2-54bf-be61488fc7bc
+                - e702230d-b1cf-405c-6b7f-a6d083aaaced
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 354.718021ms
+        duration: 305.6327ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b036e213-029b-b38b-5df2-93bbc2bb7e61
+                - 791d8d01-9044-085b-2415-bd37dc38d8e0
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:17 GMT
+                - Thu, 20 Jul 2023 06:38:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,18 +327,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 58c2278c-1f38-4e94-694f-d093da4162ee
+                - af7b319c-0ebc-425f-694e-84bc4c621fa0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 321.837753ms
+        duration: 338.2013ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f23e383d-dfdd-da35-41b6-ea02db6191be
+                - 8b8fb19d-7f57-9b18-0750-d506eeb64170
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -364,18 +364,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:18 GMT
+                - Thu, 20 Jul 2023 06:38:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -389,18 +389,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e8a28f32-294a-4f7d-7e11-c52a568b0046
+                - 0c713137-b988-4782-59d8-7dcf609310ca
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 305.898269ms
+        duration: 375.4202ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -413,9 +413,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9e3535d7-ece6-9d92-7a2b-ae2e0ba1551f
+                - cdd61432-7beb-e89a-061a-3be47c569bd3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -426,18 +426,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:18 GMT
+                - Thu, 20 Jul 2023 06:38:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -451,12 +451,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 80b61e79-c8da-4416-47b6-02127053a5ec
+                - d573022b-272b-438f-63a2-3788c173f534
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 203.295012ms
+        duration: 361.9729ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -475,9 +475,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a82a5563-c475-0d1e-d03d-3625978b2a44
+                - 21e3d88d-d5f9-632f-c767-ac70fa740b77
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -503,7 +503,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:19 GMT
+                - Thu, 20 Jul 2023 06:38:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -525,18 +525,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - eb893304-c876-41c8-56a9-0f0a35a51d8b
+                - 6aff5cd2-45fd-4ee8-54a4-cafd07aa67dc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 242.612301ms
+        duration: 245.7056ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -549,9 +549,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a42aab3c-42e0-723d-5780-3d711235d132
+                - 36122ef4-2940-de88-7f54-d5cb0eec07fb
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -562,18 +562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:19 GMT
+                - Thu, 20 Jul 2023 06:38:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -587,18 +587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 41a1c591-942a-430b-5e42-c9b408808d65
+                - 387bd9b3-4a76-40de-5925-b7f27fb4c533
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 287.58418ms
+        duration: 357.5669ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -611,9 +611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 269754aa-4253-5820-5e3c-401bf27e0c4c
+                - 9798048d-e4a7-122a-69ea-873a0fb4560a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -624,18 +624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:19 GMT
+                - Thu, 20 Jul 2023 06:38:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -649,12 +649,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cafbde68-238e-418e-56d1-111a7ea8ec03
+                - 3b931e5c-455b-4c7a-67ce-d07798b61beb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 225.842449ms
+        duration: 351.0071ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -673,9 +673,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bb16260f-ca47-e55e-2625-4d773a73bfdb
+                - eedbb878-442f-c4a7-100b-841c469dd00c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -701,7 +701,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:20 GMT
+                - Thu, 20 Jul 2023 06:38:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -723,18 +723,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6cfaad76-c93e-4aa5-618b-f9c0039c580e
+                - 93a53e57-fc29-4477-60a4-b87b5b106db6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 347.781974ms
+        duration: 244.8024ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -747,9 +747,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b80cbdc5-8652-37bc-46db-b9bba8dccdcf
+                - 58e7bd43-fafd-5c95-7213-0cf1b6ccdcdc
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -760,18 +760,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:20 GMT
+                - Thu, 20 Jul 2023 06:38:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -785,18 +785,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 36ce346c-5d79-4c43-6743-a1453919e28f
+                - 97c3d0f2-b7b7-4694-43cc-94974a16c619
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 205.424302ms
+        duration: 454.568ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -809,9 +809,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 234b85f8-bdb9-d470-41c9-264f65d7e865
+                - 127ea4d8-16d8-eb6b-c2c4-3bdadec39592
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -822,18 +822,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:21 GMT
+                - Thu, 20 Jul 2023 06:38:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -847,12 +847,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7e09694d-e01a-4069-488e-b38d6d97234b
+                - 5a94c121-9cb8-4d0c-73d2-0e44ee93043a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 354.527954ms
+        duration: 343.9733ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -871,9 +871,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 01f85efb-5852-170b-804d-c129621fdcfd
+                - 29b3a070-6cb7-1819-da70-67904ad3562b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -899,7 +899,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:21 GMT
+                - Thu, 20 Jul 2023 06:38:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -919,12 +919,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 55a01615-733c-485b-7ae7-d37ea3fbde1a
+                - e4d36f99-ecf2-4fd3-7352-1390beb165e3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 276.159514ms
+        duration: 253.796ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -943,9 +943,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e0998c61-0f29-8232-1ed1-742fd77ab300
+                - 914b96c0-0bfe-bf29-f57e-605a077cc851
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -971,7 +971,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:21 GMT
+                - Thu, 20 Jul 2023 06:38:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -991,12 +991,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 907a2951-cd1d-445d-65d3-a14efbb48010
+                - de427a9f-cbed-4604-4dd0-8c59629d2be1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 246.536522ms
+        duration: 341.845ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1015,9 +1015,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9ff8366f-164f-f097-593c-aa6ec72c2329
+                - c12c8222-6ce5-b523-0077-94567a02ace3
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1043,7 +1043,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:21 GMT
+                - Thu, 20 Jul 2023 06:38:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1065,18 +1065,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 80908fca-0660-432e-5c33-8e6e3bae2288
+                - 29587b21-edfe-417a-7f21-c95d6d8a157d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 240.503339ms
+        duration: 254.4859ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1089,9 +1089,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3a6bb49f-8e46-2cb5-5a40-0ec94f75cadf
+                - 9f9b5706-dc48-d167-5eac-4adfb906e038
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1102,18 +1102,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:22 GMT
+                - Thu, 20 Jul 2023 06:38:57 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1127,18 +1127,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a6622561-73f1-40c9-6bcb-2a563e649526
+                - 73ac5df6-8724-4e06-476c-1566a3364ddf
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 368.970059ms
+        duration: 366.0705ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1151,9 +1151,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5a7232b2-89b2-3a52-bdba-e24d82bd05b7
+                - 97e38697-c104-96a4-e716-b48ef8349390
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1164,18 +1164,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:22 GMT
+                - Thu, 20 Jul 2023 06:38:57 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1189,12 +1189,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7199d25a-e063-4b17-6121-c9a8b7ea61d5
+                - 525f1025-d509-4ee1-4e1f-ccb9eaea88c4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 208.985717ms
+        duration: 381.1489ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1213,9 +1213,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - cfa95ab8-43f0-f6c7-7c0b-936a6bd52c17
+                - dcf9dc5c-b17f-f836-7e99-71f39cfcf19c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1241,7 +1241,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:23 GMT
+                - Thu, 20 Jul 2023 06:38:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1263,18 +1263,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 27ee5717-18e4-44bc-5a8c-84b32b344d1e
+                - dd38a8c7-378a-44f0-501c-059962e943a7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 330.927262ms
+        duration: 262.502ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1287,9 +1287,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ea59a38e-b7c3-5176-f5d1-3fc88a623fd6
+                - 5c51f0ac-1475-ba31-c5f1-1b0a7f0502da
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1300,18 +1300,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:23 GMT
+                - Thu, 20 Jul 2023 06:38:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1325,18 +1325,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3a7116fa-ecf7-4f9b-6da7-2557f48661ae
+                - c2b037d2-5d30-4fa0-69e4-0625e4e60e9b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 197.354781ms
+        duration: 408.0575ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1349,9 +1349,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0fb7997a-a3b8-937a-6a34-912655c15c16
+                - d783c875-2f53-416d-7c3e-2cc5d895908e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1362,18 +1362,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:23 GMT
+                - Thu, 20 Jul 2023 06:38:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1387,12 +1387,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c321e92d-70cc-4ad2-5fe6-c9a24276c7f8
+                - 6cf09080-c375-498e-65ba-ff582c08f711
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 214.713249ms
+        duration: 433.1707ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1411,9 +1411,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 594c09c4-7866-9eba-c5e0-b73395c72695
+                - 5863dab0-f49e-c840-9c16-5a97c13a712b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1439,7 +1439,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:24 GMT
+                - Thu, 20 Jul 2023 06:38:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1461,18 +1461,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8cc1f8fb-de48-4832-4387-63e213f792fc
+                - 44b0dce4-76ec-441a-5e34-a69cc995e1ba
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 355.938339ms
+        duration: 239.5889ms
     - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1485,9 +1485,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ae04a3a7-abc7-3341-9cec-9e6880f9bdf7
+                - 9f035a18-8e08-479b-0cc5-a525f4eb7468
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1498,18 +1498,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:24 GMT
+                - Thu, 20 Jul 2023 06:38:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1523,18 +1523,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6ba21339-0562-4acb-79de-b11937b08852
+                - da9fcd28-d3e2-4986-700d-05ff664888ea
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 388.234023ms
+        duration: 353.8533ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1547,9 +1547,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4d07b7ca-b87a-defc-4b11-9f666df6b938
+                - 5bc90ad0-b982-a484-a59c-c5db180445e1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1560,18 +1560,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:25 GMT
+                - Thu, 20 Jul 2023 06:39:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1585,12 +1585,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4f5f4624-8213-4c9c-45de-022db9b5af58
+                - 52ebfec9-4ccd-464a-4508-34da477cda97
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 226.72479ms
+        duration: 494.1373ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1609,9 +1609,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2d038d2e-b9e5-7cbf-5f9d-e319760c856b
+                - 23b4173a-61d1-a7d6-2be8-515f412317a4
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1637,7 +1637,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:25 GMT
+                - Thu, 20 Jul 2023 06:39:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1657,12 +1657,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3a2d7ec4-ad66-4051-5eeb-84fef1d8dc46
+                - deea143f-d523-47cf-72c2-35d21dc6c773
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 368.50093ms
+        duration: 260.9123ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1681,9 +1681,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 01623ef2-a6c2-b012-8c73-513311bb084f
+                - 6012476a-4539-8e04-c24e-632092bedc5d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1709,7 +1709,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:25 GMT
+                - Thu, 20 Jul 2023 06:39:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1729,12 +1729,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 46232651-ebf6-429b-44f0-02216a52f3d4
+                - 125da2e1-ae13-4b91-4444-faec33bba211
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 287.408079ms
+        duration: 276.5447ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1753,9 +1753,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 425b6154-11b5-c507-6580-0ad61a61a46e
+                - d655e0b0-d7bb-3188-5e28-9c9c086842d9
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1781,7 +1781,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:26 GMT
+                - Thu, 20 Jul 2023 06:39:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1803,18 +1803,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f868d2dc-0910-4d6d-57f6-4edcbb9d78c1
+                - e4a44418-c626-47e9-6d67-38f974294744
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 323.502961ms
+        duration: 253.2577ms
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1827,9 +1827,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f27eed64-642e-6b35-b132-ba636a4b9127
+                - e0077a7d-79e1-b0fb-65b6-129808e80db6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1840,18 +1840,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:26 GMT
+                - Thu, 20 Jul 2023 06:39:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1865,18 +1865,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bc5fc697-7d1c-4487-4cc3-6398c64344bb
+                - f019b2ae-503d-411e-6ec5-1ec90902f68d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 205.999961ms
+        duration: 372.2267ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1889,9 +1889,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c967fe90-ce6e-7e0e-3666-0445fe33ee84
+                - 4fb8504b-de5e-b16a-e949-b8b538bb9ddd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1902,18 +1902,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:26 GMT
+                - Thu, 20 Jul 2023 06:39:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1927,12 +1927,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7aeaea9f-2ff5-4a74-6ef8-e0fb55963810
+                - 9071a59d-9c61-4b86-7cf1-efae54b96355
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 212.618193ms
+        duration: 408.4383ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1951,9 +1951,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0ce2b1a1-cb9e-9f3b-31e8-9230b866eb00
+                - a337a9c1-c020-eb4d-33b6-a5c8b71cce36
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1979,7 +1979,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:27 GMT
+                - Thu, 20 Jul 2023 06:39:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2001,18 +2001,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4983273d-b58c-418e-5c0b-fdce26839316
+                - 78881378-ba1d-4881-7947-bf51ebafc512
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 364.423033ms
+        duration: 301.678ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2025,9 +2025,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - aae82612-a67f-272b-a329-62799f3c59eb
+                - 128110f1-7f3e-9dd5-de45-3cf14ab00241
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2038,18 +2038,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:27 GMT
+                - Thu, 20 Jul 2023 06:39:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2063,18 +2063,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 74351c40-3346-47ca-5ca4-f6733187f709
+                - ac756084-f274-4ae9-717a-dc246069ab76
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 394.427776ms
+        duration: 504.1653ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2087,9 +2087,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ab9bfe9d-6d56-8d26-0002-fada9f310488
+                - 2dc7728f-6370-29d9-a0a0-98ad04d8319f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2100,18 +2100,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:28 GMT
+                - Thu, 20 Jul 2023 06:39:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2125,12 +2125,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 27e8cdc0-f99e-4ce5-4349-52594c2251f1
+                - dc46dc45-1a15-47fa-4ab4-0bfcf1e25200
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 292.176385ms
+        duration: 385.8563ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -2149,9 +2149,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 063f1848-1ca6-68e9-bf68-3ed06110e14f
+                - 7e784746-62cf-2951-1f6a-387ed2b1ef46
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2177,7 +2177,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:28 GMT
+                - Thu, 20 Jul 2023 06:39:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2199,18 +2199,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 08f562fe-1233-4e76-690d-57eee05b582a
+                - 542da529-10e7-4d26-5e24-99c4f83d1869
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 269.451016ms
+        duration: 262.875ms
     - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2223,9 +2223,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 71241d7d-db21-2262-d5f6-d396ae93dee2
+                - 26bd6994-b6c5-c414-a5bf-d8be93647203
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2236,18 +2236,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:29 GMT
+                - Thu, 20 Jul 2023 06:39:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2261,18 +2261,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4261fc6a-f8d0-46a7-56e2-1f5276d6417f
+                - 499c927f-8816-4151-5d60-6ac846303967
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 348.865058ms
+        duration: 355.0348ms
     - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2285,9 +2285,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 532f3e16-adce-4eef-710f-ed0d1ff03734
+                - 0fd821fc-a368-0aad-c566-b8cc3efb9beb
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2298,18 +2298,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:29 GMT
+                - Thu, 20 Jul 2023 06:39:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2323,12 +2323,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 75ec9680-2db4-42bf-7c6e-53564817de2f
+                - 3fc0dba3-a320-4366-53eb-8c7dfb78528b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 339.034505ms
+        duration: 383.0898ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2347,9 +2347,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0d9f00be-44fe-6b72-343f-c4b80bd33c93
+                - 1fcb9024-e83d-fda0-3f60-6902ca689fb7
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2375,7 +2375,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:29 GMT
+                - Thu, 20 Jul 2023 06:39:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2395,9 +2395,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 40496075-b76f-47bf-6c29-daeb82d7b69a
+                - 904c5b82-c75c-402f-5ede-74f8c093b1d6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 372.733778ms
+        duration: 242.2574ms

--- a/internal/provider/fixtures/resource_directory_role_collection.with_description.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.with_description.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f9995902-d9ae-f6c4-984d-9c676d46186f
+                - dad53bf6-eac9-8bb4-d0ce-42ce3f816603
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:02 GMT
+                - Thu, 20 Jul 2023 06:38:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bc773a0b-0861-47b7-4db2-8f7a8048e2cc
+                - 5446a1cc-f1cc-4341-426c-77f5ca2a55e5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 227.971998ms
+        duration: 364.6136ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 086ab83e-adfd-f920-4953-ab8b49aaf91c
+                - 8a09fcf2-da7a-fb73-719f-f7a4e87b0e8f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:03 GMT
+                - Thu, 20 Jul 2023 06:38:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1d2cb875-8de3-4435-4215-14ce740a0717
+                - c18603a9-362e-45ec-42de-56f581820dca
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 340.864377ms
+        duration: 387.2997ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 505d97c8-dbc2-d5b0-490d-874f577336fa
+                - d0696797-80ba-4b4f-c251-e9a87219ac04
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:03 GMT
+                - Thu, 20 Jul 2023 06:38:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a2db288b-85f4-4769-7411-7c95bc9e8f95
+                - b2447b3a-d417-4c1e-4768-65edb5f9f833
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 349.135697ms
+        duration: 412.3097ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 74d49328-ec2a-0d26-e4d8-a8839e281de0
+                - 7cef1877-6699-3f56-0d45-4bb1a1deef03
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:04 GMT
+                - Thu, 20 Jul 2023 06:38:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ba12ebb2-d12d-4149-7acd-3b5df3ad3ae7
+                - caebd831-c6da-4a0c-737e-17f8cca5e9e7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 352.230423ms
+        duration: 335.1373ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f790a051-7f7d-4fa3-7dc6-012896876dd4
+                - c6d03b56-53c5-55a3-9e5e-4fdc825b8919
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:04 GMT
+                - Thu, 20 Jul 2023 06:38:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,18 +327,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fd539ac0-03bf-45fd-55a4-790fb21ed380
+                - a89b9446-92ee-4d96-4688-463979470fe6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 499.353707ms
+        duration: 344.9394ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 931572fd-7d74-7b0e-d240-8064f23482ba
+                - 568e230f-aa42-a8a0-d914-ccfe2ac42fa4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -364,18 +364,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:05 GMT
+                - Thu, 20 Jul 2023 06:38:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -389,18 +389,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7ff59664-0c5c-4224-7134-1ec719878e31
+                - 9a7bf656-8f94-4e64-6321-cd6d22a3f05f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 265.553612ms
+        duration: 395.9135ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -413,9 +413,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3341e5ae-e082-7ed2-e206-8a6bab11d39f
+                - 556bc9d0-fc1c-c6b4-6e28-a804f648c548
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -426,18 +426,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:05 GMT
+                - Thu, 20 Jul 2023 06:38:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -451,12 +451,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1a354cf4-8d65-410a-42da-174a18f3744e
+                - e5568eef-2f68-4ae4-4805-bd5c8fcfdda1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 314.91098ms
+        duration: 387.5205ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -475,9 +475,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 614d2c2c-6ff9-5544-1cbf-6e92e79e31c7
+                - 744cceed-b43c-12d6-526f-b9f6efe36253
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -503,7 +503,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:06 GMT
+                - Thu, 20 Jul 2023 06:38:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -525,18 +525,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b5f046de-9b72-4bd2-5d88-34b360b3a68c
+                - 2782daf0-b4bf-4fff-4eb2-532798d61cd8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 366.502282ms
+        duration: 273.4363ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -549,9 +549,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 95cc4b1a-1fe0-5f1b-88b9-430b3da80670
+                - de457002-0a2b-558b-fbeb-9159c00da7d4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -562,18 +562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:06 GMT
+                - Thu, 20 Jul 2023 06:38:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -587,18 +587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 53f5af83-478a-4fb3-4d03-816a4a1bbb9c
+                - 32484f58-e7b9-41b3-7709-38ca21d47d5c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 389.242981ms
+        duration: 369.0626ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -611,9 +611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 01f9d51e-acca-19c3-4c2e-20dc9bc8edd9
+                - eea94d83-a01b-7800-d8fd-9b152dd70e89
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -624,18 +624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:07 GMT
+                - Thu, 20 Jul 2023 06:38:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -649,12 +649,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2d7c6332-1864-4953-636c-5778a9f92f5b
+                - 6b0a0dc5-4af1-42bb-7b27-4f3ca5758183
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 379.802194ms
+        duration: 412.2488ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -673,9 +673,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 376d5844-c17e-a8b3-8bc3-5d61e763e0af
+                - 99109b3a-46bb-682e-9bbd-0815ed413e27
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -701,7 +701,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:07 GMT
+                - Thu, 20 Jul 2023 06:38:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -723,18 +723,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 332add98-4a3d-43a0-4d12-c657a1f9bb51
+                - 2b55431d-abfd-4c93-4c3d-9d6819a71ded
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 407.749802ms
+        duration: 289.8298ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -747,9 +747,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c96173c9-c524-91c0-cede-1cba06bd5ddf
+                - 91c04cbf-23ec-4f17-0bde-8ceb6db31de4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -760,18 +760,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:08 GMT
+                - Thu, 20 Jul 2023 06:38:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -785,18 +785,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c62efa83-c419-4c67-46bf-4125eac0afa2
+                - 0d68bc48-ca75-479c-5cc7-6085f5cf9af6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 210.528757ms
+        duration: 404.1215ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -809,9 +809,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f755931a-4008-fcd6-12dd-3d0ecd3e490d
+                - b953d6b2-889c-e285-9918-08fd59314893
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -822,18 +822,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:08 GMT
+                - Thu, 20 Jul 2023 06:38:44 GMT
             Expires:
                 - "0"
             Pragma:
@@ -847,12 +847,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f9d8c722-5b81-4cfc-73b2-88177e690058
+                - c2f16d54-2168-4fa4-6a40-9245e59201fc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 325.420254ms
+        duration: 337.1055ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -871,9 +871,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b18804cf-86f0-6a65-eaa1-7ef3e9d3d422
+                - 097f5e7f-7887-55c3-521f-80e6929850e6
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -899,7 +899,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:36:08 GMT
+                - Thu, 20 Jul 2023 06:38:44 GMT
             Expires:
                 - "0"
             Pragma:
@@ -919,9 +919,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4e6e8dbe-9a46-4cea-4086-88c5498c6c37
+                - 17cdd9af-9ff2-43a4-4e22-2322f6212e4d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 406.206532ms
+        duration: 311.3164ms

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6e828e4a-e62a-5fe8-5a6a-d5c6b5d1c23a
+                - a24af764-81f5-a81d-9bcc-373018b2521b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:45 GMT
+                - Thu, 20 Jul 2023 06:41:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fcadd823-91bc-4791-55c5-f75a1e79a290
+                - dc1b602d-8b97-4b5c-4d6d-c406a03d3485
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 620.7008ms
+        duration: 827.3588ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 63c8cd34-c872-ad21-1125-b8ed7ec01739
+                - c536bef2-c03b-a4ed-6dd4-e907f2b364b1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:47 GMT
+                - Thu, 20 Jul 2023 06:41:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - df400db5-cd3c-4e8e-5810-3bd652b949db
+                - 70741af2-9934-42f0-7825-fce6780e608e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 617.9015ms
+        duration: 397.4219ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e0d31ce3-75fb-9bc3-7794-5e69790658e9
+                - 95af5fef-bc04-1095-9429-27e6ff280fbf
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:48 GMT
+                - Thu, 20 Jul 2023 06:41:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f45866d0-13d6-4cce-69d1-e908526eb7f2
+                - 2977ba76-fd86-4032-4999-103fb835356d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 497.2807ms
+        duration: 429.0793ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d53ea79f-5e1e-e97c-dcde-19ddce4b7b65
+                - b8569e51-5e17-ad8b-fb1e-a529f30b38d1
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":32,"active":true,"roleCollections":["Directory Viewer"]}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":36,"active":true,"roleCollections":["Directory Viewer"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:49 GMT
+                - Thu, 20 Jul 2023 06:41:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 90d4eaeb-84df-4f54-788f-0338e0a33aa8
+                - a533a2af-dbf6-4526-45b0-d258ec69dab7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 487.4395ms
+        duration: 461.9896ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - af636484-34d7-f94f-d136-c7c347cb79c2
+                - 47a1a510-b6e3-1092-640d-67ccff9117dd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -303,7 +303,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:50 GMT
+                - Thu, 20 Jul 2023 06:41:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,12 +317,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f4d0565a-7faa-4c0c-515d-30840aec5e80
+                - 86685101-a2c3-426a-6abc-878925a05183
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 495.4206ms
+        duration: 451.031ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d924ff6e-ea7b-ec8e-999b-7ce4acd93533
+                - 0a9709cd-72bb-7566-fa3b-ee135835c614
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -365,7 +365,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:51 GMT
+                - Thu, 20 Jul 2023 06:41:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c99c0864-807c-4583-625f-82817a05e2b4
+                - abd3d3ad-759b-4d70-6855-9fdd2305344e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 495.4741ms
+        duration: 386.3607ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - aee1ddc7-b641-fa37-ca25-c20e1be55137
+                - de44a7fe-d037-e2f8-dcf6-bd209731c0b5
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -427,7 +427,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:52 GMT
+                - Thu, 20 Jul 2023 06:41:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -441,12 +441,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bb4b75a7-3c53-4973-6bd2-21c213eace5f
+                - 7b1a8196-57bf-4042-6c88-13aa5f7d6e6c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 461.3694ms
+        duration: 404.4377ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -465,9 +465,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3676d495-4e2d-a4ff-fca4-fabe9d614769
+                - 78e63424-96c7-09a0-8978-6d6ff5bee2a0
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -489,7 +489,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:53 GMT
+                - Thu, 20 Jul 2023 06:41:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -503,12 +503,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c1cc82fd-6cfc-42db-5ab4-a6c2098f4433
+                - 6242076b-dea5-49ef-575b-3f4dbbd49acc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 450.9716ms
+        duration: 361.4172ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -527,9 +527,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 92dfc034-0144-5b8b-b2ab-b5c8f1d51370
+                - abdc877c-f816-876d-d058-d3a93ac8a1d7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -551,7 +551,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:54 GMT
+                - Thu, 20 Jul 2023 06:41:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -565,12 +565,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5019a771-1a16-490e-42e1-2b0991547938
+                - aa961839-0fc7-4bba-5046-1144514751a1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 434.1282ms
+        duration: 419.7864ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 162088d2-60cc-092a-a1f6-439faaf3bf5b
+                - 8eb8f791-db8d-c638-5ccd-a8363966ca82
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -610,14 +610,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":33,"active":true,"roleCollections":[]}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":37,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:55 GMT
+                - Thu, 20 Jul 2023 06:41:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,9 +639,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8d4d014d-077c-481e-7508-9d793de68f5b
+                - a06e7dc6-4401-4795-7031-feb35caf4007
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 449.1549ms
+        duration: 403.3438ms

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment_import_error.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment_import_error.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c48816b-37df-e16e-17d7-e62c933d7c84
+                - 2e561355-f457-1158-d6a8-e4c53e817f1f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:05 GMT
+                - Thu, 20 Jul 2023 06:41:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d0177a16-f3ae-467e-5ac2-636addcf86b3
+                - 5b81633b-cbd8-4738-4b04-ecf4fe4ab6c9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 405.6589ms
+        duration: 383.7404ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ff29dcc-c349-f0a8-5542-0b67cc417fc0
+                - f789c377-7334-53ad-1426-fb7784fee339
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:06 GMT
+                - Thu, 20 Jul 2023 06:41:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 30e8aa08-8f79-4143-4dfe-06d27c0e7906
+                - 91faf9f4-0840-46bc-4f62-9533b82fa3d9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 557.4999ms
+        duration: 349.0371ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 139b75d5-0211-3720-6470-aa1afa381029
+                - 7421f6cb-4947-a62f-5f69-3b4d5deceb80
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:07 GMT
+                - Thu, 20 Jul 2023 06:41:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 04d9d03f-d656-4c2e-7b4c-809fd62f12be
+                - de516558-0039-4f8f-4570-adec094bc5f3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 474.2466ms
+        duration: 389.6535ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c549bd5-2c47-32ed-473d-a287b68c0dbb
+                - 1b43daac-a58f-3500-1f37-879ecc048cdc
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":34,"active":true,"roleCollections":["Directory Viewer"]}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":38,"active":true,"roleCollections":["Directory Viewer"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:08 GMT
+                - Thu, 20 Jul 2023 06:41:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0bc75f7f-a688-422b-65a8-2eb7ba408f57
+                - 8256a0ec-3cf8-47c9-617c-d4f017819322
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 457.6588ms
+        duration: 431.2261ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 80b500ae-fb1e-0cfe-7da2-ff88dd9f2dc1
+                - c75a81a1-fa2e-c38f-f94b-f061ae9464d8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -303,7 +303,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:09 GMT
+                - Thu, 20 Jul 2023 06:41:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,12 +317,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 20121323-ec6a-4e12-51a6-88e0552ef991
+                - 789f5007-b9e5-45b6-4e38-c5cb88efd14f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 439.4293ms
+        duration: 364.4463ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 89479ff1-8f59-1209-8dcd-d0b5ab9783fa
+                - 78a3147c-bf19-f717-68c8-75c85766deb1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -365,7 +365,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:10 GMT
+                - Thu, 20 Jul 2023 06:41:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ccaad595-e3c6-43f4-6389-87eaa75b26cf
+                - c89df78d-7b5e-4cf3-621f-c1d038103165
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 396.8375ms
+        duration: 401.8729ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7931dbb3-b576-d4c0-657a-9ddd1203807f
+                - 4fc11bd4-4e25-7639-74ac-13c3fed4b92a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -427,7 +427,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:10 GMT
+                - Thu, 20 Jul 2023 06:41:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -441,12 +441,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 14ef9842-784f-4536-40e2-42528374defe
+                - f89c3e2f-07ea-4841-4950-779d8c15279f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 380.2728ms
+        duration: 394.567ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -465,9 +465,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0e1c07dc-9ca9-1b0f-ac03-82cfa09149ae
+                - fdd023cf-cba4-967b-f889-a22b200f732a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -489,7 +489,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:11 GMT
+                - Thu, 20 Jul 2023 06:41:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -503,12 +503,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 86b90a33-60a9-48c1-7a9f-5bd13e700ef3
+                - f3367cbb-1b3c-42db-7930-e3da0672969b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 433.7623ms
+        duration: 393.2332ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -527,9 +527,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 910214ad-31ba-0bd6-be2e-609a8d39efcc
+                - 485a22ba-68c1-76c4-4512-d03624513328
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -551,7 +551,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:12 GMT
+                - Thu, 20 Jul 2023 06:41:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -565,12 +565,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7c192f83-1c8e-4d26-662f-7fe68663dfa2
+                - d0ea60df-b061-40f6-47b2-88f27d38f224
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 456.0352ms
+        duration: 373.6756ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 71232057-7166-16b7-6aa9-29d45dff31c3
+                - a943ea4d-6a7b-75a4-b40c-46c02490bd2c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -613,7 +613,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:13 GMT
+                - Thu, 20 Jul 2023 06:41:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -627,12 +627,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9b39a127-600a-4285-5689-fb0d08836c50
+                - 39c7346c-eb72-4b89-70be-b8abe48c9a59
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 476.0878ms
+        duration: 418.3519ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -651,9 +651,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c5d9dfe6-163a-971a-1b37-db78e522511b
+                - b2a9494a-f8b9-a017-8f2b-3d75efdfe9fe
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -672,14 +672,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":35,"active":true,"roleCollections":[]}'
+        body: '{"id":"40c72ef9-b901-4b89-91fb-3d283231f7b4","username":"jenny.doe@test.com","email":"jenny.doe@test.com","origin":"sap.default","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":39,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:14 GMT
+                - Thu, 20 Jul 2023 06:41:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,9 +701,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8b2b602c-3a8a-42e4-6fe3-ca6fefe7678b
+                - e748a151-df44-4db2-4b7c-bebfd4baa8fa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 378.0103ms
+        duration: 419.7192ms

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment_with_origin.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment_with_origin.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - dc5ad75b-d9cc-febd-61e1-5014f44ae30b
+                - 3a69ac3c-d9b8-8b05-e0fa-27532292cd82
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:56 GMT
+                - Thu, 20 Jul 2023 06:41:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 46640ca9-2274-4978-7b47-78ac06cba39d
+                - 757eff1a-f2f5-4f37-4978-bb661300e24a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 376.2142ms
+        duration: 346.431ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b927d969-5549-6d3b-a1f8-81a71455009f
+                - 378436c4-32a5-a3cc-9761-137ed374bf9e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:57 GMT
+                - Thu, 20 Jul 2023 06:41:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a166eed4-d373-4517-7578-244d3d6281ed
+                - 2244fb60-ff70-42b3-47be-d1fb2652f17b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 381.0881ms
+        duration: 407.6866ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0525d2a5-34f1-cb20-f974-a2231a01ef7c
+                - 2b033550-27a5-d2fc-1c33-351e8e5fbf4b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:57 GMT
+                - Thu, 20 Jul 2023 06:41:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 093718d2-4796-4da6-7737-53831fd7787d
+                - 72c1071d-22f8-4491-4e76-c1778393a1c5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 454.833ms
+        duration: 403.9561ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 10a50682-eba5-fb1a-0339-48ebd61cbd1b
+                - b573d78b-4d60-8dcf-1d8c-61ad86381fcc
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"d1a6ec95-d517-48ea-af12-9744ce72a24f","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":16,"active":true,"roleCollections":["Directory Viewer"]}'
+        body: '{"id":"d1a6ec95-d517-48ea-af12-9744ce72a24f","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":18,"active":true,"roleCollections":["Directory Viewer"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:58 GMT
+                - Thu, 20 Jul 2023 06:41:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0a4cdc32-de9e-4abf-7ae5-930fd745bb32
+                - c887a876-ec4a-472a-58c5-d19e09e3056b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 474.7338ms
+        duration: 372.7349ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 53d6e6cd-df94-32f9-74ff-ca43eb63f7b1
+                - 83e9187e-37cf-e78a-95bd-08a4367e37f6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -303,7 +303,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:35:59 GMT
+                - Thu, 20 Jul 2023 06:41:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,12 +317,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 434146a4-ebf6-4523-739c-ae60f943809f
+                - 78517f5d-bec5-4abe-4f45-666f451ab934
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 412.4773ms
+        duration: 375.2793ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2e7e405b-427f-7194-aab7-9c1662bfd9b9
+                - b3183c3a-c4eb-77e9-a2d6-1d50ffd624f9
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -365,7 +365,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:00 GMT
+                - Thu, 20 Jul 2023 06:41:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cdd9bdfc-3f71-490b-4809-a390b40e9313
+                - b5c63ad2-a452-4eda-6340-c44b38ec06ce
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 377.698ms
+        duration: 379.4615ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d154790b-14d4-286e-d7b8-a2d348772e7c
+                - 309ccdb7-75e2-e6ab-07cf-09de18846093
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -427,7 +427,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:01 GMT
+                - Thu, 20 Jul 2023 06:41:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -441,12 +441,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1a6c1fd3-296a-49ba-6334-ecd7c93af953
+                - 6ba4d141-43f2-4c24-6384-45690c2a2c15
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 391.7774ms
+        duration: 392.9408ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -465,9 +465,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ef3fcf39-a71b-bc3a-3a66-348c0740b698
+                - bcb1b33f-e927-ba73-6d98-8f9119493ea9
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -489,7 +489,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:02 GMT
+                - Thu, 20 Jul 2023 06:41:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -503,12 +503,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 016f8112-f23a-4d12-6099-e1cd5b96e547
+                - 180c1fc9-13e8-48a3-453c-94093261a191
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 381.8082ms
+        duration: 398.3546ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -527,9 +527,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3d889a1b-a1e5-db78-5bbf-2858d99467d2
+                - 82d748bf-d71e-78c9-89ca-68a28424ea5e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -551,7 +551,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:03 GMT
+                - Thu, 20 Jul 2023 06:41:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -565,12 +565,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 66da42e9-3b7a-4635-40af-05ece18cf2ff
+                - 56914d9b-7590-4c6d-5723-4ed24d27f148
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 362.4693ms
+        duration: 360.0927ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 39fba1a0-d0e0-b478-ccbb-0d8146a7baf8
+                - 04899060-f318-f856-9a5a-ceb93d013608
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -610,14 +610,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"d1a6ec95-d517-48ea-af12-9744ce72a24f","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":17,"active":true,"roleCollections":[]}'
+        body: '{"id":"d1a6ec95-d517-48ea-af12-9744ce72a24f","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"05368777-4934-41e8-9f3c-6ec5f4d564b9","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":19,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 09:36:04 GMT
+                - Thu, 20 Jul 2023 06:41:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,9 +639,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b408024e-4861-4ca1-50b4-099607757c2d
+                - 1b77aa30-221e-442e-5325-211164ea1f8e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 435.0585ms
+        duration: 512.0271ms

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.import_error.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.import_error.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fbad3d93-2f50-8c22-adbe-967a74851ebc
+                - ed66e99b-41ac-ab8e-b851-71804b1ac095
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:08 GMT
+                - Thu, 20 Jul 2023 06:43:46 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ecc0ebba-a1af-4cd0-6dc4-508d567b301a
+                - 50d3dfbf-2a23-4e6a-74c2-3e33344e85aa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 278.101616ms
+        duration: 416.2423ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 366b5727-2fec-d44d-c470-ca2e5cfdd05f
+                - f893b2f9-1361-dfd2-7847-a3ab3569e846
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:08 GMT
+                - Thu, 20 Jul 2023 06:43:47 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d11490c3-8688-48fb-6c09-a4e52f25d051
+                - 2c1f04d0-214a-4fc2-7133-da5aae4abb85
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 296.152872ms
+        duration: 391.084ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9113ed16-b751-0a15-ab5c-baff829fb992
+                - 3df8d267-f733-c63b-64e1-d481b33e7a07
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:09 GMT
+                - Thu, 20 Jul 2023 06:43:47 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - afb76c8d-32bf-4dbf-7b79-1aea80732229
+                - a14fe744-2315-4293-6a34-59114f454f6f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 216.677256ms
+        duration: 404.0446ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 60cbe9c1-abbc-cd30-2e11-1b0b2694d2e9
+                - c2161b40-a467-1257-fe24-867b4e73e127
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:09 GMT
+                - Thu, 20 Jul 2023 06:43:47 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,18 +255,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3d21eec7-48f4-4003-42a1-b277bbb0ee01
+                - c8c7bc1b-3620-4b77-637f-66e6df0e227e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 179.405294ms
+        duration: 179.9553ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ae2c431a-4c76-cca4-e69f-b180c9f17980
+                - 07209b3f-e8cb-7175-825a-031f731086bd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -292,18 +292,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:09 GMT
+                - Thu, 20 Jul 2023 06:43:48 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,18 +317,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 967ef896-cb23-486b-7afb-65aba94c8e6b
+                - 3bc727f0-3d3d-4b42-545a-a7e34a080c00
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 292.312595ms
+        duration: 383.5182ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 8aa55bcb-92e1-b653-9b1c-903416d2dd19
+                - 5888eb44-43d0-fe49-65d3-cd5854541d73
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -354,18 +354,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:10 GMT
+                - Thu, 20 Jul 2023 06:43:48 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 037dab5c-8530-4c52-57d7-4ca1cf08e309
+                - 40ab17c7-a4b4-411b-64b8-c451388dd653
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 221.867097ms
+        duration: 375.3583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 27e756fb-5544-648b-e1ea-c85f781aa4ee
+                - 9618158a-40d3-35c4-a3da-b41698434438
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:10 GMT
+                - Thu, 20 Jul 2023 06:43:48 GMT
             Expires:
                 - "0"
             Pragma:
@@ -453,18 +453,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ec3103bb-e4d8-493f-5891-e2305eb8a418
+                - 7528857a-ec05-4728-4044-db2f2d4e119f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 156.77779ms
+        duration: 206.3008ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -477,9 +477,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - dbf6c5ed-43ac-5368-2701-3ac3852055cc
+                - cf101b4c-5312-c04a-0d14-0215d5220dd2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -490,18 +490,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:10 GMT
+                - Thu, 20 Jul 2023 06:43:49 GMT
             Expires:
                 - "0"
             Pragma:
@@ -515,18 +515,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 75b16813-d77c-4849-7901-39c7f2ba663b
+                - 8314b0ec-ba18-4370-608e-6ffa03611c27
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 295.262582ms
+        duration: 446.1172ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -539,9 +539,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fa8739bd-6a2c-09d0-fe78-6e65f84fe585
+                - b718689d-819e-d784-c822-bb26f619b547
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -552,18 +552,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:11 GMT
+                - Thu, 20 Jul 2023 06:43:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -577,18 +577,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 110cb24a-a602-4107-61c5-6ce082106579
+                - 8495d973-6d14-45c1-4cb2-08c597aae494
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 246.756501ms
+        duration: 385.4447ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -601,9 +601,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a9e8955a-6d36-b66d-7dac-a4e2343aa9a9
+                - 4f403772-30c3-b26c-84f3-f7a7dd024f8a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -614,18 +614,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:11 GMT
+                - Thu, 20 Jul 2023 06:43:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,18 +639,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 64b4243f-a44c-4068-4c4b-b4677cdad54d
+                - e053bf00-dc64-4e83-4d94-89e31d3be5dc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 237.652189ms
+        duration: 431.5557ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -663,9 +663,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 34554a7e-6907-f4c3-2373-dc898bf0b0a9
+                - 95565621-4f81-9c8b-0bc3-72f702c22427
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -676,18 +676,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:11 GMT
+                - Thu, 20 Jul 2023 06:43:50 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,12 +701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8a77c2a9-adb4-4220-4b04-ee83f30a368b
+                - 6e1e6a9c-8bfe-4f0d-7b14-c5c4aedcae97
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 296.578892ms
+        duration: 410.2157ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -725,9 +725,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e4b64fc7-1a71-e6b1-e8c5-1f248ebdd03e
+                - 3dbbc397-e9ef-32d8-2c1e-3b9609015d79
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -753,7 +753,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:12 GMT
+                - Thu, 20 Jul 2023 06:43:51 GMT
             Expires:
                 - "0"
             Pragma:
@@ -773,9 +773,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3409ebf5-a5f2-4e6f-5bbf-bd201eae9dbc
+                - fdbe5671-6e76-403b-7867-afcca3a48661
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 178.812447ms
+        duration: 180.9352ms

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.update.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.update.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6dd4d0c8-d075-67ad-3c37-8a9a9959041b
+                - 9e54d8f5-cd55-e157-8c23-2395c61d8752
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:58 GMT
+                - Thu, 20 Jul 2023 06:43:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 07bbb42b-645f-46c4-7008-8e0aaa7132c1
+                - 13d94d00-0575-4c10-4560-ffb2a2aa0dc4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 304.300511ms
+        duration: 352.9561ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 329d3701-4570-21d9-21e1-8455b0ed7ce5
+                - eac05464-f360-b5e7-e254-34342b02b5aa
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:59 GMT
+                - Thu, 20 Jul 2023 06:43:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4a0e3309-46b6-4191-7318-2b0e9a874234
+                - b4d3c7bf-7289-4bb1-618c-a2c4bac667d0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 212.093399ms
+        duration: 371.6299ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 00dc7219-3d65-06b7-9fa5-cf16f3961544
+                - dabcd03a-60c1-6d0f-66a2-d3e3b8ea4f95
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:59 GMT
+                - Thu, 20 Jul 2023 06:43:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d8c5baaf-8c07-46da-6a77-b0d0dc4aefce
+                - f20adece-cc0c-4b4f-5d3c-3b7386f38a14
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 218.23121ms
+        duration: 420.1497ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - eb3ef8c2-4028-7d60-ca11-3eb1c8717245
+                - 8fe7f130-da5c-d7c0-7c4a-4e3ed0846f81
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:59 GMT
+                - Thu, 20 Jul 2023 06:43:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bcfcd622-9f46-4e35-44af-23120fbd3c60
+                - e090ffec-11a6-434b-42f5-e843b69e16a7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 175.296195ms
+        duration: 178.9213ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f9a89965-fb2a-8ae4-e26f-83f472cc731e
+                - ce5bd56d-6dc9-41e3-e0d5-7d9ff83284b2
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:59 GMT
+                - Thu, 20 Jul 2023 06:43:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,18 +327,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8996756e-bbb0-45a1-4b3a-507acad69e23
+                - f7268d09-ea71-4769-73d3-13e5c4709df9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 167.138541ms
+        duration: 226.1058ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 58980618-16a7-f5ef-9829-0eb6d188435e
+                - 9d87e555-0ab0-9006-91a9-692055029d9f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -364,18 +364,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:00 GMT
+                - Thu, 20 Jul 2023 06:43:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -389,18 +389,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d3931071-54b6-49ca-4210-57dcffc2f902
+                - 8b0734b9-149a-46ce-4b9f-bbd6e128ef18
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 334.392663ms
+        duration: 397.817ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -413,9 +413,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 47af6b09-1ac5-b632-8bff-d10209e4f684
+                - 4b44cf53-c021-4c48-4f18-a53022d042e6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -426,18 +426,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:00 GMT
+                - Thu, 20 Jul 2023 06:43:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -451,12 +451,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0b5a2338-1205-4d5c-5fb7-5e80eaa6c887
+                - 6d41a598-c88f-40df-7981-73b42fd7a4af
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 306.356059ms
+        duration: 399.1953ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -475,9 +475,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - eaad3c0c-79a5-2347-6e54-d83bc8de825a
+                - c082b266-daeb-8285-3da6-b548b851ff24
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -503,7 +503,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:01 GMT
+                - Thu, 20 Jul 2023 06:43:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -525,18 +525,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3a291877-809a-485c-5662-b1c912c81c35
+                - 683ba0da-c4a5-4476-7756-36a9c8fafa1b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 160.400266ms
+        duration: 213.3369ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -549,9 +549,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 91d0b334-953d-9193-b88f-17394a1f93f9
+                - fad3c0a1-8e2c-619b-33d4-8c87a6d61922
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -562,18 +562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:01 GMT
+                - Thu, 20 Jul 2023 06:43:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -587,18 +587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 73a9c6f2-6812-406d-4f51-8a222e3b4fb0
+                - 1e5706a8-f438-4ef7-62a5-28a5424ae4bc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 331.397102ms
+        duration: 366.174ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -611,9 +611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1dd2016f-f94d-01ce-97ae-75127b72c643
+                - 4444f250-9b67-8abb-b4c4-1b8e1d3e6aff
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -624,18 +624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:01 GMT
+                - Thu, 20 Jul 2023 06:43:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -649,12 +649,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 39ade372-c7b7-4136-7c3c-d4e22e55ec11
+                - 53408769-f2b4-4d7e-6329-22033cda9839
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 259.900392ms
+        duration: 349.254ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -673,9 +673,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0e455fa6-38c3-af23-50ef-0a31ba2dd0db
+                - e0ea609f-b010-2656-21bd-db42fe6b8bc3
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -701,7 +701,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:02 GMT
+                - Thu, 20 Jul 2023 06:43:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -723,18 +723,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1cac3c9d-8e04-4d2b-7d27-fc0608ab1469
+                - 534f0c1f-9d01-438e-72cb-300ddd6d73a5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 175.045702ms
+        duration: 140.1634ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -747,9 +747,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4bde2630-fa5d-325d-0272-c6416539a550
+                - 03bc3e52-4f61-b728-e7c3-5415f484b352
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -760,18 +760,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:02 GMT
+                - Thu, 20 Jul 2023 06:43:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -785,18 +785,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dc4392b0-7678-4b80-53c7-4652270b01b0
+                - b454f290-108f-4604-4625-c58efed93ff7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 265.802605ms
+        duration: 416.9974ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -809,9 +809,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ae8d51fa-34d4-3a63-2b39-57e49867445d
+                - 28c6dfbd-1aae-d111-897c-d4f8760cc1e8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -822,18 +822,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:03 GMT
+                - Thu, 20 Jul 2023 06:43:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -847,12 +847,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 32da9d19-4b4f-4fa3-5d35-cd6207e531c6
+                - c42252c6-c8a1-4543-669f-e05a231015c9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 280.544561ms
+        duration: 400.2207ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -871,9 +871,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 56d7e5fb-0c0d-2c4a-f4a4-bd3c334c203c
+                - 970674e0-e811-52fc-a7d1-2f7830a3ea5d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -899,7 +899,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:03 GMT
+                - Thu, 20 Jul 2023 06:43:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -919,12 +919,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4ff2c8d0-7ed2-4816-57ee-ead47ff107eb
+                - 166588dd-f054-4b32-4498-65f698da8cbb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 206.054584ms
+        duration: 162.0763ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -943,9 +943,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c574a565-4cc1-84ac-bd84-b25fc3cf7b03
+                - 1a8d2dec-67fe-54bb-9158-1c7fe4ae3cab
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -971,7 +971,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:03 GMT
+                - Thu, 20 Jul 2023 06:43:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -991,12 +991,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f0593404-31d1-4686-523b-8aa8f45e5dec
+                - ba3930b7-2af6-4d0a-4586-1272b0563f33
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 158.508366ms
+        duration: 195.3604ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1015,9 +1015,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f9311ce3-23e3-2398-6f4c-eca22c44dcb8
+                - 8b345078-efed-9639-957e-1f398f7c4c7c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1043,7 +1043,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:03 GMT
+                - Thu, 20 Jul 2023 06:43:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1063,12 +1063,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6b2dc993-fcd6-440b-43ce-9f21ead9799c
+                - 00ffe012-c0e1-410a-70ea-0234c0ae302a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 219.687906ms
+        duration: 155.5193ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1087,9 +1087,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b0767487-39d1-d29f-5838-6edb93ea50c9
+                - c47e61f6-83cf-a49c-9bd7-1a97f1534ebe
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1115,7 +1115,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:03 GMT
+                - Thu, 20 Jul 2023 06:43:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1137,18 +1137,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 97f2efd8-6b3d-4d61-5dc1-df967560445b
+                - 621997e5-f7dd-48c6-52fb-dce8fcc8623a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 311.977968ms
+        duration: 187.5255ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1161,9 +1161,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5d8245b4-44bf-1e55-8cd5-c54ac88e428f
+                - 2668b9c0-088f-ce5a-1a13-923cf0b39d94
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1174,18 +1174,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:04 GMT
+                - Thu, 20 Jul 2023 06:43:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1199,18 +1199,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 04c4219a-a644-408d-6d3b-407c0e068ef7
+                - a1b16abd-df42-4080-6f42-815adafae04a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 339.165906ms
+        duration: 381.0886ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1223,9 +1223,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9a2520cf-19fb-106d-c880-18bed40ad371
+                - a9649385-5066-25ec-3404-3e6acf48f914
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1236,18 +1236,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:04 GMT
+                - Thu, 20 Jul 2023 06:43:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1261,12 +1261,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 651055fa-a358-4abe-7280-7bde87cd6efe
+                - 2136bfeb-bdc0-44cb-6d7a-b65a57276e7f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 233.748367ms
+        duration: 366.5826ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1285,9 +1285,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7de29693-bc4f-bb21-088b-fe3064bfdc5b
+                - 241bc192-054d-3e6f-bb48-861fbdd5b681
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1313,7 +1313,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:05 GMT
+                - Thu, 20 Jul 2023 06:43:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1335,18 +1335,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - eee3bf3c-cd3b-4b8e-6cb4-6b66a16e3e38
+                - d463a226-330f-4f1e-60fc-376e5a084e2f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 321.162858ms
+        duration: 165.3992ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1359,9 +1359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 67d9ce8d-dce1-688d-a57e-a229534253f3
+                - 26f9302e-fbfd-69db-adac-946fc2fda84f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1372,18 +1372,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:05 GMT
+                - Thu, 20 Jul 2023 06:43:44 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1397,18 +1397,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d9b070c7-daa2-40cc-4b34-aec3454a6dfc
+                - a17b2220-d3e5-414b-5c84-449a6ca70321
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 432.991546ms
+        duration: 425.8228ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1421,9 +1421,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5990eb6d-d9dc-2dc9-c436-db26dd4376ef
+                - b365df36-338b-f3fb-1316-e2745f1fcecd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1434,18 +1434,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:06 GMT
+                - Thu, 20 Jul 2023 06:43:44 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1459,12 +1459,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 837eaae6-3422-4e16-49e6-329a0c387d3c
+                - 65364f66-237b-4181-772d-fbcf2d3df70d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 330.395323ms
+        duration: 413.8283ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1483,9 +1483,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ed956cd-8e3a-834e-0884-2716af3d8666
+                - 61d6fc1e-6df7-a617-077e-4d1c7657f340
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1511,7 +1511,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:06 GMT
+                - Thu, 20 Jul 2023 06:43:44 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1533,18 +1533,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b91824b3-e031-429c-6dcb-f43ac46cdc80
+                - 6286b887-3f3a-482c-4ba9-77172f9fe896
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 164.411803ms
+        duration: 222.0287ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1557,9 +1557,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1120bfc4-a8b8-d10e-009f-4a3543eda344
+                - 64af1b75-e516-3242-aa4e-3605d9211031
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1570,18 +1570,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:07 GMT
+                - Thu, 20 Jul 2023 06:43:45 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1595,18 +1595,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e682e5e2-8075-4955-7719-3ad92b3e3750
+                - 0e2e8452-0ae8-4829-439d-db15e73aaa69
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 300.210183ms
+        duration: 398.5976ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1619,9 +1619,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a2af521e-df7b-af00-09fb-e942dde018b1
+                - 8591b89c-3dc1-477b-b1fd-4a4f86a377b8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1632,18 +1632,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:07 GMT
+                - Thu, 20 Jul 2023 06:43:45 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1657,12 +1657,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0d0463af-ebc8-4062-7099-8b592db45f0b
+                - e83f6965-3a77-43d1-637e-e685a0314b38
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 288.739886ms
+        duration: 417.4698ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1681,9 +1681,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c5a218ae-ba5f-786b-ec30-3a94be6e1e0f
+                - 14c384dc-cb82-01f2-b2f1-c586fcad0ed8
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1709,7 +1709,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:44:07 GMT
+                - Thu, 20 Jul 2023 06:43:46 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1729,9 +1729,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4a9eb174-466f-4439-5baa-7e719f4858fe
+                - d42b9c6a-df6b-4440-7d6b-b88642942269
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 164.696251ms
+        duration: 175.116ms

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 30538882-2114-b23d-b634-3970875197f1
+                - f77018b8-e7c1-052d-011b-8069d84e55f6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:53 GMT
+                - Thu, 20 Jul 2023 06:43:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fcab9eaa-0db0-4a20-612d-af987b5c59f3
+                - fe364886-9abd-4389-4935-2c449afa4a90
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.098987151s
+        duration: 882.8907ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 88cbe351-955b-3515-50de-2ce0649b853c
+                - b032e1a0-83e6-199c-3867-2e8b73dba86a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:53 GMT
+                - Thu, 20 Jul 2023 06:43:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ce751fed-3f99-44ec-747c-a0f37dc16c38
+                - 9ad00497-0558-4d21-7f80-b348081acffa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 354.902554ms
+        duration: 454.3993ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d7f9f790-7f8a-b613-d785-7a9a0ac2d221
+                - 9d81b999-ac80-933b-a5a7-e389f61da360
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:54 GMT
+                - Thu, 20 Jul 2023 06:43:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b961ffa5-0e9f-4177-46a2-2422b9907b4a
+                - 2bdb6160-0127-4e8b-7a26-4b146ed08b85
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 435.168195ms
+        duration: 459.7411ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f72c61a0-7377-22a6-3f14-aa21e2a5c07a
+                - 3676e414-287e-3c67-de79-aec8808cf791
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:54 GMT
+                - Thu, 20 Jul 2023 06:43:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 50f9a21f-b86a-4203-4e38-fed9b1aa589f
+                - af3340d1-923c-43e7-7f3d-3c699bdf840d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 221.006719ms
+        duration: 247.4381ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 096b1c1f-5bb4-e8f0-8b33-4bd51bee9353
+                - a0079117-6b58-c66f-0a85-b4cdcd88a060
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:54 GMT
+                - Thu, 20 Jul 2023 06:43:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,18 +327,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1670bd0b-92a6-495b-7c1f-9c9c8646d1d4
+                - 792494de-d9f7-43ca-5fe3-4cfa9b094b73
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 222.738489ms
+        duration: 276.6217ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -351,9 +351,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 13c65a47-c502-45c3-9894-c5749ed7f115
+                - 5c966169-894a-b67b-fac6-caa3106b33da
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -364,18 +364,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:55 GMT
+                - Thu, 20 Jul 2023 06:43:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -389,18 +389,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f1d1a7e4-59d6-4e2e-63d4-db9f570364b5
+                - f97f1610-f477-40df-5270-064aadd31407
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.410357ms
+        duration: 398.0417ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -413,9 +413,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0287f371-50b3-1564-5518-6ed3debf2c0e
+                - b807d8ed-57e1-b5be-05e5-449f0577bce3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -426,18 +426,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:55 GMT
+                - Thu, 20 Jul 2023 06:43:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -451,12 +451,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 864aca75-8126-4e90-68cd-9400afdc9faf
+                - 79857d7f-7905-4d89-6759-73aedfd75f5f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 288.208856ms
+        duration: 343.6707ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -475,9 +475,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f83fc402-1db9-cda6-b105-e0b8571a900d
+                - b08dfc58-5681-d72b-4442-3dd434b8f1d8
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -503,7 +503,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:56 GMT
+                - Thu, 20 Jul 2023 06:43:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -525,18 +525,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d3b0a7c5-84b3-4207-729b-22efdc070b1f
+                - 97ba0d3c-3eb5-4250-756c-b67650df932e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 161.434251ms
+        duration: 186.0538ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -549,9 +549,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e9a4b679-9a2a-0a31-20ac-fa773b407e9b
+                - 80d0df07-2674-fbd5-0b0d-004a2ac6d252
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -562,18 +562,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:56 GMT
+                - Thu, 20 Jul 2023 06:43:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -587,18 +587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d35dc072-fb1e-4ea1-79ed-22c6f7a68557
+                - bf46f52d-9995-4fa1-6245-e6f0ae6cb29e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 219.359784ms
+        duration: 423.1978ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -611,9 +611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bd6a720f-df59-3910-c443-eb0e213cfc0b
+                - 992e3a89-5ebe-6f8c-19a5-93aea7314fc4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -624,18 +624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:56 GMT
+                - Thu, 20 Jul 2023 06:43:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -649,12 +649,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 05f20510-5be0-4bf2-4214-4d38c8087e4c
+                - e2d356b7-d1ed-4b96-4438-8b27b0fcf7e0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 235.390346ms
+        duration: 415.4003ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -673,9 +673,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6033cd63-61d7-37b5-efef-94dabff15337
+                - 0760d39d-3b52-3acc-aaae-fe76bb10ceea
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -701,7 +701,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:57 GMT
+                - Thu, 20 Jul 2023 06:43:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -723,18 +723,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bdfcb818-4c90-4219-68b1-420efa67bd21
+                - e311bd56-3456-4de9-475d-11591ded0dad
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 186.320986ms
+        duration: 223.2539ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -747,9 +747,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 8da961af-cdd0-417f-c615-c1ceca23c9b1
+                - b0680b95-5e79-cd9a-2c30-f1c72d9fd956
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -760,18 +760,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:57 GMT
+                - Thu, 20 Jul 2023 06:43:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -785,18 +785,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 698ddab1-1e53-4697-4978-57a01fb6d0b2
+                - 6ff30717-7dbb-4e53-6bda-c02748907787
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 228.327677ms
+        duration: 421.2609ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -809,9 +809,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5826d39e-39b0-b40c-7cf4-e16b0d9e415a
+                - 7e381b21-7bd1-6122-84c8-eca0bc98e3c1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -822,18 +822,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:57 GMT
+                - Thu, 20 Jul 2023 06:43:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -847,12 +847,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e7b9bae0-e0a6-417d-7527-cbd8885be3f4
+                - ad264ba5-2724-41ec-67c9-05749a1021a6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 219.393603ms
+        duration: 516.2712ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -871,9 +871,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3780b49e-93db-57c9-cb98-9a648cc92e20
+                - 4e90ba47-aa0e-d1a9-b774-6eeb2afec769
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -899,7 +899,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 08:43:58 GMT
+                - Thu, 20 Jul 2023 06:43:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -919,9 +919,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7034f7cd-fd21-4f1d-4348-66aad80bc76a
+                - baeb0f8a-9a63-4b37-74b9-89709f34a78a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 195.030929ms
+        duration: 244.6832ms

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7891e8bb-a85f-7797-c395-54f5061a3de1
+                - 3f1983ed-ca38-e290-6a86-99eb836eecdd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:46 GMT
+                - Thu, 20 Jul 2023 06:44:51 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 16033c51-072c-48d9-7ec3-a05c843e3ede
+                - 736c6777-b71a-4ab5-72d5-db3ae1cd572c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 657.3701ms
+        duration: 735.1267ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5e0244af-d98e-b2b8-c61c-1fdd7ad007a3
+                - 3cde526d-6838-0511-8fa3-5b1d4c34daa2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:47 GMT
+                - Thu, 20 Jul 2023 06:44:51 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - eacfd1bf-5edb-4de4-756c-483dde7ad035
+                - 8b9cf2dd-ae70-4def-432a-48096620da86
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 460.7013ms
+        duration: 442.8114ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7e9327f9-53bf-8a0d-f6b7-96aad761765a
+                - 03e10578-0026-f2e3-661c-ac6960d04189
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:47 GMT
+                - Thu, 20 Jul 2023 06:44:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 770378f2-9d37-4320-46af-049a6703a726
+                - 03073c22-6f86-484f-611d-b01ba6cead4d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 458.9598ms
+        duration: 398.9372ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f63e9233-c882-a53d-dd9c-3c44f04a28ff
+                - 7cca0382-134b-a0fb-96b9-1b70e4f39fb0
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":43,"active":true,"roleCollections":["Global Account Viewer"]}'
+        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":47,"active":true,"roleCollections":["Global Account Viewer"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:48 GMT
+                - Thu, 20 Jul 2023 06:44:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 09a0b8d1-6f61-4c17-542a-2c1e6e6de638
+                - c5ca8577-d4f1-4456-710f-94d8dd446221
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 542.2804ms
+        duration: 362.5093ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e70bd318-e72b-b523-718a-eed87bb80b98
+                - 33e19cc5-4357-424e-9c4a-9a55cd2aa6b7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -303,7 +303,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:48 GMT
+                - Thu, 20 Jul 2023 06:44:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,12 +317,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fdad18ba-dbf6-4d24-46c2-adb17e3c48d8
+                - 16f7b85e-5858-42d3-4fa6-448792ab2a6c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 429.3928ms
+        duration: 427.6253ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c4125714-ae1b-05cd-bc7c-60e561bdbd4d
+                - f4ead413-e49f-6530-13ed-872c5b0957f8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -365,7 +365,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:49 GMT
+                - Thu, 20 Jul 2023 06:44:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9cfb4c4b-2273-4c3d-47bb-c52bcba2fe8c
+                - d749b771-dff8-4c78-588b-8c52d20eab5b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 438.9229ms
+        duration: 369.517ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - af920597-a2d1-dbc6-98e2-3db7bfc9ff3d
+                - 1a398427-d227-e1a1-8841-3ebea9aa43d7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -427,7 +427,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:49 GMT
+                - Thu, 20 Jul 2023 06:44:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -441,12 +441,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f749b45f-59cd-4ab7-6d2d-e7f6e72544ea
+                - 7d881472-03e5-4ab7-4e23-5d04a08b64de
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 441.3754ms
+        duration: 386.2232ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -465,9 +465,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 32f65f62-78fb-90c4-7772-09f06b3a1ce0
+                - 788cc9c2-6ded-d28a-3280-509ce746dcdf
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -489,7 +489,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:50 GMT
+                - Thu, 20 Jul 2023 06:44:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -503,12 +503,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0600eaa0-4b8e-4f4c-6abd-643bebf899fc
+                - 831a785c-9223-4868-5b5d-ff5b8c27cb35
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 365.9855ms
+        duration: 367.7404ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -527,9 +527,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 59da6e6c-0573-95b8-c75a-6a5afe9d1f84
+                - c547d06f-5d25-19a9-999f-2020a6377777
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -551,7 +551,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:50 GMT
+                - Thu, 20 Jul 2023 06:44:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -565,12 +565,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6230fe0a-a581-4bf7-5cf5-ae28de5516ed
+                - 256dcaa6-c609-4cb4-533b-549a3fb4e6ff
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 488.0547ms
+        duration: 347.9088ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 08106a4a-5890-3105-4070-ff11a4933d1c
+                - b9087edb-92c7-85c6-68e5-f2e077a4df27
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -610,14 +610,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":44,"active":true,"roleCollections":[]}'
+        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":48,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:51 GMT
+                - Thu, 20 Jul 2023 06:44:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,9 +639,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d29a1e64-cc1a-4f09-5683-34d71ed836c6
+                - fabc8268-e24d-4abf-58e1-7a95e6bcafc8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 449.539ms
+        duration: 413.0836ms

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment_import_error.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment_import_error.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e2c4dc8f-17d8-2052-de62-9f1e7dc00a6c
+                - 88d044f6-447d-062d-e6f9-e1544c10e7da
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:56 GMT
+                - Thu, 20 Jul 2023 06:45:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3e8163b3-5acd-41a5-5108-5d5544034425
+                - f64f16b8-bff6-463f-554f-e41fa7ddc58e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 416.7952ms
+        duration: 385.1158ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 34b1aa81-26cf-0080-9a68-d098c77afd4c
+                - 4703a1b7-a7b3-09a4-a388-61290582b32e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:57 GMT
+                - Thu, 20 Jul 2023 06:45:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6c837d48-c1b3-4e74-6689-538ea9452b7d
+                - 59cd60a8-1596-4b93-4113-0b205d1068cf
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 415.3215ms
+        duration: 357.4125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 34850155-1221-c76f-b9d3-95393c9e1041
+                - d7352f2f-f05b-e917-0859-5c3afd35c327
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:57 GMT
+                - Thu, 20 Jul 2023 06:45:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f1fd7638-5fc5-42b6-58df-14cf460a66d5
+                - fab1a2f7-81e9-4e20-75ed-81b0f6829910
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 358.1199ms
+        duration: 368.6897ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - eb97cada-14c9-7111-fffa-2e5cadad542b
+                - e98aa865-a0df-1670-5c4c-346bd39f5dac
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":45,"active":true,"roleCollections":["Global Account Viewer"]}'
+        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":49,"active":true,"roleCollections":["Global Account Viewer"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:57 GMT
+                - Thu, 20 Jul 2023 06:45:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e3e85a50-7803-40bc-78c5-a52e4328b618
+                - b1963e04-f2b2-4ef2-5587-ffff6aa605b7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 314.4557ms
+        duration: 468.9336ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 389a7466-a47e-7e28-7348-dfb340bd43cc
+                - 7e9ffcba-7fa4-4e70-ffe3-33115824e2ac
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -303,7 +303,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:58 GMT
+                - Thu, 20 Jul 2023 06:45:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,12 +317,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8b42f1c5-e6b5-4f85-5904-8d3e71936798
+                - 07419035-cc72-446a-44a1-fd6e72267f81
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 443.9353ms
+        duration: 516.7505ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5dc80071-e40d-8290-16ad-c8de68f508d4
+                - 7a0880fd-c579-e673-1f93-897e3fdf9ec4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -365,7 +365,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:59 GMT
+                - Thu, 20 Jul 2023 06:45:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 90fe21b7-c2bd-4e55-540d-ccd76b6fc81f
+                - 21c633c4-eb6c-4a0c-47be-5e83dafb379e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 413.1525ms
+        duration: 397.3727ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 976d21c3-e53f-f2ad-bdcc-75513743706b
+                - a4513b69-82b2-375c-b91e-dd5801b18d85
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -427,7 +427,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:59 GMT
+                - Thu, 20 Jul 2023 06:45:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -441,12 +441,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 20281455-cc9d-4d0e-60bb-3c040a0508a7
+                - 65ea9c39-dc6d-4f44-5b1c-082b0b1764f6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 405.1903ms
+        duration: 392.7641ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -465,9 +465,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7d3080ed-423e-c55c-9c10-656d8c24d79f
+                - 81cd61fe-b45b-a229-0948-c36bbcad9b84
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -489,7 +489,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:59 GMT
+                - Thu, 20 Jul 2023 06:45:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -503,12 +503,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e4b1d731-2b8e-4894-791a-a67656dbde68
+                - 7c679404-cf03-400f-72fb-2cddad289760
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 346.3544ms
+        duration: 444.9478ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -527,9 +527,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - dffe4723-f888-81c8-0231-a81baa344980
+                - 645200ef-7e97-84b5-7069-4cd53189b9dd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -551,7 +551,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:11:00 GMT
+                - Thu, 20 Jul 2023 06:45:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -565,12 +565,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d4f38e9f-0977-4e16-5ef8-be78548e8c2f
+                - 140bd3b6-09b1-4d44-4039-acf4c054e46e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 443.84ms
+        duration: 431.1552ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d5cf17b4-4db2-3ee4-936a-fd078ebc0377
+                - 38e33cde-0012-6298-a14c-df520dea4cce
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -613,7 +613,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:11:00 GMT
+                - Thu, 20 Jul 2023 06:45:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -627,12 +627,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 54dd47fd-fd8b-4105-5f41-753069ecb7ef
+                - bb2d04eb-29f9-4493-4265-c55fe60c20b9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 376.1899ms
+        duration: 438.3131ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -651,9 +651,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4059f59d-80c1-309d-c1fa-ccf9a76c3c5e
+                - b7485595-e397-b5fd-4df7-114ec9bb82fa
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -672,14 +672,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":46,"active":true,"roleCollections":[]}'
+        body: '{"id":"86535387-54aa-4282-af13-67dd50cdd13c","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":50,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:11:01 GMT
+                - Thu, 20 Jul 2023 06:45:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,9 +701,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 561d2d1e-4c39-43bd-4207-f1fcc6209cb5
+                - 368875bb-c2d1-450e-6e0c-8d145371a72d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 642.0952ms
+        duration: 398.1654ms

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment_with_origin.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment_with_origin.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bc8f9295-fc9f-7e15-9b4c-f680cfb95f86
+                - b8e56861-1869-9b11-8e31-a3c3c39c1dac
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:51 GMT
+                - Thu, 20 Jul 2023 06:44:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e9181352-37da-4cb2-7315-4a9f13892912
+                - 6f384e24-b714-4c6b-56e5-fc69e50b1556
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 407.0873ms
+        duration: 425.9349ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 15c1d102-c7b5-9a43-a8cd-ff77e17437ba
+                - 89a99782-1607-ae3f-7d17-c9e8cc01fa68
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:52 GMT
+                - Thu, 20 Jul 2023 06:44:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8e078773-1544-4c7f-5e69-5952924c668d
+                - 8e0679ce-06aa-419a-646f-35289d31850e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 412.7247ms
+        duration: 408.3021ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 79fd455e-76c1-a92b-7045-3ec3e7a9e2bb
+                - 3f1325f8-0efc-8884-c7a9-83d460d757e1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:52 GMT
+                - Thu, 20 Jul 2023 06:44:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a7fa6efa-3c47-4768-4dc9-5e9c56491b5a
+                - bcb19cf7-94c3-4074-78ca-89577a8b3506
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 440.885ms
+        duration: 374.1476ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 482dc14c-ee9c-7ce5-164c-98ae51f55c7d
+                - 8b98e005-8e34-e339-3462-0cf21261f1f7
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -226,14 +226,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"c316226a-a6dc-4fab-9c93-81d8c1deadfe","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"John","familyName":"Doe","origin":"terraformint-platform","externalId":"I000000","lastLogonTime":1685617807221,"previousLogonTime":1685563657315,"zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":37,"active":true,"roleCollections":["Global Account Viewer"]}'
+        body: '{"id":"c316226a-a6dc-4fab-9c93-81d8c1deadfe","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"John","familyName":"Doe","origin":"terraformint-platform","externalId":"I000000","lastLogonTime":1685617807221,"previousLogonTime":1685563657315,"zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":39,"active":true,"roleCollections":["Global Account Viewer"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:53 GMT
+                - Thu, 20 Jul 2023 06:44:57 GMT
             Expires:
                 - "0"
             Pragma:
@@ -255,12 +255,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b6b79f23-bb0d-4bb6-577b-25dedc9a5017
+                - 991b899b-30de-411a-7e79-8265f72b9924
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 433.3254ms
+        duration: 316.5989ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -279,9 +279,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d42f5d0a-c618-75a4-f3ef-2701fcf1242a
+                - 18afd528-c40e-a1f8-9195-9b02ffa0715b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -303,7 +303,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:53 GMT
+                - Thu, 20 Jul 2023 06:44:57 GMT
             Expires:
                 - "0"
             Pragma:
@@ -317,12 +317,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 13b6c03a-96f1-411e-62b5-92a3949a3c57
+                - 5eb997ec-8bab-4d3b-7860-52e90cf9044f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 490.4609ms
+        duration: 369.287ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -341,9 +341,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - cf6de80d-3ca9-1a5c-4135-9661923b5e43
+                - 23ae792b-ba9c-5435-5af0-4c3a157a1b73
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -365,7 +365,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:54 GMT
+                - Thu, 20 Jul 2023 06:44:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -379,12 +379,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e137a259-6a30-4aa7-52c8-5b0ab15dd626
+                - 3b6d68b9-f7ed-40a2-46c2-87b7fbd46f5d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 421.68ms
+        duration: 371.115ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,9 +403,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f2a9a8df-e5c6-82ff-b07f-2398b6212efc
+                - 79ec6b22-49f0-4a49-bc71-1cab471b9491
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -427,7 +427,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:54 GMT
+                - Thu, 20 Jul 2023 06:44:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -441,12 +441,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4f1367af-4586-4dfa-4222-48e035b545b5
+                - ea430754-2c85-4f12-55d9-ec7d6677dcd7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 345.8724ms
+        duration: 345.8232ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -465,9 +465,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 44c26132-c36d-021b-603f-2c1943f5fbc1
+                - 08fa4d02-616b-80e6-2712-9a86cb23dce0
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -489,7 +489,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:55 GMT
+                - Thu, 20 Jul 2023 06:44:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -503,12 +503,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cccddd35-6951-4d51-6f36-79268967ad13
+                - 7cf0c957-3253-4f5a-603f-05bdd9045507
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 397.5453ms
+        duration: 417.3862ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -527,9 +527,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 450457c6-a84a-2ad3-2ba5-f5ce620e00de
+                - 35565e7d-effd-edc5-940c-607717b190e6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -551,7 +551,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:55 GMT
+                - Thu, 20 Jul 2023 06:44:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -565,12 +565,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e451da66-a6d4-48e3-6dce-5a20c63315a1
+                - 8e20dbd5-22f2-4bd3-673d-799b32e92521
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 397.8083ms
+        duration: 388.8065ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -589,9 +589,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 97d1dc2b-4512-3ec1-fe0e-56a2c8e8d453
+                - feeecd53-ef05-c98a-de51-c620c0db7355
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -610,14 +610,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"c316226a-a6dc-4fab-9c93-81d8c1deadfe","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"John","familyName":"Doe","origin":"terraformint-platform","externalId":"I000000","lastLogonTime":1685617807221,"previousLogonTime":1685563657315,"zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":38,"active":true,"roleCollections":[]}'
+        body: '{"id":"c316226a-a6dc-4fab-9c93-81d8c1deadfe","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"John","familyName":"Doe","origin":"terraformint-platform","externalId":"I000000","lastLogonTime":1685617807221,"previousLogonTime":1685563657315,"zoneId":"03760ecf-9d89-4189-a92a-1c7efed09298","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":40,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Wed, 05 Jul 2023 12:10:56 GMT
+                - Thu, 20 Jul 2023 06:44:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,9 +639,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 57cde02f-d2c5-41c9-5041-4bc2cc6c39da
+                - 94a41263-da29-4d6a-672b-4943dde28499
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 447.7893ms
+        duration: 398.6657ms

--- a/internal/provider/fixtures/resource_subaccount_role_collection.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.import_error.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 0bd01608-d03d-daa6-be68-2d6c77d8c274
+                - 0d21e736-0588-b549-95fc-60eec946d4b3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:28 GMT
+                - Thu, 20 Jul 2023 06:34:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7011788c-fe2e-4258-500d-a90f76b5ffbc
+                - 69e78ff0-a5d4-4cfd-4920-dab6c37564f3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 379.309275ms
+        duration: 335.3811ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 080b414c-dfd4-bd03-62c2-c1dcea4b451a
+                - 26c710a4-d73e-294b-8fb0-f212c15e4e3c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:29 GMT
+                - Thu, 20 Jul 2023 06:34:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 80c8de94-de37-4999-4056-44472b681824
+                - dba487ac-b01b-42cf-53bc-f202da309cc1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 305.827833ms
+        duration: 372.457ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b4cc1781-3b2b-f982-13cf-e71622ba51ef
+                - 0ff4a373-0512-4947-a0e2-970027aadd3d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:29 GMT
+                - Thu, 20 Jul 2023 06:34:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9b7e5bcf-f316-446b-6c31-30a22a523277
+                - 4ffa2f7f-8253-4b0f-79a8-057be6922630
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 223.116328ms
+        duration: 374.0871ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5d118fbd-0ec1-504c-9e3c-f800cdd878a6
+                - 2d93e14a-d9c5-75e2-e580-59be3cecb6d5
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:29 GMT
+                - Thu, 20 Jul 2023 06:34:19 GMT
             Expires:
                 - "0"
             Location:
@@ -257,12 +257,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 67898dc4-8f39-441f-4ac6-589882b201dd
+                - 336cced6-459a-421e-7b5c-5993df21b738
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 172.148362ms
+        duration: 168.9981ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +283,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?create
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 5d118fbd-0ec1-504c-9e3c-f800cdd878a6
+                - 2d93e14a-d9c5-75e2-e580-59be3cecb6d5
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -313,7 +313,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:30 GMT
+                - Thu, 20 Jul 2023 06:34:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,18 +335,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1752a26f-7414-466b-7242-3c9570b950ef
+                - 3dc105a1-6cf8-49a1-4b21-e89b8683a223
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 116.135586ms
+        duration: 100.5313ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 12744e45-7fbb-5b96-9cde-440be7455696
+                - 34b4c52e-f6b1-76f3-a040-9ed423d79015
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -372,18 +372,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:30 GMT
+                - Thu, 20 Jul 2023 06:34:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -397,18 +397,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bc22db23-f329-49f5-7300-2849c8b07c1a
+                - b12a38d0-9e78-4bf0-76d4-1a211796b43d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 270.691747ms
+        duration: 416.573ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -421,9 +421,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e0cf98e9-4ef4-339f-5b57-234920449170
+                - 00e918c9-357d-81b6-c2e5-4a598c5bea74
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -434,18 +434,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:31 GMT
+                - Thu, 20 Jul 2023 06:34:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -459,12 +459,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 63c2ed73-6790-4bc0-6f2a-42e16ad81cd4
+                - 0808c86c-540d-4595-4fb0-912d49458942
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 306.169637ms
+        duration: 365.7442ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1d06c58c-42e0-1174-bbb2-0bb3ad8cb863
+                - 9ac79e33-5f9b-2099-19f8-ba60b88fb198
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -511,7 +511,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:31 GMT
+                - Thu, 20 Jul 2023 06:34:20 GMT
             Expires:
                 - "0"
             Location:
@@ -535,12 +535,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4e7bc143-19ca-48f8-67a6-96faff43d947
+                - ffc53273-8dc2-4876-664c-06531807c632
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 159.268739ms
+        duration: 179.6908ms
     - id: 8
       request:
         proto: ""
@@ -561,9 +561,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1d06c58c-42e0-1174-bbb2-0bb3ad8cb863
+                - 9ac79e33-5f9b-2099-19f8-ba60b88fb198
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -591,7 +591,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:31 GMT
+                - Thu, 20 Jul 2023 06:34:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -613,18 +613,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7db2cff5-3947-490a-51e9-92c7ec4ece4d
+                - 793945f0-c1f2-4769-7417-8305c501b8bd
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 107.962565ms
+        duration: 119.5369ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -637,9 +637,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 271bfb67-0bda-2cd7-f30d-dc66ce887db0
+                - cfd3d90c-a498-99a9-9a23-9b78c493121e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -650,18 +650,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:31 GMT
+                - Thu, 20 Jul 2023 06:34:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -675,18 +675,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9d2a9565-c641-4e0c-75e4-e097ae67febd
+                - 3bcce063-adf2-4003-75ae-e21dd9123120
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 215.355274ms
+        duration: 344.7492ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -699,9 +699,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 51edc016-3135-903f-8396-0f9154b236ea
+                - 2d6c24ae-88b0-2cc6-def9-2e2de8c74b76
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -712,18 +712,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:32 GMT
+                - Thu, 20 Jul 2023 06:34:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -737,18 +737,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5dc5ae49-7fe5-45b4-429c-051a95c58d63
+                - ab3ad67b-89bf-4f30-4f5f-5646bc8c7fc4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 305.654745ms
+        duration: 418.9628ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -761,9 +761,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 67c3a789-3bea-d928-2790-c9292e8db58c
+                - 0c6a7c4e-5293-f7f0-9c45-3d4e0b25e621
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -774,18 +774,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:32 GMT
+                - Thu, 20 Jul 2023 06:34:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -799,18 +799,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7db7acbf-332f-42db-68ea-ff8ea98d0e15
+                - 77504118-f3a9-4d12-744e-2931f4a9134d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 369.606502ms
+        duration: 432.0509ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -823,9 +823,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2abae6cc-9d0d-8fb1-ae28-576f447c78e9
+                - 3c6ee241-e2e6-6a10-f643-4cb1bc54e1e9
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -836,18 +836,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:33 GMT
+                - Thu, 20 Jul 2023 06:34:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -861,12 +861,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 43ce5453-5773-4852-4300-8075a2c43ecc
+                - c0467155-e50e-432f-5adf-17a3215e5d25
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 262.76132ms
+        duration: 367.1155ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -885,9 +885,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3cadf567-fa1a-ff37-7b20-8babc6a97b35
+                - 5b9bb458-4857-5ad6-f814-573cc58c14d0
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -913,7 +913,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:33 GMT
+                - Thu, 20 Jul 2023 06:34:22 GMT
             Expires:
                 - "0"
             Location:
@@ -937,12 +937,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 31f2cc10-a14e-4655-68dd-edeb8960ef44
+                - 72e0da15-0ee5-4880-68b1-7f65867110ad
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 181.834238ms
+        duration: 170.0099ms
     - id: 14
       request:
         proto: ""
@@ -963,9 +963,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?delete
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3cadf567-fa1a-ff37-7b20-8babc6a97b35
+                - 5b9bb458-4857-5ad6-f814-573cc58c14d0
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -993,7 +993,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:33 GMT
+                - Thu, 20 Jul 2023 06:34:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1013,9 +1013,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4a3caa10-88f1-4568-5124-8bc7b7e8a4d7
+                - 8a6aec18-9ca6-4a97-5f91-deaa56ec6bd7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 133.779935ms
+        duration: 151.6481ms

--- a/internal/provider/fixtures/resource_subaccount_role_collection.update.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.update.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4ab22bec-6fb4-ff99-5c0e-cc1e2ff76a6b
+                - a72c48cb-632a-0889-c2c0-f6735f08f07d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:17 GMT
+                - Thu, 20 Jul 2023 06:34:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 26bc26c7-e548-40fe-682c-de69ec0bbbc0
+                - abdb155a-f759-4e2d-5bc2-32f4b6e3ca9b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 366.259851ms
+        duration: 375.0023ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6d3cd393-fefc-173f-2cc2-c9236e72caed
+                - 0cf92db1-ba02-377a-8e9b-24ff90639e58
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:18 GMT
+                - Thu, 20 Jul 2023 06:34:07 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d3dabcd1-1f34-4c23-584f-15d0a478a616
+                - 7fa0ea8b-1d48-4c8a-6898-30e902e0c042
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 229.012193ms
+        duration: 390.3688ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bc00abd9-e553-c45f-6fec-ca6995ca58c0
+                - f13b0874-8f3b-4837-13d5-44e66ad5825e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:18 GMT
+                - Thu, 20 Jul 2023 06:34:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - edb53a43-a0df-44be-7d24-09b014b1125b
+                - 0ff420c0-03bf-40cb-4213-51e5a7a00e51
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 225.044109ms
+        duration: 375.1788ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b08430d8-50ec-ddc4-fef8-8a341182e30f
+                - ec852298-73a5-c290-021c-74d62b943b1a
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:18 GMT
+                - Thu, 20 Jul 2023 06:34:08 GMT
             Expires:
                 - "0"
             Location:
@@ -257,12 +257,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 0f066901-f5ea-4060-5a0d-aaeb19d93eec
+                - 5d827158-2150-4115-5e91-a0b0cbccc18e
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 172.314492ms
+        duration: 181.1388ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +283,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?create
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b08430d8-50ec-ddc4-fef8-8a341182e30f
+                - ec852298-73a5-c290-021c-74d62b943b1a
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -313,7 +313,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:18 GMT
+                - Thu, 20 Jul 2023 06:34:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b774540f-21fa-4cb4-550a-d81f2ed68381
+                - cbd30c55-4243-4bcd-5e68-3be49e6edcd4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 169.543568ms
+        duration: 120.3404ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f4cd5ca5-8752-0ed2-3172-141591b84d99
+                - a9fa95da-1957-16fa-ef41-25cbedada3c6
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -387,7 +387,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:19 GMT
+                - Thu, 20 Jul 2023 06:34:08 GMT
             Expires:
                 - "0"
             Location:
@@ -411,12 +411,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 35f323e8-a0ac-4ce3-5f14-9af01c06b2f5
+                - 9a1f712f-54b7-4087-6c05-4ba9db67a5f9
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 173.954655ms
+        duration: 211.939ms
     - id: 6
       request:
         proto: ""
@@ -437,9 +437,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?add
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f4cd5ca5-8752-0ed2-3172-141591b84d99
+                - a9fa95da-1957-16fa-ef41-25cbedada3c6
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -467,7 +467,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:19 GMT
+                - Thu, 20 Jul 2023 06:34:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8c0ee822-9d08-4842-44a9-907b9be6a3a9
+                - 91356479-2b01-4dee-7ff4-4e12b1e06b72
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 113.152463ms
+        duration: 132.5389ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -511,9 +511,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6ec4c391-5e8f-62b6-a84f-dd366f3b4777
+                - 48cd8f53-17be-3395-e737-759fcb584a35
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -539,7 +539,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:19 GMT
+                - Thu, 20 Jul 2023 06:34:08 GMT
             Expires:
                 - "0"
             Location:
@@ -563,12 +563,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e404487d-ccce-44ba-414c-f5e6fcecdf41
+                - aec66cbd-8199-4de3-5ea2-1ba61c8afb80
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 255.906742ms
+        duration: 162.7326ms
     - id: 8
       request:
         proto: ""
@@ -589,9 +589,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?add
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6ec4c391-5e8f-62b6-a84f-dd366f3b4777
+                - 48cd8f53-17be-3395-e737-759fcb584a35
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -619,7 +619,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:19 GMT
+                - Thu, 20 Jul 2023 06:34:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,18 +639,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 80f8b85a-a183-46e4-4f51-3d38435a7de7
+                - dcd01b9d-59ec-40f4-7af3-ab6f490f535b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 106.266238ms
+        duration: 141.3094ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -663,9 +663,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b6ff3097-cfcc-5873-ab03-9cd526e14765
+                - 29b4d046-801b-a1ac-f01c-00a32e1abda7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -676,18 +676,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:19 GMT
+                - Thu, 20 Jul 2023 06:34:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,18 +701,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c28b020b-97c2-43ab-4e5e-b8dbd1de7037
+                - 2a51d76a-77ae-4c67-4446-22e0acb6f3f9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 262.15607ms
+        duration: 384.2828ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -725,9 +725,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d3dd975f-c68b-c4cb-fe21-7afccd0d79d5
+                - fe2fd220-03a5-6e94-bf08-49ea148133ec
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -738,18 +738,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:20 GMT
+                - Thu, 20 Jul 2023 06:34:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -763,12 +763,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1443e332-d643-4ac3-70d1-699519cfd7d0
+                - 3fdcaa12-a3bd-4557-585d-ef02d35e137e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 211.332549ms
+        duration: 393.9914ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -787,9 +787,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ab50ec5-7f06-3e92-619f-9a8a2cad21b2
+                - 6a8485ca-9ee0-016e-f92b-6ce8b1102c6d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -815,7 +815,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:20 GMT
+                - Thu, 20 Jul 2023 06:34:10 GMT
             Expires:
                 - "0"
             Location:
@@ -839,12 +839,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8fb8f161-e86f-4d7d-564e-0bb15fd5d531
+                - b10c8576-1d18-4e85-4fbf-fa73acfdf960
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 176.314659ms
+        duration: 159.795ms
     - id: 12
       request:
         proto: ""
@@ -865,9 +865,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ab50ec5-7f06-3e92-619f-9a8a2cad21b2
+                - 6a8485ca-9ee0-016e-f92b-6ce8b1102c6d
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -895,7 +895,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:20 GMT
+                - Thu, 20 Jul 2023 06:34:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -917,18 +917,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 271ed66f-f0fc-461b-4114-a9f4cafb7e07
+                - 54a47a85-7605-4184-6396-b21af7371f3c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 151.384815ms
+        duration: 173.9984ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -941,9 +941,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e04abf48-5ba9-7962-852b-25ece0068a64
+                - 739bd3d8-0ab3-fa1f-1475-a2925f2d7c61
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -954,18 +954,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:20 GMT
+                - Thu, 20 Jul 2023 06:34:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -979,18 +979,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 12024764-0f34-4f5e-72ad-1ec0cb1f73a3
+                - c47ec530-53b5-431b-5495-543994fa59e4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 208.760382ms
+        duration: 391.6728ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1003,9 +1003,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 6a5455ed-9dc4-25b6-422d-13d8ea740cd2
+                - d6b3197c-c96c-c2d1-523e-08ee8ba89323
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1016,18 +1016,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:21 GMT
+                - Thu, 20 Jul 2023 06:34:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1041,12 +1041,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a836e1a0-a8b7-4c3a-4f23-8206e72cd097
+                - 10e3edce-f404-498f-7d38-03de78d346dc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 243.294493ms
+        duration: 404.0136ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1065,9 +1065,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1d9c485e-c0db-7d8b-3b35-a76051d081c3
+                - 2065f11f-e78d-1d65-136e-8f4c77060306
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1093,7 +1093,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:21 GMT
+                - Thu, 20 Jul 2023 06:34:11 GMT
             Expires:
                 - "0"
             Location:
@@ -1117,12 +1117,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 75260756-2aab-4ee0-5889-629889c155e2
+                - 8cc73725-9235-459a-767c-488b96c514bb
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 315.768219ms
+        duration: 183.723ms
     - id: 16
       request:
         proto: ""
@@ -1143,9 +1143,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1d9c485e-c0db-7d8b-3b35-a76051d081c3
+                - 2065f11f-e78d-1d65-136e-8f4c77060306
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1173,7 +1173,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:21 GMT
+                - Thu, 20 Jul 2023 06:34:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1195,18 +1195,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - eaac705f-8670-44bc-6729-35a233cb54ee
+                - 63729025-9aa5-4d7a-7f34-552e5ebdf9fd
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 94.754237ms
+        duration: 93.1058ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1219,9 +1219,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e90b67bb-fc80-e453-8198-22c9e827ea58
+                - 29bacbfb-e6ad-bd40-65bd-ee879cdb9526
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1232,18 +1232,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:22 GMT
+                - Thu, 20 Jul 2023 06:34:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1257,18 +1257,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f81d695e-81e4-4374-64ac-8ee9dc8ba022
+                - 4e1c715f-c437-48c7-67f4-64722392f735
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 282.408291ms
+        duration: 356.529ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1281,9 +1281,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b6766d85-eb6c-395c-4707-108f17031550
+                - 71307ca3-31b1-a247-460f-c0f2470cbbf7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1294,18 +1294,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:22 GMT
+                - Thu, 20 Jul 2023 06:34:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1319,12 +1319,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2d910e57-9f80-4d4c-4076-820dca8fda06
+                - 46d9d808-b2bc-4578-56b5-33b9b60c4734
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 343.835466ms
+        duration: 341.5027ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1343,9 +1343,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ec53126a-2fed-6d1d-d20a-c76dda96b49e
+                - 5b411b41-81ca-f2a4-b85f-0497ae2d8570
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1371,7 +1371,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:22 GMT
+                - Thu, 20 Jul 2023 06:34:12 GMT
             Expires:
                 - "0"
             Location:
@@ -1395,12 +1395,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 670501e4-babb-49d8-60d0-8225f3dc8c6e
+                - f5d09366-8bc4-4eb1-6b31-de3339cdb8b9
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 181.210513ms
+        duration: 209.8095ms
     - id: 20
       request:
         proto: ""
@@ -1421,9 +1421,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?update
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ec53126a-2fed-6d1d-d20a-c76dda96b49e
+                - 5b411b41-81ca-f2a4-b85f-0497ae2d8570
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1451,7 +1451,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:23 GMT
+                - Thu, 20 Jul 2023 06:34:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1471,12 +1471,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bbb8933e-71b1-4673-4180-8ac6585d6a84
+                - b5ce1521-2da2-443c-6f3e-fccf556c4e12
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 104.138502ms
+        duration: 135.8883ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1495,9 +1495,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2c356757-17c7-f985-344d-1c362a35b15c
+                - 7e2ee162-214c-b1c7-789e-560cef17663b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1523,7 +1523,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:23 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Location:
@@ -1547,12 +1547,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1fa5512f-c39c-402c-6098-41ac2742fbf4
+                - 1b199609-89f9-4df6-59f3-6e37b397faca
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 158.818065ms
+        duration: 182.6067ms
     - id: 22
       request:
         proto: ""
@@ -1573,9 +1573,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?remove
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2c356757-17c7-f985-344d-1c362a35b15c
+                - 7e2ee162-214c-b1c7-789e-560cef17663b
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1603,7 +1603,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:23 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1623,12 +1623,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0b04621c-4300-410c-4219-f4981844169d
+                - 2e1b95ee-1b4f-471e-6031-86c80e853f74
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 116.73271ms
+        duration: 108.8702ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1647,9 +1647,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9aadc5d0-69d2-1b2b-bd65-35d3502b1433
+                - 14debc36-b9c5-fbdd-cd7b-45eb1ff86aa5
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1675,7 +1675,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:23 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Location:
@@ -1699,12 +1699,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 9d7f3c37-eb59-4a1a-70ec-2c701c9abab9
+                - 1dff3aa5-7741-4b97-62d1-a902b7a00c2c
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 163.144985ms
+        duration: 167.1307ms
     - id: 24
       request:
         proto: ""
@@ -1725,9 +1725,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?remove
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9aadc5d0-69d2-1b2b-bd65-35d3502b1433
+                - 14debc36-b9c5-fbdd-cd7b-45eb1ff86aa5
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1755,7 +1755,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:23 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1775,12 +1775,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 888e2f05-b581-4d91-66a7-f5fcf19e609b
+                - d8ad6990-e1c8-4e8c-6840-9b99781552b8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 106.297034ms
+        duration: 148.4563ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1799,9 +1799,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9bd0cba9-40a7-3307-4961-f18b40c4a3ec
+                - d39eedd3-365f-b7b2-319d-322308e84e1f
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1827,7 +1827,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:23 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Location:
@@ -1851,12 +1851,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2cff3c36-d946-4c12-6827-9cbb0c10482c
+                - 30cf4bcc-3dee-4a07-580b-d95bed87bf52
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 290.019607ms
+        duration: 212.1237ms
     - id: 26
       request:
         proto: ""
@@ -1877,9 +1877,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?add
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9bd0cba9-40a7-3307-4961-f18b40c4a3ec
+                - d39eedd3-365f-b7b2-319d-322308e84e1f
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1907,7 +1907,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:24 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1927,12 +1927,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d2fb728f-abf7-4748-5d63-fbc2320cda0a
+                - 48ec0020-0272-4ddc-5d50-48510655a293
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 202.494964ms
+        duration: 97.7853ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1951,9 +1951,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 8f67fc81-a5fe-3852-263a-ec3ec8f67374
+                - d5d2c751-0083-bd6f-41c5-9f54fe2e390f
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1979,7 +1979,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:24 GMT
+                - Thu, 20 Jul 2023 06:34:13 GMT
             Expires:
                 - "0"
             Location:
@@ -2003,12 +2003,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 15583e6e-d24a-462e-7017-623d3a9f657e
+                - 7a219c0d-6379-4428-7990-01628afc77b3
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 164.09465ms
+        duration: 153.4516ms
     - id: 28
       request:
         proto: ""
@@ -2029,9 +2029,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 8f67fc81-a5fe-3852-263a-ec3ec8f67374
+                - d5d2c751-0083-bd6f-41c5-9f54fe2e390f
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2059,7 +2059,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:24 GMT
+                - Thu, 20 Jul 2023 06:34:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2081,18 +2081,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d41aefb2-2376-43a8-4e4b-cfa1d4b235fd
+                - d5ab67a0-ef36-4d00-4d67-df13c7d652b7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 87.41048ms
+        duration: 86.0078ms
     - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2105,9 +2105,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 63c4ba3c-db0b-c700-194b-40ae11a6e9dd
+                - bd06dac5-596a-c0c3-2169-d9bd298dedc6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2118,18 +2118,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:24 GMT
+                - Thu, 20 Jul 2023 06:34:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2143,18 +2143,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6996b23f-bf9f-42f3-52c6-52d70d55933d
+                - 086049b4-8771-47fc-4b35-f990efc7f3b9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 193.367948ms
+        duration: 351.7035ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2167,9 +2167,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 71049de7-8c0f-9ef1-e3a4-f0c4794b1ce6
+                - 6eef0d78-aa53-6ccf-2b63-91ec3560cb0e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2180,18 +2180,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:25 GMT
+                - Thu, 20 Jul 2023 06:34:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2205,12 +2205,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0549dd65-0ec2-4403-699e-c848c2db700b
+                - 1c6c13d0-26b2-4bef-4f84-d69331bfbf9e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 337.761111ms
+        duration: 339.4294ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -2229,9 +2229,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c274f40c-64ad-d915-6b7f-1d0d9fff58d1
+                - 2e2e8de5-6af1-adee-6860-a3d93ced9129
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2257,7 +2257,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:25 GMT
+                - Thu, 20 Jul 2023 06:34:15 GMT
             Expires:
                 - "0"
             Location:
@@ -2281,12 +2281,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - bffe2e04-187c-4d3c-5bd3-ee6933efcd53
+                - 05412619-16b1-4394-7df4-5c4c6e98105b
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 202.308133ms
+        duration: 188.0881ms
     - id: 32
       request:
         proto: ""
@@ -2307,9 +2307,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c274f40c-64ad-d915-6b7f-1d0d9fff58d1
+                - 2e2e8de5-6af1-adee-6860-a3d93ced9129
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2337,7 +2337,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:25 GMT
+                - Thu, 20 Jul 2023 06:34:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2359,18 +2359,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 74718a9f-63c7-4c8c-7617-edfecbd9655d
+                - 264b1cb2-3736-4754-6cbd-7aeb4bce7c15
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 108.724713ms
+        duration: 120.3904ms
     - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2383,9 +2383,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a839412e-693e-4443-6b61-0572b5290f61
+                - 6cf2d8fe-6dbf-680d-c558-b5ba93be141c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2396,18 +2396,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:25 GMT
+                - Thu, 20 Jul 2023 06:34:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2421,18 +2421,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 147c9223-2188-45ec-665d-698dd43d81aa
+                - 647c7be5-3c04-4b02-745e-2b807ccbf543
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 247.715023ms
+        duration: 351.2423ms
     - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2445,9 +2445,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d867c4fa-4dcf-8f72-a13e-b7741a189510
+                - 61d62f48-7f1f-3c5e-41d6-273f28b8abd7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2458,18 +2458,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:26 GMT
+                - Thu, 20 Jul 2023 06:34:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2483,12 +2483,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4bf85b9d-1fa5-4e9c-6998-abdca89cbb68
+                - d9462d47-43f4-4762-7b55-670b4b192da9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 212.154949ms
+        duration: 356.7005ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2507,9 +2507,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c48260fc-b5d5-a23d-8ac0-ec553e49451a
+                - b9fac701-d1c9-72c2-24e6-d9c5fb9cb1f2
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2535,7 +2535,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:26 GMT
+                - Thu, 20 Jul 2023 06:34:16 GMT
             Expires:
                 - "0"
             Location:
@@ -2559,12 +2559,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2cc8697a-3f64-4d09-5cc6-45cc732402c5
+                - 6ceb9d6e-1f95-4f0a-786d-55330fb37024
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 265.678589ms
+        duration: 205.4848ms
     - id: 36
       request:
         proto: ""
@@ -2585,9 +2585,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c48260fc-b5d5-a23d-8ac0-ec553e49451a
+                - b9fac701-d1c9-72c2-24e6-d9c5fb9cb1f2
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2615,7 +2615,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:26 GMT
+                - Thu, 20 Jul 2023 06:34:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2637,18 +2637,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 29b5adc9-0546-4378-6337-bfb907504f49
+                - 7f3d6cf9-0aeb-474d-6216-3585b3a25852
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 88.454584ms
+        duration: 102.532ms
     - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2661,9 +2661,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 63807087-183c-4d4d-db5b-fce68c72426d
+                - e2d5e59c-5769-b3f1-a900-4e38a826a33b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2674,18 +2674,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:27 GMT
+                - Thu, 20 Jul 2023 06:34:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2699,18 +2699,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a12cceed-614a-4db4-5ca6-ccabf3643c87
+                - 7ca61e9f-347e-40de-553e-e8720175e5ea
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 428.723007ms
+        duration: 384.1269ms
     - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2723,9 +2723,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4622fd71-05a0-0313-d10b-ebecfca0e651
+                - 715f8111-2b26-216a-3f24-bf0eed893c60
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2736,18 +2736,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:27 GMT
+                - Thu, 20 Jul 2023 06:34:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2761,12 +2761,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 94c22cb0-9f59-4edd-5f02-3cb701e3e8eb
+                - 84edbe6a-0884-4e7f-5d3e-ed23c7e8b580
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 362.156014ms
+        duration: 394.8634ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2785,9 +2785,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 95afd7ae-5f5c-81f9-f7bf-501dfda581ee
+                - 1a269d06-ca57-963b-190f-21d6c60550db
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2813,7 +2813,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:28 GMT
+                - Thu, 20 Jul 2023 06:34:17 GMT
             Expires:
                 - "0"
             Location:
@@ -2837,12 +2837,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - eb81777c-79c7-467f-400e-b4f1202b41d6
+                - 0220a94a-e031-438f-47fd-4077a3384528
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 191.715926ms
+        duration: 190.5621ms
     - id: 40
       request:
         proto: ""
@@ -2863,9 +2863,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?delete
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 95afd7ae-5f5c-81f9-f7bf-501dfda581ee
+                - 1a269d06-ca57-963b-190f-21d6c60550db
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -2893,7 +2893,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:28 GMT
+                - Thu, 20 Jul 2023 06:34:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2913,9 +2913,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - de551133-e4f8-4e0c-7c7e-fb83b93ac5e4
+                - 3056ac92-511d-4c9c-42fd-104d7a43e000
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 166.579018ms
+        duration: 104.1882ms

--- a/internal/provider/fixtures/resource_subaccount_role_collection.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 2152fd2b-c164-b90e-4325-166e9fe26e39
+                - 3b21136b-6f8f-91ce-1dd6-ada3c93bcef6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:09 GMT
+                - Thu, 20 Jul 2023 06:33:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,18 +57,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 94c5ab91-45e1-4de9-578b-b2d08facf14c
+                - 6bc0cee0-0695-4a91-7a36-435cfb99d0b8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 617.528362ms
+        duration: 985.702ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b0365a15-5794-c131-7676-d4460c6deba8
+                - a88639eb-e749-7f35-7720-afa5bb193619
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:09 GMT
+                - Thu, 20 Jul 2023 06:34:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6c7b5ee5-1c84-4b2e-4134-cabdbb0c718e
+                - ebe1b224-f2e7-4ec6-4c59-533741c01f33
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 449.158272ms
+        duration: 496.4194ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 8b016953-bce4-dc77-8459-51807b099283
+                - c84556e3-f710-38e5-5f33-3e45192e36be
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +156,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:10 GMT
+                - Thu, 20 Jul 2023 06:34:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 68425702-91ab-48f6-6f6f-ef7f3e94d5fc
+                - 32338e8a-d148-41fc-79a5-992b0d102b1d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 357.900965ms
+        duration: 429.3353ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 95efb7ae-4fa3-1f12-302a-8b5cbdcdf999
+                - a40816b6-057a-53cd-bfa8-aa9b16f64e29
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:10 GMT
+                - Thu, 20 Jul 2023 06:34:01 GMT
             Expires:
                 - "0"
             Location:
@@ -257,12 +257,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5805d380-85ec-4f60-6f93-ebbd2cc90929
+                - 5c5258fc-eb35-4a03-7cd6-8b1bd24129aa
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 289.534725ms
+        duration: 287.31ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +283,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?create
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 95efb7ae-4fa3-1f12-302a-8b5cbdcdf999
+                - a40816b6-057a-53cd-bfa8-aa9b16f64e29
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -313,7 +313,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:11 GMT
+                - Thu, 20 Jul 2023 06:34:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - aaa02381-9bb8-434c-6e98-727b020fb838
+                - 449c177b-2707-4652-6ec6-af1bb765448b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 300.164681ms
+        duration: 493.802ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 76f04f55-b56f-7975-cf49-b0feae73e9f8
+                - 721da227-910d-1d01-4d90-dd74ecb64b71
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -387,7 +387,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:11 GMT
+                - Thu, 20 Jul 2023 06:34:01 GMT
             Expires:
                 - "0"
             Location:
@@ -411,12 +411,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e3f007d6-f3d0-4488-6173-8b68cf51c9db
+                - a0389a60-91a6-4614-7860-4517e9fc75e4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 216.688733ms
+        duration: 233.981ms
     - id: 6
       request:
         proto: ""
@@ -437,9 +437,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?add
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 76f04f55-b56f-7975-cf49-b0feae73e9f8
+                - 721da227-910d-1d01-4d90-dd74ecb64b71
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -467,7 +467,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:11 GMT
+                - Thu, 20 Jul 2023 06:34:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7df091f5-a37d-4a2b-7b0d-424ccc72f403
+                - 6ab435f2-6d60-4a5f-6d7c-459046f18e36
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 93.568031ms
+        duration: 218.7602ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -511,9 +511,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 00969f8d-cb00-2175-a140-282ba061b336
+                - 2c95edbe-536c-2519-a79c-565f27293755
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -539,7 +539,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:11 GMT
+                - Thu, 20 Jul 2023 06:34:02 GMT
             Expires:
                 - "0"
             Location:
@@ -563,12 +563,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8f6fef29-0252-493b-4898-cc0f6690e210
+                - fd0ea498-2cc6-41ed-7d25-291afd888be1
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 323.120419ms
+        duration: 258.5608ms
     - id: 8
       request:
         proto: ""
@@ -589,9 +589,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role?add
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 00969f8d-cb00-2175-a140-282ba061b336
+                - 2c95edbe-536c-2519-a79c-565f27293755
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -619,7 +619,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:11 GMT
+                - Thu, 20 Jul 2023 06:34:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -639,18 +639,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ee12d1b9-a798-4263-6492-0a3ca0be9a11
+                - 1773d7cf-2da6-4eae-68b3-e06c9ff6dfe8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 106.620333ms
+        duration: 176.5055ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -663,9 +663,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 39028741-66f4-eb73-3f05-ab8db54ff5b9
+                - d984b461-02a4-3a87-08c2-c0dc869be6ba
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -676,18 +676,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:12 GMT
+                - Thu, 20 Jul 2023 06:34:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,18 +701,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6d554754-c984-4a48-6aff-a5e446d6b021
+                - ce456855-3b9b-4c32-7e7d-df8af427160b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 310.728508ms
+        duration: 373.5809ms
     - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -725,9 +725,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 76a00aad-9a94-30e6-8710-8a887f9c8aaa
+                - 59b0d122-0b4b-20eb-4945-9543080f63ec
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -738,18 +738,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:12 GMT
+                - Thu, 20 Jul 2023 06:34:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -763,12 +763,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 951c535b-83c5-45e0-77b8-d23265d6d9c7
+                - 19cac51e-f0c5-40e9-6d6c-abdaf19c98b7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 318.074854ms
+        duration: 392.1325ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -787,9 +787,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e45335b2-8129-ae10-edba-c178e05f0b2c
+                - 7ee18e45-b199-d12a-174a-e0741466eb28
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -815,7 +815,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:13 GMT
+                - Thu, 20 Jul 2023 06:34:03 GMT
             Expires:
                 - "0"
             Location:
@@ -839,12 +839,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e9142949-a06d-488e-596c-8008c2b176db
+                - 12123248-27e6-4cde-6f86-1650e7c55e8d
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 236.726168ms
+        duration: 201.0141ms
     - id: 12
       request:
         proto: ""
@@ -865,9 +865,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e45335b2-8129-ae10-edba-c178e05f0b2c
+                - 7ee18e45-b199-d12a-174a-e0741466eb28
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -895,7 +895,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:13 GMT
+                - Thu, 20 Jul 2023 06:34:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -917,18 +917,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 09c2e056-11ac-472f-57eb-4587423bf50b
+                - 9b254e2c-b858-4127-4212-64804d3164f6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 244.607491ms
+        duration: 156.1427ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -941,9 +941,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 343285ce-c07d-8937-84ad-3df47647c7e7
+                - 1ca8fdb4-848c-dff6-87cd-abce0481eb8a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -954,18 +954,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:14 GMT
+                - Thu, 20 Jul 2023 06:34:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -979,18 +979,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cc7d4df9-b475-4b4d-7ac8-5a7f3d626c47
+                - 2ea480e2-27b9-455f-4b7d-c7de01a3dea6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 549.216778ms
+        duration: 362.369ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1003,9 +1003,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4df3c40f-e6d6-cdd2-f54d-51047c010fb0
+                - 10af93f1-697e-3386-82a2-176faf4a71fa
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1016,18 +1016,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:14 GMT
+                - Thu, 20 Jul 2023 06:34:04 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1041,12 +1041,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bbb0b74e-9bae-453b-7032-ad26f7db8ede
+                - 6d014221-bf73-457e-7bfa-737bd844508a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 313.522906ms
+        duration: 339.5159ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1065,9 +1065,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b0067203-a489-5d4f-ff93-991dcb67dddd
+                - 8c7f818d-f0a3-07e3-d369-0e5eef2f525c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1093,7 +1093,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:15 GMT
+                - Thu, 20 Jul 2023 06:34:04 GMT
             Expires:
                 - "0"
             Location:
@@ -1117,12 +1117,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4a604ad2-28c1-421d-6598-162c0cd794a2
+                - 10cf76ba-4ca6-43af-50e1-073b32d41660
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 267.485855ms
+        duration: 277.4486ms
     - id: 16
       request:
         proto: ""
@@ -1143,9 +1143,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b0067203-a489-5d4f-ff93-991dcb67dddd
+                - 8c7f818d-f0a3-07e3-d369-0e5eef2f525c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1173,7 +1173,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:15 GMT
+                - Thu, 20 Jul 2023 06:34:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1195,18 +1195,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 820820ce-3fb2-486f-6fc6-b37d08df066f
+                - 64088e79-40b8-42bc-5e8a-8e8b659547ca
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 167.046108ms
+        duration: 188.0786ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1219,9 +1219,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 9c98dd82-4d5d-be7e-98d6-f6071cbd63ff
+                - 0184728c-6623-7131-b3b3-398d70707ddc
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1232,18 +1232,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:16 GMT
+                - Thu, 20 Jul 2023 06:34:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1257,18 +1257,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f81db3d5-4412-45a2-5ccf-b78cd19e42df
+                - a1688607-86e7-48d9-74b2-0b2cd321b604
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 610.07724ms
+        duration: 468.1672ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1281,9 +1281,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ee82101f-4f6b-97c7-cf5f-6298ef31ba56
+                - 1a642d43-13a0-cc25-c749-3b1b78e26c83
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1294,18 +1294,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 149
         uncompressed: false
         body: '{"issuer":"accounts.sap.com","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "149"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:16 GMT
+                - Thu, 20 Jul 2023 06:34:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1319,12 +1319,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4d5d6956-c607-4b4b-6537-83a8c35de01f
+                - b13f14d0-b07c-4497-45a3-405b30325b3d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 430.467616ms
+        duration: 461.4954ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1343,9 +1343,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 785032a9-2567-759c-23c9-fd48f8d5c773
+                - d8fb2f1c-b4cd-207d-60b5-a8dc2039be51
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1371,7 +1371,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 18 Jul 2023 07:58:16 GMT
+                - Thu, 20 Jul 2023 06:34:06 GMT
             Expires:
                 - "0"
             Location:
@@ -1395,12 +1395,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 9ce77d1f-8272-4f0a-64b6-57e28e20168c
+                - 6d908c46-fabe-4534-68f8-627c4a888756
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 304.346027ms
+        duration: 291.2109ms
     - id: 20
       request:
         proto: ""
@@ -1421,9 +1421,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?delete
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 785032a9-2567-759c-23c9-fd48f8d5c773
+                - d8fb2f1c-b4cd-207d-60b5-a8dc2039be51
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -1451,7 +1451,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 18 Jul 2023 07:58:17 GMT
+                - Thu, 20 Jul 2023 06:34:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1471,9 +1471,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fd86cf05-0fd9-41bc-48c8-1bf8333c9646
+                - b7a91451-f8d9-48a7-7c95-9bfe9f8f2702
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 176.509418ms
+        duration: 125.7925ms

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 7f525a0e-fa63-8758-dd2a-616428d176fc
+                - 1e55314b-ff68-a998-c6f6-1401bfab392a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:26:54 GMT
+                - Thu, 20 Jul 2023 06:36:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9538971b-c7d6-438a-719d-3ba28dc39c73
+                - ac979f64-7172-4915-5cf4-f226c88efe70
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 838.4948ms
+        duration: 712.5883ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - d1275c05-291d-03cb-7423-e81198d52aac
+                - 26184942-208e-af2a-7e01-368bc31408c3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:26:56 GMT
+                - Thu, 20 Jul 2023 06:36:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2685ca2b-be61-419a-77f1-73dbb32cd498
+                - 52db3195-d7ad-4460-5f03-384c60c6f71c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 546.4549ms
+        duration: 392.6308ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 366ead4a-6dfd-05a0-9838-888f66f82113
+                - 7adc4d38-99f4-9e91-0ef0-eb8ba81fad56
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:26:57 GMT
+                - Thu, 20 Jul 2023 06:36:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e7297119-4b48-4246-7922-b45275c97c0c
+                - 66dcaa7f-0f09-42ed-7770-5f577deae7be
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 466.2007ms
+        duration: 384.0816ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bded1692-0472-b302-7617-5a072c74d701
+                - 9e973eac-a694-b8eb-a674-b20bf19c93c9
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 19 Jun 2023 14:26:58 GMT
+                - Thu, 20 Jul 2023 06:36:31 GMT
             Expires:
                 - "0"
             Location:
@@ -257,12 +257,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - a7704a25-3ffe-409f-6e9d-374d8258a10d
+                - 89906aad-3ac1-49be-6275-53fc7cb1ce16
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 343.9382ms
+        duration: 211.5405ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +283,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?assign
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - bded1692-0472-b302-7617-5a072c74d701
+                - 9e973eac-a694-b8eb-a674-b20bf19c93c9
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -306,14 +306,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":1,"active":true,"roleCollections":["Destination Administrator"]}'
+        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":5,"active":true,"roleCollections":["Destination Administrator"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:26:59 GMT
+                - Thu, 20 Jul 2023 06:36:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 04a7257b-1e46-4a74-731e-0bba9ea21ca8
+                - 168de444-6a93-4a93-5155-08cec78f4ce0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 404.5551ms
+        duration: 414.656ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 56037a93-1579-8ea6-e4df-843231477c0c
+                - 2bbfc4b9-026f-fec2-8432-2ba9259d47a5
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -383,7 +383,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:00 GMT
+                - Thu, 20 Jul 2023 06:36:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -397,12 +397,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2f944166-b4ef-442a-4856-bb042b731237
+                - eb56922c-697e-4f09-4948-8d6e9ee87636
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 545.4487ms
+        duration: 362.8336ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -421,9 +421,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3215c84d-7b0a-b82c-f4cb-b847573e4756
+                - 2c085042-68bd-4881-9dcc-20207aa2e940
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -445,7 +445,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:01 GMT
+                - Thu, 20 Jul 2023 06:36:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -459,12 +459,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3a0b2cc0-b7d9-4138-4004-36b11a2e45ac
+                - ce350c2c-ea76-47e9-7cc9-339e398e5395
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 651.8123ms
+        duration: 389.8628ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 12e9c887-7698-5128-dcd7-33a1297c8a4c
+                - fe69ea65-7298-6b63-15dd-aa582ce99468
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -507,7 +507,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:02 GMT
+                - Thu, 20 Jul 2023 06:36:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -521,12 +521,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d51899ca-1dec-4973-6c29-b90d9b7f52c9
+                - 13cd8ab4-4859-4b91-6782-549670a9a406
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 510.3808ms
+        duration: 383.8998ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -545,9 +545,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fb6dc25e-e64d-541e-f551-c2f50bb5167f
+                - 530e0d97-b6b1-d1b6-9693-827f067ae538
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -569,7 +569,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:03 GMT
+                - Thu, 20 Jul 2023 06:36:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -583,12 +583,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b1ba6dcb-22ac-4e1f-7bc5-cfa95c24d09f
+                - f737cdf4-5c28-4848-4e64-b6577691a7b0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 506.0305ms
+        duration: 364.2976ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -607,9 +607,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 51a6b901-c973-77f2-dc36-4edf9fbe997f
+                - 1edf8b8e-04f5-86b0-2a56-360ebd4d46a3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -631,7 +631,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:04 GMT
+                - Thu, 20 Jul 2023 06:36:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -645,12 +645,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ed150d2b-b0e6-4389-501a-60c153ef9e02
+                - eb86a937-7ce0-4aac-78fd-0f90ac9b5ef4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 571.6309ms
+        duration: 395.3064ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -669,9 +669,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 573c7e60-a327-e9ae-c894-7470d9c12b55
+                - 7021b809-1fe4-f257-fc8c-76216b575b8c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -697,7 +697,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 19 Jun 2023 14:27:05 GMT
+                - Thu, 20 Jul 2023 06:36:34 GMT
             Expires:
                 - "0"
             Location:
@@ -721,12 +721,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f7c385e3-35bb-4ff4-7fe3-3df45278343b
+                - b593ce47-2ff6-4d86-74ba-4f003c39299e
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 271.8626ms
+        duration: 186.2662ms
     - id: 11
       request:
         proto: ""
@@ -747,9 +747,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?unassign
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 573c7e60-a327-e9ae-c894-7470d9c12b55
+                - 7021b809-1fe4-f257-fc8c-76216b575b8c
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -770,14 +770,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":2,"active":true,"roleCollections":[]}'
+        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":6,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:06 GMT
+                - Thu, 20 Jul 2023 06:36:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -799,9 +799,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7464232f-841e-402f-5aec-af7113c23f19
+                - 67579c07-35f8-4588-6020-7c5daba4e926
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 243.6241ms
+        duration: 217.484ms

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment_import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment_import_error.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 658239d8-1faa-e133-1543-66de9173430d
+                - 9d2edd39-0cb2-5c26-0c09-655fd471fae9
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:53:59 GMT
+                - Thu, 20 Jul 2023 06:36:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - de854341-ec5b-4615-51ba-76b3949c8ca0
+                - 08004b5e-a46d-4f1f-5348-2cdac56965d0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 769.4028ms
+        duration: 339.2173ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - b9cd2674-b6b4-5f2b-ab11-5c87107c7a44
+                - 4135c960-0f9c-4126-d01a-916f544ffb4f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:01 GMT
+                - Thu, 20 Jul 2023 06:36:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6e5ef717-d3f0-4ae9-630b-4c55ccf69d7b
+                - a2bdc1bd-0e48-497a-6db5-bdcfa340d679
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 421.2068ms
+        duration: 390.8127ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 1af4185f-75cd-0ed6-0a8c-bd541f32cace
+                - a08137a9-519a-73a6-d365-ed8b87a98a14
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:02 GMT
+                - Thu, 20 Jul 2023 06:36:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 175bb652-64da-4552-55e4-c63e9b944d95
+                - 3b58ef6b-3d3c-430b-63cd-2b2d5215375c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 468.9109ms
+        duration: 353.1238ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fd082fe2-8f89-9c68-50ff-d8947fe96422
+                - 8d0aa064-f4f0-f496-78b1-a13ea7bc7b54
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 03 Jul 2023 06:54:02 GMT
+                - Thu, 20 Jul 2023 06:36:40 GMT
             Expires:
                 - "0"
             Location:
@@ -257,12 +257,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1967cbdb-70d9-4460-66f4-3ef0f7a94317
+                - 2cadd396-7f3a-48cc-7721-60d1b6f5ec51
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 196.4016ms
+        duration: 170.537ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +283,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?assign
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fd082fe2-8f89-9c68-50ff-d8947fe96422
+                - 8d0aa064-f4f0-f496-78b1-a13ea7bc7b54
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -306,14 +306,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":3,"active":true,"roleCollections":["Destination Administrator"]}'
+        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":7,"active":true,"roleCollections":["Destination Administrator"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:03 GMT
+                - Thu, 20 Jul 2023 06:36:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fb34f74a-aded-4057-477e-4e36c14a961a
+                - fe217f78-bb09-4014-7366-e5098baaab6d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 511.9154ms
+        duration: 233.9083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - fa7792ac-a276-1221-7f92-aa0225aef175
+                - 3b9c7805-9841-84b9-6e36-a9fc9a0e2dc1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -383,7 +383,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:04 GMT
+                - Thu, 20 Jul 2023 06:36:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -397,12 +397,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 136ef568-5433-44c9-71e6-ddc64f879a9c
+                - 9ea57dc5-1a06-43c6-77ab-03dfc9140ead
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 401.5505ms
+        duration: 337.2898ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -421,9 +421,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 630cb16e-5ff0-55b6-5989-c9246d2afb7b
+                - 0743e2b6-1cb1-3ae0-db6a-6566de7c04e1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -445,7 +445,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:05 GMT
+                - Thu, 20 Jul 2023 06:36:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -459,12 +459,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bbb987b7-9c2c-46de-5c45-e9787a8b6cc4
+                - 5c76d7e5-c2b8-4258-6977-fb6c4bda6b0a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 388.309ms
+        duration: 369.0063ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 00db5a29-8a04-175a-1c78-6062fed6ab4c
+                - 2200744d-6a0b-7a2b-6eea-410f2d02fe0b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -507,7 +507,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:06 GMT
+                - Thu, 20 Jul 2023 06:36:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -521,12 +521,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ecf374a8-6aa3-4ada-6979-b7a7c6b22953
+                - d1eb4b38-2b39-4967-5f16-c7a61a397ca5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 386.951ms
+        duration: 390.1857ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -545,9 +545,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 307c6ad0-ca89-c531-11ae-3150e4a39d2e
+                - fe74c093-98d4-b92b-64e9-a1ed6dc04991
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -569,7 +569,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:07 GMT
+                - Thu, 20 Jul 2023 06:36:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -583,12 +583,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8b61daee-e6f8-4aca-50b0-6b3aadb19b41
+                - 50d2a251-d7f8-4523-7600-3b3c5ed45035
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 396.637ms
+        duration: 369.964ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -607,9 +607,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - ddff7067-d9e8-843f-7b41-d3c19d57a9b2
+                - 486db651-0552-8338-4353-83c6598a3653
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -631,7 +631,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:07 GMT
+                - Thu, 20 Jul 2023 06:36:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -645,12 +645,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e39f2ea4-7aa4-4ac7-5451-cd8a77dc7369
+                - 94711c43-f196-4c5b-5f8b-01890a8bcbf1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 370.9772ms
+        duration: 396.8601ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -669,9 +669,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 4d74b9c8-ce18-6d89-3849-98cab1f445eb
+                - 970be4c5-e793-f091-f1ef-24d1905bc16b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -693,7 +693,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:08 GMT
+                - Thu, 20 Jul 2023 06:36:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -707,12 +707,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2818227b-d71a-4449-6627-003d56ff40ad
+                - 1ed3ea28-e90b-4de2-625b-816cfa9c0ec3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 426.6641ms
+        duration: 460.3044ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -731,9 +731,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a8442ca9-cc9c-a060-6e94-9979f58d939c
+                - 6f10d7a8-1392-e537-bf80-f98d65901325
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -759,7 +759,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 03 Jul 2023 06:54:09 GMT
+                - Thu, 20 Jul 2023 06:36:43 GMT
             Expires:
                 - "0"
             Location:
@@ -783,12 +783,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - eaf68347-5381-4d76-6f39-f6bfec2b118f
+                - 806871cd-b60e-4797-526d-b6e3594f3bbb
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 172.5328ms
+        duration: 175.3816ms
     - id: 12
       request:
         proto: ""
@@ -809,9 +809,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?unassign
             User-Agent:
-                - Terraform/1.5.1 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - a8442ca9-cc9c-a060-6e94-9979f58d939c
+                - 6f10d7a8-1392-e537-bf80-f98d65901325
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -832,14 +832,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":4,"active":true,"roleCollections":[]}'
+        body: '{"id":"0ae20b4c-b46a-4ee7-9e3f-42c0e9a78534","username":"jenny.doe@test.com","email":"jenny.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"sap.default","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":8,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 03 Jul 2023 06:54:09 GMT
+                - Thu, 20 Jul 2023 06:36:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -861,9 +861,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 76a092a1-4c1b-4348-58ff-a8ec3db5a728
+                - eeb6fe2e-1ad1-487c-4df6-1de109b25225
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 241.7676ms
+        duration: 213.3641ms

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment_with_origin.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment_with_origin.yaml
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 959aba2a-8fe3-05be-c5d0-250ae5eaf73b
+                - 85d127a7-a783-b60e-23b9-68341ea4b612
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:07 GMT
+                - Thu, 20 Jul 2023 06:36:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -57,12 +57,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 04ffaf04-ed03-4e59-7da8-a8d03b05cc19
+                - fce69751-9fe9-4d54-4d32-6a9e484c537a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 550.318ms
+        duration: 411.2541ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -81,9 +81,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c1623ca7-7347-7dc5-dc26-df8cafc88e3e
+                - b3009fde-7abc-f10a-ed8f-0e4a3dd042b8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:08 GMT
+                - Thu, 20 Jul 2023 06:36:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -119,12 +119,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e4003d7e-76cc-4556-65ca-eaf78d7c8c7e
+                - eff0fb55-61fe-43ee-7e98-fcbec1fb7f68
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 536.9071ms
+        duration: 379.9925ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -143,9 +143,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 3593f584-767a-c1c1-33bb-7064583c6ef5
+                - 316421b7-9101-02ef-4b96-d025ecfde409
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -167,7 +167,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:09 GMT
+                - Thu, 20 Jul 2023 06:36:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -181,12 +181,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e3cb3aec-1e1d-4f94-531d-3828d601cb52
+                - 555e2a66-3149-4774-526d-08ee425459c8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 546.4344ms
+        duration: 357.1789ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +205,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e1cf4bc3-8f39-038d-3c9d-07c60a357721
+                - a07e7330-792d-09c2-8be1-b6c84606b3ee
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -233,7 +233,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 19 Jun 2023 14:27:10 GMT
+                - Thu, 20 Jul 2023 06:36:35 GMT
             Expires:
                 - "0"
             Location:
@@ -257,12 +257,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 171faf2b-6cde-4ba8-6182-fbae78d65cf5
+                - 63ff22c7-b8f6-4b13-67ba-1c93a49d3158
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 203.0983ms
+        duration: 179.1823ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +283,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?assign
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - e1cf4bc3-8f39-038d-3c9d-07c60a357721
+                - a07e7330-792d-09c2-8be1-b6c84606b3ee
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -306,14 +306,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"20c3ec19-a43d-439d-a9ce-d02cf611f64c","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":1,"active":true,"roleCollections":["Destination Administrator"]}'
+        body: '{"id":"20c3ec19-a43d-439d-a9ce-d02cf611f64c","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":3,"active":true,"roleCollections":["Destination Administrator"]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:10 GMT
+                - Thu, 20 Jul 2023 06:36:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5706a15a-7a8f-4c29-68fe-5294d267a0e1
+                - 6f4ef72b-0d53-4776-50cd-40be85ddbfc5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 307.8861ms
+        duration: 251.7452ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f6983e3a-d961-42b8-21f0-cc87bd29a82f
+                - 0c93a5f1-0eb9-da59-f1da-c547a83dac4f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -383,7 +383,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:11 GMT
+                - Thu, 20 Jul 2023 06:36:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -397,12 +397,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 89c8a6db-16fa-498b-50ff-e3861d889617
+                - 9c62196d-bf5a-4fa0-6ed8-878425cebcd4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 494.718ms
+        duration: 351.6517ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -421,9 +421,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 27b79541-4813-85ce-5f14-74f2c64fb5ff
+                - 092af08f-40c2-af6f-a386-f0832c4cacaf
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -445,7 +445,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:12 GMT
+                - Thu, 20 Jul 2023 06:36:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -459,12 +459,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2a26ea75-bf58-4b45-724f-0c277fc138b0
+                - a27bbdd9-19db-4a70-5287-8fd9b801bb1c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 330.286ms
+        duration: 386.1219ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -483,9 +483,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - caaa6138-8f8e-543f-2309-25e42766f21f
+                - 59d5685d-c283-4eac-778d-9cdfb3ec6f2e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -507,7 +507,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:13 GMT
+                - Thu, 20 Jul 2023 06:36:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -521,12 +521,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d0c97221-34ea-45dc-533c-5efff4018c4e
+                - 938ad503-7549-44c4-5810-0e76ec2f28ff
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 367.4225ms
+        duration: 395.8845ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -545,9 +545,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - f01da16d-54a1-045c-1445-4b7ecbe1e654
+                - 4ef7c06a-be27-dc28-87ef-7f75d23f61d2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -569,7 +569,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:14 GMT
+                - Thu, 20 Jul 2023 06:36:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -583,12 +583,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d32b3e8c-4264-4fea-4b63-0f42d0892d81
+                - f626c46f-6535-4b69-7af3-6fff4186f8c9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 571.999ms
+        duration: 353.4362ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -607,9 +607,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - 017846ae-ee2b-4d63-f480-d1e78b88825b
+                - f3c9fc94-fab6-ec1e-4170-7ba01cdbaa8b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -631,7 +631,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:15 GMT
+                - Thu, 20 Jul 2023 06:36:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -645,12 +645,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2ed7f0e6-5d41-479b-5557-0dee5fa3f720
+                - 7449ec0a-1829-4736-62ac-51c4804d05e8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 387.1258ms
+        duration: 361.8338ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -669,9 +669,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c04e5d99-c66b-2929-7c13-a0b6b05fefae
+                - 28635985-31df-d3b1-77fe-541599552b93
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -697,7 +697,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 19 Jun 2023 14:27:16 GMT
+                - Thu, 20 Jul 2023 06:36:38 GMT
             Expires:
                 - "0"
             Location:
@@ -721,12 +721,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5522e32b-23d1-4b66-74cc-546313c2392d
+                - 0ab3e9a3-3287-424e-62ca-ece5a12daa84
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 231.7175ms
+        duration: 201.3505ms
     - id: 11
       request:
         proto: ""
@@ -747,9 +747,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/security/role-collection?unassign
             User-Agent:
-                - Terraform/1.4.6 terraform-provider-btp/dev
+                - Terraform/1.5.2 terraform-provider-btp/dev
             X-Correlationid:
-                - c04e5d99-c66b-2929-7c13-a0b6b05fefae
+                - 28635985-31df-d3b1-77fe-541599552b93
             X-Cpcli-Customidp:
                 - ""
             X-Cpcli-Format:
@@ -770,14 +770,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"20c3ec19-a43d-439d-a9ce-d02cf611f64c","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":2,"active":true,"roleCollections":[]}'
+        body: '{"id":"20c3ec19-a43d-439d-a9ce-d02cf611f64c","username":"john.doe@test.com","email":"john.doe@test.com","givenName":"unknown","familyName":"unknown","origin":"terraformint-platform","zoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","verified":false,"legacyVerificationBehavior":false,"passwordChangeRequired":false,"version":4,"active":true,"roleCollections":[]}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 19 Jun 2023 14:27:16 GMT
+                - Thu, 20 Jul 2023 06:36:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -799,9 +799,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c2fcfccf-cab0-469a-6b42-6859ccdb3d46
+                - 10d5abda-b12f-4aed-773a-8cea3fccddf3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 247.8002ms
+        duration: 198.6489ms

--- a/internal/provider/resource_directory_role.go
+++ b/internal/provider/resource_directory_role.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -50,9 +52,12 @@ __Further documentation:__
 				},
 			},
 			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `directory_id` attribute instead",
-				MarkdownDescription: "The ID of the directory.",
+				DeprecationMessage:  "Use the `directory_id`, `name`, `app_id` and `role_template_name` attributes instead",
+				MarkdownDescription: "The combined unique ID of the role.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the role.",
@@ -135,6 +140,12 @@ func (rs *directoryRoleResource) Read(ctx context.Context, req resource.ReadRequ
 	updatedState, diags := directoryRoleFromValue(ctx, cliRes)
 	updatedState.DirectoryId = state.DirectoryId
 	updatedState.Id = state.DirectoryId
+
+	if updatedState.Id.IsNull() || updatedState.Id.IsUnknown() {
+		// Setting ID of state - required by hashicorps terraform plugin testing framework for Import. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+		updatedState.Id = types.StringValue(fmt.Sprintf("%s,%s,%s,%s", state.DirectoryId.ValueString(), state.Name.ValueString(), state.RoleTemplateName.ValueString(), state.RoleTemplateAppId.ValueString()))
+	}
+
 	resp.Diagnostics.Append(diags...)
 
 	diags = resp.State.Set(ctx, &updatedState)
@@ -163,7 +174,10 @@ func (rs *directoryRoleResource) Create(ctx context.Context, req resource.Create
 
 	updatedPlan, diags := directoryRoleFromValue(ctx, cliRes)
 	updatedPlan.DirectoryId = plan.DirectoryId
-	updatedPlan.Id = plan.DirectoryId
+
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	updatedPlan.Id = types.StringValue(fmt.Sprintf("%s,%s,%s,%s", plan.DirectoryId.ValueString(), plan.Name.ValueString(), plan.RoleTemplateName.ValueString(), plan.RoleTemplateAppId.ValueString()))
+
 	resp.Diagnostics.Append(diags...)
 
 	diags = resp.State.Set(ctx, &updatedPlan)

--- a/internal/provider/resource_directory_role.go
+++ b/internal/provider/resource_directory_role.go
@@ -51,7 +51,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id`, `name`, `app_id` and `role_template_name` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role.",
 				Computed:            true,

--- a/internal/provider/resource_directory_role.go
+++ b/internal/provider/resource_directory_role.go
@@ -52,7 +52,7 @@ __Further documentation:__
 				},
 			},
 			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `directory_id`, `name`, `app_id` and `role_template_name` attributes instead",
+				DeprecationMessage:  "Use the `directory_id`, `name`, `role_template_name` and `app_id` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/resource_directory_role_collection.go
+++ b/internal/provider/resource_directory_role_collection.go
@@ -77,7 +77,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` and `name` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role collection as used for import operations.",
 				Computed:            true,

--- a/internal/provider/resource_directory_role_collection.go
+++ b/internal/provider/resource_directory_role_collection.go
@@ -3,10 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/SAP/terraform-provider-btp/internal/tfutils"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -76,7 +77,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` attribute instead",
 				MarkdownDescription: "The ID of the directory.",
 				Computed:            true,

--- a/internal/provider/resource_directory_role_collection.go
+++ b/internal/provider/resource_directory_role_collection.go
@@ -78,8 +78,8 @@ __Further documentation:__
 				},
 			},
 			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `directory_id` attribute instead",
-				MarkdownDescription: "The ID of the directory.",
+				DeprecationMessage:  "Use the `directory_id` and `name` attributes instead",
+				MarkdownDescription: "The combined unique ID of the role collection as used for import operations.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -138,8 +138,10 @@ func (rs *directoryRoleCollectionType) Read(ctx context.Context, req resource.Re
 	state.Name = types.StringValue(cliRes.Name)
 	state.Description = types.StringValue(cliRes.Description)
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-	state.Id = types.StringValue(fmt.Sprintf("%s,%s", state.DirectoryId.ValueString(), state.Name))
+	if state.Id.IsNull() || state.Id.IsUnknown() {
+		// Setting ID of state - required by hashicorps terraform plugin testing framework for Import. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+		state.Id = types.StringValue(fmt.Sprintf("%s,%s", state.DirectoryId.ValueString(), cliRes.Name))
+	}
 
 	state.Roles = []directoryRoleCollectionRoleRefType{}
 	for _, role := range cliRes.RoleReferences {
@@ -179,7 +181,7 @@ func (rs *directoryRoleCollectionType) Create(ctx context.Context, req resource.
 	plan.Name = types.StringValue(cliRes.Name)
 	plan.Description = types.StringValue(cliRes.Description)
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
 	plan.Id = types.StringValue(fmt.Sprintf("%s,%s", plan.DirectoryId.ValueString(), cliRes.Name))
 
 	diags = resp.State.Set(ctx, &plan)

--- a/internal/provider/resource_directory_role_collection_assignment.go
+++ b/internal/provider/resource_directory_role_collection_assignment.go
@@ -71,7 +71,7 @@ func (rs *directoryRoleCollectionAssignmentResource) Schema(_ context.Context, _
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `directory_id` and `role_collection_name` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role collection.",
 				Computed:            true,

--- a/internal/provider/resource_directory_role_collection_assignment.go
+++ b/internal/provider/resource_directory_role_collection_assignment.go
@@ -72,9 +72,12 @@ func (rs *directoryRoleCollectionAssignmentResource) Schema(_ context.Context, _
 				},
 			},
 			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `role_collection_name` field instead",
-				MarkdownDescription: "The ID of the role collection",
+				DeprecationMessage:  "Use the `directory_id` and `role_collection_name` attributes instead",
+				MarkdownDescription: "The combined unique ID of the role collection.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				MarkdownDescription: "The username of the user to assign.",
@@ -120,9 +123,6 @@ func (rs *directoryRoleCollectionAssignmentResource) Read(ctx context.Context, r
 		return
 	}
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-	state.Id = types.StringValue(fmt.Sprintf("%s,%s,%s", state.DirectoryId.ValueString(), state.RoleCollectionName.ValueString(), state.Username.ValueString()))
-
 	// This resource is not supposed to be read by definition. However nothing the user can do about that, hence no error message is raised via resp.Diagnostics.
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -150,7 +150,7 @@ func (rs *directoryRoleCollectionAssignmentResource) Create(ctx context.Context,
 		return
 	}
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
 	plan.Id = types.StringValue(fmt.Sprintf("%s,%s,%s", plan.DirectoryId.ValueString(), plan.RoleCollectionName.ValueString(), plan.Username.ValueString()))
 
 	diags = resp.State.Set(ctx, &plan)

--- a/internal/provider/resource_globalaccount_role_collection.go
+++ b/internal/provider/resource_globalaccount_role_collection.go
@@ -74,7 +74,7 @@ __Further documentation:__
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `name` attribute instead",
 				MarkdownDescription: "The ID of the role collection.",
 				Computed:            true,

--- a/internal/provider/resource_globalaccount_role_collection.go
+++ b/internal/provider/resource_globalaccount_role_collection.go
@@ -3,10 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/SAP/terraform-provider-btp/internal/tfutils"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -128,8 +129,10 @@ func (rs *globalaccountRoleCollectionResource) Read(ctx context.Context, req res
 	state.Name = types.StringValue(cliRes.Name)
 	state.Description = types.StringValue(cliRes.Description)
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-	state.Id = state.Name
+	if state.Id.IsNull() || state.Id.IsUnknown() {
+		// Setting ID of state - required by hashicorps terraform plugin testing framework for Import. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+		state.Id = state.Name
+	}
 
 	state.Roles = []globalaccountRoleCollectionRoleRefType{}
 	for _, role := range cliRes.RoleReferences {
@@ -160,7 +163,7 @@ func (rs *globalaccountRoleCollectionResource) Create(ctx context.Context, req r
 
 	plan.Name = types.StringValue(cliRes.Name)
 	plan.Description = types.StringValue(cliRes.Description)
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
 	plan.Id = types.StringValue(cliRes.Name)
 
 	for _, role := range plan.Roles {

--- a/internal/provider/resource_globalaccount_role_collection_assignment.go
+++ b/internal/provider/resource_globalaccount_role_collection_assignment.go
@@ -59,7 +59,7 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Schema(_ context.Contex
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `role_collection_name` attribute instead",
 				MarkdownDescription: "The combined unique ID of the role collection.",
 				Computed:            true,

--- a/internal/provider/resource_globalaccount_role_collection_assignment.go
+++ b/internal/provider/resource_globalaccount_role_collection_assignment.go
@@ -60,9 +60,12 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Schema(_ context.Contex
 				},
 			},
 			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `role_collection_name` field instead",
-				MarkdownDescription: "The ID of the role collection",
+				DeprecationMessage:  "Use the `role_collection_name` attribute instead",
+				MarkdownDescription: "The combined unique ID of the role collection.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				MarkdownDescription: "The name of the user to assign.",
@@ -108,9 +111,6 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Read(ctx context.Contex
 		return
 	}
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-	state.Id = types.StringValue(fmt.Sprintf("%s,%s", state.RoleCollectionName.ValueString(), state.Username.ValueString()))
-
 	// This resource is not supposed to be read by definition. However nothing the user can do about that, hence no error message is raised via resp.Diagnostics.
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -138,7 +138,7 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Create(ctx context.Cont
 		return
 	}
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
 	plan.Id = types.StringValue(fmt.Sprintf("%s,%s", plan.RoleCollectionName.ValueString(), plan.Username.ValueString()))
 
 	diags = resp.State.Set(ctx, &plan)

--- a/internal/provider/resource_subaccount_role.go
+++ b/internal/provider/resource_subaccount_role.go
@@ -51,7 +51,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id`, `name`, `app_id` and `role_template_name` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role.",
 				Computed:            true,

--- a/internal/provider/resource_subaccount_role.go
+++ b/internal/provider/resource_subaccount_role.go
@@ -52,7 +52,7 @@ __Further documentation:__
 				},
 			},
 			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `subaccount_id`, `name`, `app_id` and `role_template_name` attributes instead",
+				DeprecationMessage:  "Use the `subaccount_id`, `name`, `role_template_name` and `app_id` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/resource_subaccount_role.go
+++ b/internal/provider/resource_subaccount_role.go
@@ -8,7 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/SAP/terraform-provider-btp/internal/btpcli"
 	"github.com/SAP/terraform-provider-btp/internal/validation/uuidvalidator"
@@ -46,6 +49,14 @@ __Further documentation:__
 				Optional:            true,
 				Validators: []validator.String{
 					uuidvalidator.ValidUUID(),
+				},
+			},
+			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+				DeprecationMessage:  "Use the `subaccount_id`, `name`, `app_id` and `role_template_name` attributes instead",
+				MarkdownDescription: "The combined unique ID of the role.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
@@ -96,6 +107,12 @@ func (rs *subaccountRoleResource) Read(ctx context.Context, req resource.ReadReq
 
 	updatedState, diags := subaccountRoleFromValue(ctx, cliRes)
 	updatedState.SubaccountId = state.SubaccountId
+
+	if updatedState.Id.IsNull() || updatedState.Id.IsUnknown() {
+		// Setting ID of state - required by hashicorps terraform plugin testing framework for Import. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+		updatedState.Id = types.StringValue(fmt.Sprintf("%s,%s,%s,%s", state.SubaccountId.ValueString(), state.Name.ValueString(), state.RoleTemplateName.ValueString(), state.RoleTemplateAppId.ValueString()))
+	}
+
 	resp.Diagnostics.Append(diags...)
 
 	diags = resp.State.Set(ctx, &updatedState)
@@ -123,6 +140,10 @@ func (rs *subaccountRoleResource) Create(ctx context.Context, req resource.Creat
 
 	updatedPlan, diags := subaccountRoleFromValue(ctx, cliRes)
 	updatedPlan.SubaccountId = plan.SubaccountId
+
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	updatedPlan.Id = types.StringValue(fmt.Sprintf("%s,%s,%s,%s", plan.SubaccountId.ValueString(), plan.Name.ValueString(), plan.RoleTemplateName.ValueString(), plan.RoleTemplateAppId.ValueString()))
+
 	resp.Diagnostics.Append(diags...)
 
 	diags = resp.State.Set(ctx, &updatedPlan)

--- a/internal/provider/resource_subaccount_role_collection.go
+++ b/internal/provider/resource_subaccount_role_collection.go
@@ -76,7 +76,7 @@ __Further documentation:__
 					uuidvalidator.ValidUUID(),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` and `name` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role collection as used for import operations.",
 				Computed:            true,

--- a/internal/provider/resource_subaccount_role_collection_assignment.go
+++ b/internal/provider/resource_subaccount_role_collection_assignment.go
@@ -72,9 +72,12 @@ func (rs *subaccountRoleCollectionAssignmentResource) Schema(_ context.Context, 
 				},
 			},
 			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
-				DeprecationMessage:  "Use the `role_collection_name` field instead",
-				MarkdownDescription: "The ID of the role collection",
+				DeprecationMessage:  "Use the `subaccount_id` and `role_collection_name` attributes instead",
+				MarkdownDescription: "The combined unique ID of the role collection.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_name": schema.StringAttribute{
 				MarkdownDescription: "The username of the user to assign.",
@@ -120,9 +123,6 @@ func (rs *subaccountRoleCollectionAssignmentResource) Read(ctx context.Context, 
 		return
 	}
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
-	state.Id = types.StringValue(fmt.Sprintf("%s,%s,%s", state.SubaccountId.ValueString(), state.RoleCollectionName.ValueString(), state.Username.ValueString()))
-
 	// This resource is not supposed to be read by definition. However nothing the user can do about that, hence no error message is raised via resp.Diagnostics.
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -150,7 +150,7 @@ func (rs *subaccountRoleCollectionAssignmentResource) Create(ctx context.Context
 		return
 	}
 
-	// Setting ID of state - required by hashicorps terraform plugin testing framework for Import . See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
+	// Setting ID of state - required by hashicorps terraform plugin testing framework for Create. See issue https://github.com/hashicorp/terraform-plugin-testing/issues/84
 	plan.Id = types.StringValue(fmt.Sprintf("%s,%s,%s", plan.SubaccountId.ValueString(), plan.RoleCollectionName.ValueString(), plan.Username.ValueString()))
 
 	diags = resp.State.Set(ctx, &plan)

--- a/internal/provider/resource_subaccount_role_collection_assignment.go
+++ b/internal/provider/resource_subaccount_role_collection_assignment.go
@@ -71,7 +71,7 @@ func (rs *subaccountRoleCollectionAssignmentResource) Schema(_ context.Context, 
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
-			"id": schema.StringAttribute{ // required hashicorps terraform plugin testing framework
+			"id": schema.StringAttribute{ // required by hashicorps terraform plugin testing framework
 				DeprecationMessage:  "Use the `subaccount_id` and `role_collection_name` attributes instead",
 				MarkdownDescription: "The combined unique ID of the role collection.",
 				Computed:            true,

--- a/internal/provider/type_subaccount_role.go
+++ b/internal/provider/type_subaccount_role.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/SAP/terraform-provider-btp/internal/btpcli/types/xsuaa_authz"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -9,6 +10,7 @@ import (
 
 type subaccountRoleType struct {
 	SubaccountId      types.String `tfsdk:"subaccount_id"`
+	Id                types.String `tfsdk:"id"`
 	Name              types.String `tfsdk:"name"`
 	RoleTemplateAppId types.String `tfsdk:"app_id"`
 	RoleTemplateName  types.String `tfsdk:"role_template_name"`


### PR DESCRIPTION
## Purpose

This PR contains the changes to have an aligned setup of the **artificial** `ID` field in resources and data sources that is needed for the Terraform plugin test framework. The changes comprise:

* Mark the ID field as "computed"
* Align the "DeprecationMessage" field
* Align the "MarkdownDescription"
* Use `stringplanmodifier.UseStateForUnknown()` in schema
* Regenerate documentation
* re-record test fixtures for resources

Closes #292 

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code

```
go test ./...
```

## What to Check

Verify that the following are valid

* All tests are executed successfully

## Other Information

Further information is available here: <https://github.com/hashicorp/terraform-plugin-testing/issues/84>
