### PR TITLE
docs: align error message punctuation to Terraform best practices

### DIFF
--- a/internal/provider/datasource_whoami.go
+++ b/internal/provider/datasource_whoami.go
@@ -69,7 +69,7 @@ func (gen *whoamiDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	user := gen.client.GetLoggedInUser()
 	if user == nil {
-		resp.Diagnostics.AddError("No user found", "")
+		resp.Diagnostics.AddError("No User Found", "")
 		return
 	}
 

--- a/internal/provider/resource_directory_role_collection_assignment.go
+++ b/internal/provider/resource_directory_role_collection_assignment.go
@@ -199,7 +199,7 @@ func (rs *directoryRoleCollectionAssignmentResource) Delete(ctx context.Context,
 
 func (rs *directoryRoleCollectionAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.AddError(
-		"Import not supported",
+		"Import Not Supported",
 		"Import is not supported for this resource. Use the resource directory_role_collection instead.",
 	)
 }

--- a/internal/provider/resource_directory_role_collection_assignment_test.go
+++ b/internal/provider/resource_directory_role_collection_assignment_test.go
@@ -68,7 +68,7 @@ func TestResourceDirectoryRoleCollectionAssignment(t *testing.T) {
 					ImportStateId:     "05368777-4934-41e8-9f3c-6ec5f4d564b9",
 					ImportState:       true,
 					ImportStateVerify: true,
-					ExpectError:       regexp.MustCompile(`Import not supported`),
+					ExpectError:       regexp.MustCompile(`Import Not Supported`),
 				},
 			},
 		})

--- a/internal/provider/resource_globalaccount_role_collection_assignment.go
+++ b/internal/provider/resource_globalaccount_role_collection_assignment.go
@@ -188,7 +188,7 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Delete(ctx context.Cont
 
 func (rs *globalaccountRoleCollectionAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.AddError(
-		"Import not supported",
+		"Import Not Supported",
 		"Import is not supported for this resource. Use the resource globalaccount_role_collection instead.",
 	)
 }

--- a/internal/provider/resource_globalaccount_role_collection_assignment_test.go
+++ b/internal/provider/resource_globalaccount_role_collection_assignment_test.go
@@ -66,7 +66,7 @@ func TestResourceGlobalaccountRoleCollectionAssignment(t *testing.T) {
 					ImportStateId:     "anyID",
 					ImportState:       true,
 					ImportStateVerify: true,
-					ExpectError:       regexp.MustCompile(`Import not supported`),
+					ExpectError:       regexp.MustCompile(`Import Not Supported`),
 				},
 			},
 		})

--- a/internal/provider/resource_subaccount_role_collection_assignment.go
+++ b/internal/provider/resource_subaccount_role_collection_assignment.go
@@ -200,7 +200,7 @@ func (rs *subaccountRoleCollectionAssignmentResource) Delete(ctx context.Context
 
 func (rs *subaccountRoleCollectionAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.AddError(
-		"Import not supported",
+		"Import Not Supported",
 		"Import is not supported for this resource. Use the resource subaccount_role_collection instead.",
 	)
 }

--- a/internal/provider/resource_subaccount_role_collection_assignment_test.go
+++ b/internal/provider/resource_subaccount_role_collection_assignment_test.go
@@ -68,7 +68,7 @@ func TestResourceRolCollectionAssignment(t *testing.T) {
 					ImportStateId:     "ef23ace8-6ade-4d78-9c1f-8df729548bbf",
 					ImportState:       true,
 					ImportStateVerify: true,
-					ExpectError:       regexp.MustCompile(`Import not supported`),
+					ExpectError:       regexp.MustCompile(`Import Not Supported`),
 				},
 			},
 		})


### PR DESCRIPTION
## Purpose

* Alignment of error messages according to Hashicorp best practices (see <https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#creating-diagnostics>)

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

n/a

## What to Check

Verify that the following are valid:

n/a

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
