### PR TITLE
chore: add stale handling for issues and prs

### DIFF
--- a/.github/workflows/cleanup-action-caches.yml
+++ b/.github/workflows/cleanup-action-caches.yml
@@ -1,4 +1,4 @@
-name: cleanup gh actions caches
+name: Cleanup GH Actions Caches
 on:
   pull_request:
     types:

--- a/.github/workflows/stale-handling.yml
+++ b/.github/workflows/stale-handling.yml
@@ -1,0 +1,22 @@
+name: Close Stale Issues and PRs
+on:
+  schedule:
+    - cron: '30 2 * * *'
+
+permissions:
+    issues: write
+    pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 15 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This pull request is stale because it has been open 15 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 15
+          days-before-close: 5
+          any-of-issue-labels: 'needs-author-feedback'


### PR DESCRIPTION
## Purpose

* Adds handing of stale issues via GH Actions

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: improvement of setup
```

## How to Test

n/a

## What to Check

n/a

## Other Information

Also aligned the title of the GH action for cache cleanups.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
