### PR TITLE
fix: error handling of entitlement polling

### DIFF
--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -202,7 +202,7 @@ func (rs *subaccountEntitlementResource) createOrUpdate(ctx context.Context, req
 			if entitlement == nil {
 				return nil, cis_entitlements.StateProcessing, nil
 			}
-
+			// No error returned even if operation failed
 			if entitlement.Assignment.EntityState == cis_entitlements.StateProcessingFailed {
 				return *entitlement, entitlement.Assignment.EntityState, errors.New("undefined API error during entitlement processing")
 			}
@@ -263,6 +263,7 @@ func (rs *subaccountEntitlementResource) Delete(ctx context.Context, req resourc
 				return entitlement, cis_entitlements.StateProcessingFailed, err
 			}
 
+			// No error returned even if operation failed
 			if entitlement.Assignment.EntityState == cis_entitlements.StateProcessingFailed {
 				return *entitlement, entitlement.Assignment.EntityState, errors.New("undefined API error during entitlement processing")
 			}


### PR DESCRIPTION
## Purpose

* This PR fixes the handling of error scenarios when polling for a state change for the resource entitlement.
* Error that occurs looks basically like this if the entitlement fails:
   
   ```bash
   When applying changes to btp_subaccount_entitlement.entitlement-quotas["xxx"], 
    provider
    │ "provider["registry.terraform.io/sap/btp"]" produced an unexpected new value: .amount: was cty.NumberIntVal(1), but now  
    │ cty.NumberIntVal(0).
   ```

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

see also PR #352


## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
