### PR TITLE
fix: exchange refresh token

### DIFF
--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -105,7 +105,8 @@ func (v2 *v2Client) doRequest(ctx context.Context, method string, endpoint strin
 
 	res, err := v2.httpClient.Do(req)
 
-	if v2.session != nil && err == nil {
+	if v2.session != nil && err == nil && res.Header.Get(HeaderCLIReplacementRefreshToken) != "" {
+		// Only update the refresh token if the request was successful and the server returned a replacement refresh token
 		v2.session.RefreshToken = res.Header.Get(HeaderCLIReplacementRefreshToken)
 	}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Due to changes in the BTP CLI server the replacement refresh token can be empty. This fix ensures that the refresh token used for consecutive calls is only exchanged with the replacement refresh token if the later is not empty
* Fixes #379 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
