### PR TITLE
fix: env instance parameters classification

### DIFF
--- a/docs/resources/subaccount_environment_instance.md
+++ b/docs/resources/subaccount_environment_instance.md
@@ -59,6 +59,7 @@ resource "btp_subaccount_environment_instance" "cloudfoundry" {
 
 - `environment_type` (String) The type of the environment instance that is used.
 - `name` (String) The name of the environment instance.
+- `parameters` (String) The configuration parameters for the environment instance.
 - `plan_name` (String) The name of the service plan for the environment instance in the corresponding service broker's catalog.
 - `service_name` (String) The name of the service for the environment instance in the corresponding service broker's catalog.
 - `subaccount_id` (String) The ID of the subaccount.
@@ -66,7 +67,6 @@ resource "btp_subaccount_environment_instance" "cloudfoundry" {
 ### Optional
 
 - `landscape_label` (String) The name of the landscape within the logged in region on which the environment instance is created.
-- `parameters` (String) The configuration parameters for the environment instance.
 
 ### Read-Only
 

--- a/internal/provider/resource_subaccount_environment_instance.go
+++ b/internal/provider/resource_subaccount_environment_instance.go
@@ -90,6 +90,10 @@ __Further documentation:__
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"parameters": schema.StringAttribute{
+				MarkdownDescription: "The configuration parameters for the environment instance.",
+				Required:            true,
+			},
 			"landscape_label": schema.StringAttribute{
 				MarkdownDescription: "The name of the landscape within the logged in region on which the environment instance is created.",
 				Optional:            true,
@@ -97,11 +101,6 @@ __Further documentation:__
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-			},
-			"parameters": schema.StringAttribute{
-				MarkdownDescription: "The configuration parameters for the environment instance.",
-				Optional:            true,
-				Computed:            true,
 			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the environment instance.",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The `parameters` parameter of the resource `subaccount_environment_instance` is changed to required as for Kyma and Cloud Foundry the corresponding JSON object must be provided to successfully create an enviroment instance.
* Fixes #378 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
