### PR TITLE
fix: extend timeout for service instance and env instance

### DIFF
--- a/internal/provider/resource_subaccount_environment_instance.go
+++ b/internal/provider/resource_subaccount_environment_instance.go
@@ -259,7 +259,7 @@ func (rs *subaccountEnvironmentInstanceResource) Create(ctx context.Context, req
 
 			return subRes, subRes.State, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
@@ -308,7 +308,7 @@ func (rs *subaccountEnvironmentInstanceResource) Update(ctx context.Context, req
 
 			return subRes, subRes.State, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
@@ -357,7 +357,7 @@ func (rs *subaccountEnvironmentInstanceResource) Delete(ctx context.Context, req
 
 			return subRes, subRes.State, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}

--- a/internal/provider/resource_subaccount_service_instance.go
+++ b/internal/provider/resource_subaccount_service_instance.go
@@ -205,7 +205,7 @@ func (rs *subaccountServiceInstanceResource) Create(ctx context.Context, req res
 
 			return subRes, subRes.LastOperation.State, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
@@ -285,7 +285,7 @@ func (rs *subaccountServiceInstanceResource) Update(ctx context.Context, req res
 
 			return subRes, subRes.LastOperation.State, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
@@ -338,7 +338,7 @@ func (rs *subaccountServiceInstanceResource) Delete(ctx context.Context, req res
 
 			return subRes, subRes.LastOperation.State, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}


### PR DESCRIPTION
## Purpose

* This PR extends the timeouts for the creation of services instances and environment instances to 60 minutes
* This is a temporal workaround. The solution will be provided as described in #11 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: workaround for timeout issue with env instances
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
