### PR TITLE
fix: workaround for service instance creation

### DIFF
--- a/internal/btpcli/facade_services_instance.go
+++ b/internal/btpcli/facade_services_instance.go
@@ -67,7 +67,18 @@ func (f servicesInstanceFacade) Create(ctx context.Context, args *ServiceInstanc
 		return servicemanager.ServiceInstanceResponseObject{}, CommandResponse{}, err
 	}
 
-	return doExecute[servicemanager.ServiceInstanceResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
+	// return doExecute[servicemanager.ServiceInstanceResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
+	serviceInstanceResponseObject, cmdRes, err := doExecute[servicemanager.ServiceInstanceResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
+
+	if cmdRes.StatusCode == 202 {
+		//TODO workaround for NGPBUG-350117 => needs to be structured after fix
+		return f.GetByName(ctx, args.Subaccount, args.Name)
+	} else if err != nil {
+		return serviceInstanceResponseObject, cmdRes, err
+	} else {
+		err = fmt.Errorf("the backend responded with an unknown error: %d", cmdRes.StatusCode)
+		return serviceInstanceResponseObject, cmdRes, err
+	}
 }
 
 type ServiceInstanceUpdateInput struct {

--- a/internal/btpcli/facade_services_instance.go
+++ b/internal/btpcli/facade_services_instance.go
@@ -70,14 +70,16 @@ func (f servicesInstanceFacade) Create(ctx context.Context, args *ServiceInstanc
 	// return doExecute[servicemanager.ServiceInstanceResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
 	serviceInstanceResponseObject, cmdRes, err := doExecute[servicemanager.ServiceInstanceResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
 
-	if cmdRes.StatusCode == 202 {
-		//TODO workaround for NGPBUG-350117 => needs to be structured after fix
+	//TODO workaround for NGPBUG-350117 => needs to be structured after fix
+	if cmdRes.StatusCode == 201 {
+		return serviceInstanceResponseObject, cmdRes, err
+	} else if cmdRes.StatusCode == 202 {
 		return f.GetByName(ctx, args.Subaccount, args.Name)
 	} else if err != nil {
-		return serviceInstanceResponseObject, cmdRes, err
+		return servicemanager.ServiceInstanceResponseObject{}, cmdRes, err
 	} else {
 		err = fmt.Errorf("the backend responded with an unknown error: %d", cmdRes.StatusCode)
-		return serviceInstanceResponseObject, cmdRes, err
+		return servicemanager.ServiceInstanceResponseObject{}, cmdRes, err
 	}
 }
 

--- a/internal/provider/fixtures/resource_subaccount_service_instance_import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance_import_error.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - bef488c3-c5c6-a3c7-900f-5783038fd45d
+                - 450d61ea-871d-813a-bdd2-ec5927a11c19
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"2857cc05-0ae9-4798-8bef-c288faae4fe8","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:38 GMT
+                - Thu, 24 Aug 2023 08:30:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -54,21 +54,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 65bfee78-5ac9-42c2-72c2-cbc87c92ac3b
+                - c931415e-8312-4f5f-54d5-c88a3adc28e1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 328.52712ms
+        duration: 518.1979ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 94a569ec-d222-198e-1778-0739683d301a
+                - 93d32126-7997-3db3-bbbc-0e41fda95cf8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"5604d83e-58ed-43d6-9628-7d2d0d11ed30","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:39 GMT
+                - Thu, 24 Aug 2023 08:30:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -116,21 +118,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dc8a0a0e-6d73-4c95-5e78-19eefdb7e406
+                - 56fc9e3d-acea-40e6-5e34-7b574e7c9409
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 332.970192ms
+        duration: 745.4642ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - cb4c63d4-cf0f-db48-bcbc-6dfc7271d279
+                - 2b33bc77-6a07-7b96-b55b-c37896cd2f62
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"5f5b62fb-e232-48b9-96e2-28f7de9e1daa","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:39 GMT
+                - Thu, 24 Aug 2023 08:30:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -178,15 +182,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e3da780e-ced8-439f-4d19-33acc89d5c8b
+                - 2fb9b7b9-78ec-49d7-657f-5dde1e71b6b2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 251.328344ms
+        duration: 451.3851ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +211,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 94ae7ea2-2ecf-292e-2577-7e5cdc7546ee
+                - 3ef9e876-2e21-579b-8b10-5c0c8960418a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -233,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:39 GMT
+                - Thu, 24 Aug 2023 08:30:11 GMT
             Expires:
                 - "0"
             Location:
@@ -246,10 +252,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -257,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2834861a-d6b8-4e2e-57c0-d0e09f715827
+                - 1630c898-75c0-4329-564b-019a131d90ff
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 325.12295ms
+        duration: 126.2206ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +285,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?create
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 94ae7ea2-2ecf-292e-2577-7e5cdc7546ee
+                - 3ef9e876-2e21-579b-8b10-5c0c8960418a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -306,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","ready":true,"last_operation":{"id":"088546d6-df43-461c-a1f4-52414863f8ee","ready":true,"type":"create","state":"succeeded","resource_id":"88a077e5-f462-4535-9e33-dfddeae66eb8","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"94ae7ea2-2ecf-292e-2577-7e5cdc7546ee","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:40.032478Z","updated_at":"2023-08-01T14:12:40.321361Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","crm_customer_id":"","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","region":"cf-eu12","platform":"sapcp","origin":"sapcp","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:12:40.032476Z","updated_at":"2023-08-01T14:12:40.316400781Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5","username":"","password":""}'
+        body: '{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","ready":true,"last_operation":{"id":"d2759c20-638f-43db-9fe3-885617c5f1b6","ready":true,"type":"create","state":"succeeded","resource_id":"b920f17d-2e67-474d-9b06-aeec7481ff58","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"3ef9e876-2e21-579b-8b10-5c0c8960418a","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:30:12.017086Z","updated_at":"2023-08-24T08:30:12.323984Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","region":"cf-eu12","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:30:12.017082Z","updated_at":"2023-08-24T08:30:12.318515601Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5","username":"","password":""}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:40 GMT
+                - Thu, 24 Aug 2023 08:30:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +337,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 01a347d2-0f8a-4a57-564f-e725043e83c4
+                - ff85bd6e-8faa-44ec-7fd1-c67e7087083f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 437.792001ms
+        duration: 597.4907ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -353,15 +355,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 22846cef-7b1b-a7de-67d5-835db8c69154
+                - 1f9da101-5b77-4c0e-bf5d-ce68f31d0bd7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -387,7 +389,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:45 GMT
+                - Thu, 24 Aug 2023 08:30:17 GMT
             Expires:
                 - "0"
             Location:
@@ -400,10 +402,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -411,12 +409,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - bf31c8c7-7506-4254-4ca3-972a03fb1608
+                - 4015fd06-8d50-4652-4d8c-b5723d1df891
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 218.223641ms
+        duration: 115.0695ms
     - id: 6
       request:
         proto: ""
@@ -429,7 +427,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -437,9 +435,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 22846cef-7b1b-a7de-67d5-835db8c69154
+                - 1f9da101-5b77-4c0e-bf5d-ce68f31d0bd7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -460,14 +458,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","ready":true,"last_operation":{"id":"088546d6-df43-461c-a1f4-52414863f8ee","ready":true,"type":"create","state":"succeeded","resource_id":"88a077e5-f462-4535-9e33-dfddeae66eb8","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"94ae7ea2-2ecf-292e-2577-7e5cdc7546ee","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:40.032478Z","updated_at":"2023-08-01T14:12:40.321361Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","crm_customer_id":"","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","region":"cf-eu12","platform":"sapcp","origin":"sapcp","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:12:40.032476Z","updated_at":"2023-08-01T14:12:40.316401Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","ready":true,"last_operation":{"id":"d2759c20-638f-43db-9fe3-885617c5f1b6","ready":true,"type":"create","state":"succeeded","resource_id":"b920f17d-2e67-474d-9b06-aeec7481ff58","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"3ef9e876-2e21-579b-8b10-5c0c8960418a","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:30:12.017086Z","updated_at":"2023-08-24T08:30:12.323984Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","region":"cf-eu12","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:30:12.017082Z","updated_at":"2023-08-24T08:30:12.318516Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:45 GMT
+                - Thu, 24 Aug 2023 08:30:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -489,18 +487,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 58b6799c-46df-497e-5b36-f7cdaacdcd86
+                - 371a5e89-e061-4289-5caa-f295805e91d7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 99.722508ms
+        duration: 103.9298ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -513,9 +511,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 4038ef3b-bd4d-718a-c0bc-1c7046ab1588
+                - 9a92400b-07a3-b68f-468d-e37613f5ea7c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -526,18 +524,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"9747ced4-ff0e-40ad-815c-2347afb06328","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:46 GMT
+                - Thu, 24 Aug 2023 08:30:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -548,21 +546,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7faf5d3d-012d-4d62-7ebf-13f923385f9b
+                - d9992687-b127-4025-4fb9-0100e4a46454
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 291.575405ms
+        duration: 385.5655ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -575,9 +575,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 75bfd21e-f92b-ee72-d7db-152cab8de22f
+                - 1c325bab-8081-4db9-5068-54e10e37a47b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -588,18 +588,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"f47ed94d-f949-4f1b-b8cf-f35878c7f698","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:46 GMT
+                - Thu, 24 Aug 2023 08:30:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -610,15 +610,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9472cb0a-f225-4b04-5431-9312dbaa1b40
+                - 4f696643-ace9-435c-51ca-f229c54e6049
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 251.179377ms
+        duration: 410.1388ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -631,15 +633,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - fe22dea4-f49e-a068-78ce-c2167dcdcf7c
+                - 95826738-d739-f5e7-d908-7b98b3cbbd70
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -665,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:46 GMT
+                - Thu, 24 Aug 2023 08:30:18 GMT
             Expires:
                 - "0"
             Location:
@@ -678,10 +680,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -689,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5ebd3a5c-9e06-4b22-798d-3fa4567ab4d9
+                - dcd70882-b433-4be8-6483-ffe95e947aac
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 192.420381ms
+        duration: 112.9712ms
     - id: 10
       request:
         proto: ""
@@ -707,7 +705,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -715,9 +713,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - fe22dea4-f49e-a068-78ce-c2167dcdcf7c
+                - 95826738-d739-f5e7-d908-7b98b3cbbd70
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -738,14 +736,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","ready":true,"last_operation":{"id":"088546d6-df43-461c-a1f4-52414863f8ee","ready":true,"type":"create","state":"succeeded","resource_id":"88a077e5-f462-4535-9e33-dfddeae66eb8","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"94ae7ea2-2ecf-292e-2577-7e5cdc7546ee","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:40.032478Z","updated_at":"2023-08-01T14:12:40.321361Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","crm_customer_id":"","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","region":"cf-eu12","platform":"sapcp","origin":"sapcp","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:12:40.032476Z","updated_at":"2023-08-01T14:12:40.316401Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","ready":true,"last_operation":{"id":"d2759c20-638f-43db-9fe3-885617c5f1b6","ready":true,"type":"create","state":"succeeded","resource_id":"b920f17d-2e67-474d-9b06-aeec7481ff58","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"3ef9e876-2e21-579b-8b10-5c0c8960418a","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:30:12.017086Z","updated_at":"2023-08-24T08:30:12.323984Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","region":"cf-eu12","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:30:12.017082Z","updated_at":"2023-08-24T08:30:12.318516Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:46 GMT
+                - Thu, 24 Aug 2023 08:30:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -767,18 +765,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2590b36d-d563-42e0-6681-dd180c7219ac
+                - 8401fa80-1fc3-4d5e-79f6-95fff8bfde2f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 108.093535ms
+        duration: 95.8811ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -791,9 +789,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - d08f3e41-fde6-35db-cdb8-0c75849241a2
+                - 6443492c-2bea-5cd7-e777-b6e64e444f55
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -804,18 +802,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"6b6bf692-6d5e-4fd8-a1cf-4951311c23de","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:47 GMT
+                - Thu, 24 Aug 2023 08:30:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -826,21 +824,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6daa140f-0b6a-4ea0-65ef-ebbd2cdd92f9
+                - 71c84759-5f31-4292-4570-f8236310e31c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 250.90819ms
+        duration: 474.1969ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -853,9 +853,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 3d3248c0-381a-2899-bc83-be77e68459a8
+                - 055ec532-6c87-e15f-753d-da6553dfce16
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -866,18 +866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"6ab5aa42-c740-4578-84f6-3396eda293d4","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:47 GMT
+                - Thu, 24 Aug 2023 08:30:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -888,21 +888,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 45cd212c-1b45-41c7-4a33-aa39208e5e47
+                - ffca1627-d7e6-49e5-424a-cdcdf115cee3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 240.466149ms
+        duration: 347.861ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -915,9 +917,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - be49cbf1-1a3b-1ac9-a5d1-29330aee5533
+                - fda041f1-8b73-5f42-f5db-444a839f1b61
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -928,18 +930,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"5211d97b-f6f3-47a8-bbf0-0d835898b740","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:48 GMT
+                - Thu, 24 Aug 2023 08:30:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -950,21 +952,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e8c9be2b-8c0e-4452-530c-d7c63149ccef
+                - 88925e0a-b742-468a-5de0-06351fb58fb0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 304.797698ms
+        duration: 424.1756ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -977,9 +981,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 2269397e-edb4-091a-444f-f891c692f9a4
+                - 5f46b286-02a2-3af0-e633-8bd6a277920e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -990,18 +994,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"987741b8-d9b8-47bf-97bd-9b0b13e77fbd","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:48 GMT
+                - Thu, 24 Aug 2023 08:30:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1012,15 +1016,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 83ec611f-2c0c-41cf-6410-14cdb3ea076a
+                - e30705b3-ee34-4b23-5cf9-a94d63136cf7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 350.036283ms
+        duration: 424.3137ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1033,15 +1039,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","id":"88a077e5-f462-4535-9e33-dfddeae66eb8","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"confirm":"true","id":"b920f17d-2e67-474d-9b06-aeec7481ff58","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 735775ce-0a25-7d7b-2c2b-20391cd23af1
+                - a0196e8e-710e-f450-3c73-dd1b334b7e4f
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1067,7 +1073,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:48 GMT
+                - Thu, 24 Aug 2023 08:30:20 GMT
             Expires:
                 - "0"
             Location:
@@ -1080,10 +1086,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1091,12 +1093,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1203aedc-b228-40d7-6116-be722f830d0a
+                - 7bbeb590-91e7-4d67-4fc1-3be866e9f851
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 204.640211ms
+        duration: 113.6243ms
     - id: 16
       request:
         proto: ""
@@ -1109,7 +1111,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","id":"88a077e5-f462-4535-9e33-dfddeae66eb8","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"confirm":"true","id":"b920f17d-2e67-474d-9b06-aeec7481ff58","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1117,9 +1119,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?delete
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 735775ce-0a25-7d7b-2c2b-20391cd23af1
+                - a0196e8e-710e-f450-3c73-dd1b334b7e4f
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1147,7 +1149,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:49 GMT
+                - Thu, 24 Aug 2023 08:30:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1169,12 +1171,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1914fb9a-dacf-492d-474e-8eaea14f4b23
+                - 93b552c3-65f7-44f9-7d21-f27a34f5be1f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 318.530567ms
+        duration: 448.2074ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1187,15 +1189,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - b5ed6b94-9604-390f-aa4b-6ed932984f1e
+                - 968aa33a-8bb7-9bd7-f773-90ce1311fc53
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1221,7 +1223,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:54 GMT
+                - Thu, 24 Aug 2023 08:30:26 GMT
             Expires:
                 - "0"
             Location:
@@ -1234,10 +1236,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1245,12 +1243,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2aa7c7a8-e33c-4df5-48d7-63a96bc01824
+                - 16fc62c1-d5c7-47d0-7769-0d1130cdae5d
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 210.934363ms
+        duration: 113.0532ms
     - id: 18
       request:
         proto: ""
@@ -1263,7 +1261,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"88a077e5-f462-4535-9e33-dfddeae66eb8","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"b920f17d-2e67-474d-9b06-aeec7481ff58","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1271,9 +1269,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - b5ed6b94-9604-390f-aa4b-6ed932984f1e
+                - 968aa33a-8bb7-9bd7-f773-90ce1311fc53
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1302,7 +1300,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:54 GMT
+                - Thu, 24 Aug 2023 08:30:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1324,9 +1322,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 92021c36-5877-4b24-642b-9306a228494f
+                - e7d71bef-47a7-416d-41fe-8375e57cfbb3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 97.018965ms
+        duration: 149.6321ms

--- a/internal/provider/fixtures/resource_subaccount_service_instance_with_parameters.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance_with_parameters.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - f3933fa4-1992-4d95-a42b-16593a099aa2
+                - 6759d715-ccc5-50b4-2319-444f28e9d7eb
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"79f34ac7-fc6a-465a-8a66-dc63ec549e65","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:33 GMT
+                - Thu, 24 Aug 2023 08:33:05 GMT
             Expires:
                 - "0"
             Pragma:
@@ -54,21 +54,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 68d75d6e-033a-4a55-753b-ae754f575bba
+                - 2bd03cde-5610-4d1d-6255-b61425aa3b50
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 593.862721ms
+        duration: 751.5507ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 58d12c84-9290-6071-a63b-20a40f3ac65e
+                - 9fa5ca59-eab5-7b95-7075-f76e33696735
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"a4eb8191-3098-4d97-99d7-32bbe77c7e17","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:33 GMT
+                - Thu, 24 Aug 2023 08:33:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -116,21 +118,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 983bdda9-8f02-4ea8-5cdd-c40ebf7d4351
+                - ed402b67-b8d2-467d-7299-3c2567492223
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 311.260874ms
+        duration: 356.7384ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 4c6e5378-bcd0-8d72-8a95-cfd870e96087
+                - 7ff1f107-5965-1ace-4a19-f8f12bd90601
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"07586f10-7394-4232-a152-00fad77b08fd","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:34 GMT
+                - Thu, 24 Aug 2023 08:33:06 GMT
             Expires:
                 - "0"
             Pragma:
@@ -178,15 +182,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 74c34cdb-276e-458d-41a9-06e143bac12d
+                - ced2fca3-a0a6-470f-6d99-6330aecdc14b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 313.515639ms
+        duration: 732.1052ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +211,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 742caaeb-cc5e-eda7-c644-d5a1525d006d
+                - 61c08079-7222-34e4-52b3-ab739aafd030
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -233,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:13:34 GMT
+                - Thu, 24 Aug 2023 08:33:06 GMT
             Expires:
                 - "0"
             Location:
@@ -246,10 +252,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -257,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - fee50fe4-e56b-4e91-530a-13075267a8e2
+                - 008e602b-7892-4abc-78da-dfb9decb7fb4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 367.113778ms
+        duration: 140.6813ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +285,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?create
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 742caaeb-cc5e-eda7-c644-d5a1525d006d
+                - 61c08079-7222-34e4-52b3-ab739aafd030
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -306,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","ready":true,"last_operation":{"id":"131457c3-91a2-4092-a4d2-36f7371709d3","ready":true,"type":"create","state":"succeeded","resource_id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"742caaeb-cc5e-eda7-c644-d5a1525d006d","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:13:35.051548Z","updated_at":"2023-08-01T14:13:35.693155Z"},"name":"tf-test-destination","service_plan_id":"cdf9c103-ef56-43e5-ac1d-4f1c5b15e05c","platform_id":"service-manager","context":{"platform":"sapcp","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","crm_customer_id":"","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-destination"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:13:35.051545Z","updated_at":"2023-08-01T14:13:35.690383907Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5","username":"","password":""}'
+        body: '{"id":"110fc306-da28-47f9-8395-6077af374c74","ready":true,"last_operation":{"id":"b6ec8f69-70d7-46d8-8468-b535aa65b0ce","ready":true,"type":"create","state":"succeeded","resource_id":"110fc306-da28-47f9-8395-6077af374c74","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"61c08079-7222-34e4-52b3-ab739aafd030","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:33:07.289725Z","updated_at":"2023-08-24T08:33:08.003513Z"},"name":"tf-test-destination","service_plan_id":"cdf9c103-ef56-43e5-ac1d-4f1c5b15e05c","platform_id":"service-manager","context":{"global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","platform":"sapcp","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","instance_name":"tf-test-destination"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:33:07.289722Z","updated_at":"2023-08-24T08:33:07.998299428Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5","username":"","password":""}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:35 GMT
+                - Thu, 24 Aug 2023 08:33:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +337,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 44930828-e8dd-457a-6335-9e70fd25b788
+                - 410b6eba-0cf3-4f53-6c1f-61381b15621b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.119130586s
+        duration: 1.031615s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -353,15 +355,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"110fc306-da28-47f9-8395-6077af374c74","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - f6d4fd89-4050-0088-bc3a-7baecc4ffe44
+                - 7af66b31-360e-2e63-fccd-40fcd478a9ed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -387,7 +389,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:13:40 GMT
+                - Thu, 24 Aug 2023 08:33:13 GMT
             Expires:
                 - "0"
             Location:
@@ -400,10 +402,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -411,12 +409,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7b919957-ef7e-47ea-4023-c3f236961497
+                - 2e4ea935-cfd5-4f8d-6ca6-a9275cdf9584
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 261.090078ms
+        duration: 165.6228ms
     - id: 6
       request:
         proto: ""
@@ -429,7 +427,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"110fc306-da28-47f9-8395-6077af374c74","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -437,9 +435,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - f6d4fd89-4050-0088-bc3a-7baecc4ffe44
+                - 7af66b31-360e-2e63-fccd-40fcd478a9ed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -460,14 +458,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","ready":true,"last_operation":{"id":"131457c3-91a2-4092-a4d2-36f7371709d3","ready":true,"type":"create","state":"succeeded","resource_id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"742caaeb-cc5e-eda7-c644-d5a1525d006d","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:13:35.051548Z","updated_at":"2023-08-01T14:13:35.693155Z"},"name":"tf-test-destination","service_plan_id":"cdf9c103-ef56-43e5-ac1d-4f1c5b15e05c","platform_id":"service-manager","context":{"platform":"sapcp","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","crm_customer_id":"","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-destination"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:13:35.051545Z","updated_at":"2023-08-01T14:13:35.690384Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"110fc306-da28-47f9-8395-6077af374c74","ready":true,"last_operation":{"id":"b6ec8f69-70d7-46d8-8468-b535aa65b0ce","ready":true,"type":"create","state":"succeeded","resource_id":"110fc306-da28-47f9-8395-6077af374c74","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"61c08079-7222-34e4-52b3-ab739aafd030","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:33:07.289725Z","updated_at":"2023-08-24T08:33:08.003513Z"},"name":"tf-test-destination","service_plan_id":"cdf9c103-ef56-43e5-ac1d-4f1c5b15e05c","platform_id":"service-manager","context":{"global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","platform":"sapcp","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","instance_name":"tf-test-destination"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:33:07.289722Z","updated_at":"2023-08-24T08:33:07.998299Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:41 GMT
+                - Thu, 24 Aug 2023 08:33:13 GMT
             Expires:
                 - "0"
             Pragma:
@@ -489,18 +487,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 254b3cc2-5622-43e6-57f2-c4a1b00e7c2e
+                - 7b176d59-05ed-4912-6f30-b2e58c26e1d5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 144.565122ms
+        duration: 170.6266ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -513,9 +511,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 42f74694-0f8c-c0c8-2ec1-149f60a61bed
+                - 93512e62-571e-c50b-6a1c-ac057bbbb54e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -526,18 +524,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"2244363e-00b9-44ba-b2e6-5b0ac8fb5175","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:41 GMT
+                - Thu, 24 Aug 2023 08:33:13 GMT
             Expires:
                 - "0"
             Pragma:
@@ -548,21 +546,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c2584bf6-a017-4ccc-614f-1c8032074bc9
+                - 49ec6901-8ea7-448b-58d7-8b3379204917
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 265.880379ms
+        duration: 372.8957ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -575,9 +575,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - e08ece9f-3516-0470-ad9e-e326813b74cc
+                - 063664cc-0d07-bb68-2d4a-6dc79c2090af
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -588,18 +588,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"58dffd00-1755-4c7c-bf34-cf56440e3370","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:41 GMT
+                - Thu, 24 Aug 2023 08:33:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -610,15 +610,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b355e669-cc1c-4139-63b4-3b1492f72fa5
+                - cdd2f628-2c57-44f1-58fc-5d008432c3a4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 239.406215ms
+        duration: 415.9172ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -631,15 +633,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"110fc306-da28-47f9-8395-6077af374c74","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 65f4e8c6-b529-3ee7-caf1-d65723ce6fd2
+                - 198708fe-9cd9-1e2f-ab4f-3763a9e5d5b2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -665,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:13:42 GMT
+                - Thu, 24 Aug 2023 08:33:14 GMT
             Expires:
                 - "0"
             Location:
@@ -678,10 +680,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -689,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ea12fc45-715d-4564-5a8e-a2c9f7ed29cb
+                - bf5b90a2-80c5-43a6-7891-fdf9f6082760
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 222.123393ms
+        duration: 146.0224ms
     - id: 10
       request:
         proto: ""
@@ -707,7 +705,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"110fc306-da28-47f9-8395-6077af374c74","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -715,9 +713,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 65f4e8c6-b529-3ee7-caf1-d65723ce6fd2
+                - 198708fe-9cd9-1e2f-ab4f-3763a9e5d5b2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -738,14 +736,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","ready":true,"last_operation":{"id":"131457c3-91a2-4092-a4d2-36f7371709d3","ready":true,"type":"create","state":"succeeded","resource_id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"742caaeb-cc5e-eda7-c644-d5a1525d006d","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:13:35.051548Z","updated_at":"2023-08-01T14:13:35.693155Z"},"name":"tf-test-destination","service_plan_id":"cdf9c103-ef56-43e5-ac1d-4f1c5b15e05c","platform_id":"service-manager","context":{"platform":"sapcp","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","crm_customer_id":"","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-destination"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:13:35.051545Z","updated_at":"2023-08-01T14:13:35.690384Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"110fc306-da28-47f9-8395-6077af374c74","ready":true,"last_operation":{"id":"b6ec8f69-70d7-46d8-8468-b535aa65b0ce","ready":true,"type":"create","state":"succeeded","resource_id":"110fc306-da28-47f9-8395-6077af374c74","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"61c08079-7222-34e4-52b3-ab739aafd030","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:33:07.289725Z","updated_at":"2023-08-24T08:33:08.003513Z"},"name":"tf-test-destination","service_plan_id":"cdf9c103-ef56-43e5-ac1d-4f1c5b15e05c","platform_id":"service-manager","context":{"global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","platform":"sapcp","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","instance_name":"tf-test-destination"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:33:07.289722Z","updated_at":"2023-08-24T08:33:07.998299Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:42 GMT
+                - Thu, 24 Aug 2023 08:33:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -767,18 +765,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - eeb9c242-06d9-4858-6d83-1c9b9ca27a9a
+                - e7a69ef8-83a5-466f-47d8-d876e140667c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 166.326544ms
+        duration: 115.2327ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -791,9 +789,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - f2d653e1-7965-684b-dff3-1f0be72a924e
+                - d55ab5c7-407e-bfc1-80f6-b027c8ef3600
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -804,18 +802,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"2f1ecaf1-e71b-42ba-9e58-557bbf8a811b","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:42 GMT
+                - Thu, 24 Aug 2023 08:33:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -826,21 +824,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bf672eb7-e5c3-49b1-5d4c-58a4326583b4
+                - f7421508-bda3-4621-7bc3-0fdd567c9682
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 341.175434ms
+        duration: 373.2664ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -853,9 +853,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - e7e28c70-3249-22c4-dd68-854652fd84b4
+                - 92c0711d-e618-03c6-54ce-ce6475909965
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -866,18 +866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"ba2d7ab9-15f8-4582-9c22-add03db64573","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:43 GMT
+                - Thu, 24 Aug 2023 08:33:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -888,21 +888,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c90fd468-24d3-4729-42f7-d1c2f3509f38
+                - 5ccf630e-5cc2-49fe-6de5-b80e19643568
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 229.811018ms
+        duration: 350.2289ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -915,9 +917,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - e05a7f7b-4502-32da-5012-10030a6d50ff
+                - 2ac16115-2720-a62f-1d5c-ee77a945160d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -928,18 +930,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"dd12c686-8a9a-4aa2-ad54-2820a4b8297c","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:43 GMT
+                - Thu, 24 Aug 2023 08:33:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -950,15 +952,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ace9bb62-ed9f-48ca-7b42-6101e96b348b
+                - c1bf6986-61a2-4614-7824-31e9cdeee829
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 240.53414ms
+        duration: 338.4676ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -971,15 +975,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"confirm":"true","id":"110fc306-da28-47f9-8395-6077af374c74","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 9ffff886-e85e-b17c-c0bb-da48a62d524b
+                - 4ff462b0-a356-edbd-aa85-5bcef4af7aed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1005,7 +1009,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:13:43 GMT
+                - Thu, 24 Aug 2023 08:33:15 GMT
             Expires:
                 - "0"
             Location:
@@ -1018,10 +1022,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1029,12 +1029,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - cb84e0ac-a854-477b-5f6e-dd5d00239500
+                - 7d608d53-190c-4104-4240-5fce01ad31ae
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 186.059809ms
+        duration: 149.7362ms
     - id: 15
       request:
         proto: ""
@@ -1047,7 +1047,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"confirm":"true","id":"110fc306-da28-47f9-8395-6077af374c74","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1055,9 +1055,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?delete
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 9ffff886-e85e-b17c-c0bb-da48a62d524b
+                - 4ff462b0-a356-edbd-aa85-5bcef4af7aed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1085,7 +1085,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:44 GMT
+                - Thu, 24 Aug 2023 08:33:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1107,12 +1107,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ce643682-79e6-4ee5-47e5-27d46a167db3
+                - 3e27be81-a084-4d68-56d4-f616e10507af
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 740.779742ms
+        duration: 800.292ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1125,15 +1125,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"110fc306-da28-47f9-8395-6077af374c74","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 40708e58-2d16-2276-c7c7-baf82e2485bd
+                - cab84b0d-4079-9078-f6ec-5ac861223405
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1159,7 +1159,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:13:49 GMT
+                - Thu, 24 Aug 2023 08:33:21 GMT
             Expires:
                 - "0"
             Location:
@@ -1172,10 +1172,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1183,12 +1179,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7e2c529e-1902-4832-5c8d-c08075106de0
+                - 2cbd0d02-cb60-47c3-6df4-b6dc5446d0c2
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 206.644914ms
+        duration: 115.6257ms
     - id: 17
       request:
         proto: ""
@@ -1201,7 +1197,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"ca0d95e2-49b5-412a-a6c7-060bee0aab65","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"110fc306-da28-47f9-8395-6077af374c74","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1209,9 +1205,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 40708e58-2d16-2276-c7c7-baf82e2485bd
+                - cab84b0d-4079-9078-f6ec-5ac861223405
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1240,7 +1236,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:13:49 GMT
+                - Thu, 24 Aug 2023 08:33:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1262,9 +1258,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 673d371e-9b3b-42f0-4848-231e9116a32e
+                - ab8a51e2-7747-46a4-4cc7-e7b499be7ca3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 140.659294ms
+        duration: 136.1656ms

--- a/internal/provider/fixtures/resource_subaccount_service_instance_wo_parameters.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance_wo_parameters.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - fb3e734a-0f2f-9b8d-4cac-149b389e6b49
+                - babb7c95-612f-69e7-4783-75038a183dcd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"5a995737-3cfd-4846-a889-60b49fee2ed8","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:11:57 GMT
+                - Thu, 24 Aug 2023 08:28:52 GMT
             Expires:
                 - "0"
             Pragma:
@@ -54,21 +54,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 54716cac-55e0-4107-5403-a002d93fd5bd
+                - 7c5aa85c-09d6-4d6f-49ca-70e5dd060afa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 480.464658ms
+        duration: 608.3654ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -81,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 80ee4a9b-3bfe-b5d1-c8ec-af73bf33ed9a
+                - 59879649-ef72-1855-d6d2-fdab5fa7b635
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -94,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"8af7f827-7068-436f-aa50-f3e7d7984e9e","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:11:58 GMT
+                - Thu, 24 Aug 2023 08:28:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -116,21 +118,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 69fc7bc0-52a7-41c9-47a9-fef9b1a13e47
+                - cba0721a-20b6-4274-4e91-7547e821574f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 350.54426ms
+        duration: 454.6283ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -143,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 7fd9812a-af6a-7ab7-bd1f-f019aa6c6ab8
+                - d285c146-845d-169f-6118-89ae88bc174b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -156,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"f3cbf060-92d7-4b86-8cf0-70e03680cd10","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:11:58 GMT
+                - Thu, 24 Aug 2023 08:28:53 GMT
             Expires:
                 - "0"
             Pragma:
@@ -178,15 +182,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f21bf91f-c6c1-4046-6339-afaa46647ad2
+                - 30b764c8-bc6c-4a9b-5ee0-13b4ada404c0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 361.804773ms
+        duration: 398.1048ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -205,9 +211,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 4005338a-c282-6de2-677c-194533c88002
+                - f15f02c3-6a33-e3e1-1ca0-0934b3e4d520
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -233,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:11:59 GMT
+                - Thu, 24 Aug 2023 08:28:53 GMT
             Expires:
                 - "0"
             Location:
@@ -246,10 +252,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -257,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1d626ce2-6e0b-42ff-72d9-53b894103a1c
+                - 662ea09d-d465-46cf-748d-1910de80e23e
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 217.917631ms
+        duration: 107.2042ms
     - id: 4
       request:
         proto: ""
@@ -283,9 +285,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?create
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 4005338a-c282-6de2-677c-194533c88002
+                - f15f02c3-6a33-e3e1-1ca0-0934b3e4d520
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -306,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"594a732b-56dd-4178-9ed4-4d76a92ff6ed","ready":true,"type":"create","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4005338a-c282-6de2-677c-194533c88002","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:11:59.296784Z","updated_at":"2023-08-01T14:11:59.575939Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:11:59.572959899Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5","username":"","password":""}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"722f68b3-c39c-4fef-9f19-43186c134d85","ready":true,"type":"create","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"f15f02c3-6a33-e3e1-1ca0-0934b3e4d520","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:28:54.185638Z","updated_at":"2023-08-24T08:28:54.576978Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","region":"cf-eu12","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:28:54.571382091Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5","username":"","password":""}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:11:59 GMT
+                - Thu, 24 Aug 2023 08:28:54 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +337,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 63fa9a2f-42cb-42b1-499f-a3ceab7b2c5a
+                - 5e391f64-b960-4332-6b66-7d348f1a66ca
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 582.486584ms
+        duration: 691.3804ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -353,15 +355,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 2edf7fe2-3056-5ffd-023e-8ed558b4ddf9
+                - 39712629-c5b4-8842-398a-af2becf7eee3
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -387,7 +389,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:04 GMT
+                - Thu, 24 Aug 2023 08:28:59 GMT
             Expires:
                 - "0"
             Location:
@@ -400,10 +402,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -411,12 +409,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f6570a76-8d8b-4da8-6a6d-8fb4c476f665
+                - ece93059-bb26-429a-7c06-f9f49685de5f
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 394.399555ms
+        duration: 146.8428ms
     - id: 6
       request:
         proto: ""
@@ -429,7 +427,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -437,9 +435,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 2edf7fe2-3056-5ffd-023e-8ed558b4ddf9
+                - 39712629-c5b4-8842-398a-af2becf7eee3
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -460,14 +458,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"594a732b-56dd-4178-9ed4-4d76a92ff6ed","ready":true,"type":"create","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4005338a-c282-6de2-677c-194533c88002","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:11:59.296784Z","updated_at":"2023-08-01T14:11:59.575939Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:11:59.57296Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"722f68b3-c39c-4fef-9f19-43186c134d85","ready":true,"type":"create","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"f15f02c3-6a33-e3e1-1ca0-0934b3e4d520","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:28:54.185638Z","updated_at":"2023-08-24T08:28:54.576978Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","region":"cf-eu12","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:28:54.571382Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:05 GMT
+                - Thu, 24 Aug 2023 08:28:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -489,18 +487,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 54013849-bcda-4261-4732-cb1b4499cae5
+                - 7cf373d0-33cc-4d79-6c0e-683dfe8fa9be
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 136.225601ms
+        duration: 99.9715ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -513,9 +511,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 37dfe777-c10e-651f-22e1-a5303eb7d31c
+                - 97d98a9a-3a18-86a8-4506-5ae478d9566f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -526,18 +524,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"df1a6aca-534c-458f-bd0c-e37d6e2ebb05","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:05 GMT
+                - Thu, 24 Aug 2023 08:29:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -548,21 +546,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 87a61213-6bb1-4c70-4d5b-4eae0178488b
+                - acc6b105-630e-46c4-4b2b-cea012544bc4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.27101ms
+        duration: 393.0961ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -575,9 +575,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 3433f5d8-7dfb-8311-0e14-6e72914b4692
+                - 4842f0e5-12b7-103b-8667-e69d234aade5
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -588,18 +588,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"38907342-753e-417f-9058-eb46638c2d6e","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:06 GMT
+                - Thu, 24 Aug 2023 08:29:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -610,15 +610,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 830d0f22-fc10-4337-78a4-3255ac0ccb02
+                - b86f7ad4-57f4-4bd4-7f11-82192184cc21
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 375.077235ms
+        duration: 326.4737ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -631,15 +633,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - df74ea0c-f9aa-7bc6-50bf-e71b08dc1b6c
+                - 7fc72dfc-b644-25a8-d776-c993684c576a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -665,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:06 GMT
+                - Thu, 24 Aug 2023 08:29:00 GMT
             Expires:
                 - "0"
             Location:
@@ -678,10 +680,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -689,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 134c74b6-6097-43ff-7ee2-65d848ef6a00
+                - 53c983a5-01cd-483d-568d-079ce18b2c53
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 220.02922ms
+        duration: 99.8951ms
     - id: 10
       request:
         proto: ""
@@ -707,7 +705,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -715,9 +713,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - df74ea0c-f9aa-7bc6-50bf-e71b08dc1b6c
+                - 7fc72dfc-b644-25a8-d776-c993684c576a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -738,14 +736,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"594a732b-56dd-4178-9ed4-4d76a92ff6ed","ready":true,"type":"create","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4005338a-c282-6de2-677c-194533c88002","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:11:59.296784Z","updated_at":"2023-08-01T14:11:59.575939Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:11:59.57296Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"722f68b3-c39c-4fef-9f19-43186c134d85","ready":true,"type":"create","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"f15f02c3-6a33-e3e1-1ca0-0934b3e4d520","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:28:54.185638Z","updated_at":"2023-08-24T08:28:54.576978Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","region":"cf-eu12","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:28:54.571382Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:06 GMT
+                - Thu, 24 Aug 2023 08:29:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -767,18 +765,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6cf034c8-3e6f-4eae-5ea8-d82d70055b8f
+                - 712cb955-e513-4761-7a5b-cce1adf0c495
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 114.638398ms
+        duration: 145.6128ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -791,9 +789,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - c89f6f9a-4d07-225d-0012-bebfe7a0aa43
+                - df94a510-0955-eec3-cbb5-5ef8284bfe17
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -804,18 +802,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"acdf51ef-2723-4a95-af9b-a3ec90c60d33","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:06 GMT
+                - Thu, 24 Aug 2023 08:29:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -826,21 +824,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2ee6c3ae-6a7c-4d4a-7068-e02ec4dc0afb
+                - b130e538-9492-47d3-45f0-ff7ddf8536b9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 334.853994ms
+        duration: 354.0791ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -853,9 +853,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 77485aab-4743-faad-fa55-625a97d70446
+                - 33d56ff6-0102-74a7-0490-cdaa0f1570bd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -866,18 +866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"3842288b-be90-43ea-bfe1-fcf6c5f23a51","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:07 GMT
+                - Thu, 24 Aug 2023 08:29:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -888,15 +888,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cbc30d82-a071-402d-5ae4-509d5946dc26
+                - 1457906b-0e27-43a3-5058-2b580ad781d7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 283.934239ms
+        duration: 337.0157ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -909,15 +911,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 926607d9-6b45-5cfd-3623-5fa42dd367f8
+                - ad0937dd-9028-95dc-2067-807697d82750
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -943,7 +945,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:07 GMT
+                - Thu, 24 Aug 2023 08:29:01 GMT
             Expires:
                 - "0"
             Location:
@@ -956,10 +958,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -967,12 +965,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 90b655a8-5802-42d4-55f0-4cd3616e5f96
+                - 33a3fc4e-9a4e-43a4-7355-0d9c00a6f7f3
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 243.035882ms
+        duration: 109.6453ms
     - id: 14
       request:
         proto: ""
@@ -985,7 +983,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -993,9 +991,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 926607d9-6b45-5cfd-3623-5fa42dd367f8
+                - ad0937dd-9028-95dc-2067-807697d82750
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1016,14 +1014,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"594a732b-56dd-4178-9ed4-4d76a92ff6ed","ready":true,"type":"create","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4005338a-c282-6de2-677c-194533c88002","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:11:59.296784Z","updated_at":"2023-08-01T14:11:59.575939Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:11:59.57296Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"722f68b3-c39c-4fef-9f19-43186c134d85","ready":true,"type":"create","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"f15f02c3-6a33-e3e1-1ca0-0934b3e4d520","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:28:54.185638Z","updated_at":"2023-08-24T08:28:54.576978Z"},"name":"tf-test-audit-log","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","region":"cf-eu12","license_type":"SAPDEV","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","origin":"sapcp","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","instance_name":"tf-test-audit-log"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:28:54.571382Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:07 GMT
+                - Thu, 24 Aug 2023 08:29:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1045,18 +1043,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a4872e01-ed4c-4d64-76cd-3bbb7b36c69d
+                - b89b7849-b510-426a-583d-bf0b6479e7b4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 139.289405ms
+        duration: 98.8824ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1069,9 +1067,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - dc2cabfe-294c-309c-3741-18b3bd2588bc
+                - 5c939f7e-7092-9231-8b9d-cee6701e28e7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1082,18 +1080,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"5801dfea-de3a-4a1f-aa43-9ff2ef73e018","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:08 GMT
+                - Thu, 24 Aug 2023 08:29:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1104,21 +1102,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 663c1cf9-efd4-440e-526a-26494bc1d3aa
+                - 5e6e9737-5210-4143-7811-db356a3f0025
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 327.189854ms
+        duration: 386.2638ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1131,9 +1131,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - fae6a84d-d077-9077-55c9-5c7c69199f3a
+                - 624d5562-cfb0-d1b9-12bd-75510c635c99
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1144,18 +1144,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"ba492013-2c2f-40b0-b851-d96fbdaabdb6","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:08 GMT
+                - Thu, 24 Aug 2023 08:29:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1166,15 +1166,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b342355b-f79e-40fb-6e81-0de70f5f610d
+                - ee8ab548-1f19-4b6e-64c2-09c8a99bd535
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 488.369246ms
+        duration: 392.3598ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1187,15 +1189,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","name":"tf-test-audit-log","newName":"TF-TEST-AUDIT-LOG","plan":"02fed361-89c1-4560-82c3-0deaf93ac75b","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","name":"tf-test-audit-log","newName":"TF-TEST-AUDIT-LOG","plan":"02fed361-89c1-4560-82c3-0deaf93ac75b","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 45ac2e2a-0ac4-eb1f-875d-197a638e8585
+                - 4c7bca59-b7ac-38d4-843f-1efb4b167715
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1221,7 +1223,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:09 GMT
+                - Thu, 24 Aug 2023 08:29:03 GMT
             Expires:
                 - "0"
             Location:
@@ -1234,10 +1236,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1245,12 +1243,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 3ca025bd-6e29-40d4-6ef8-74ef99a36521
+                - 6ec3fb04-df2d-4416-6db3-95fb96667381
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 190.593444ms
+        duration: 183.9078ms
     - id: 18
       request:
         proto: ""
@@ -1263,7 +1261,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","name":"tf-test-audit-log","newName":"TF-TEST-AUDIT-LOG","plan":"02fed361-89c1-4560-82c3-0deaf93ac75b","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","name":"tf-test-audit-log","newName":"TF-TEST-AUDIT-LOG","plan":"02fed361-89c1-4560-82c3-0deaf93ac75b","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1271,9 +1269,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?update
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 45ac2e2a-0ac4-eb1f-875d-197a638e8585
+                - 4c7bca59-b7ac-38d4-843f-1efb4b167715
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1294,14 +1292,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: Use 'btp get services/instance 073615a0-bd4e-455e-b6fb-43577274b245 --subaccount 59cd458e-e66e-4b60-b6d8-8f219379f9a5' to check the status of the update instance operation you initiated.
+        body: Use 'btp get services/instance f164d5df-8178-436d-914f-b0bf024abd3b --subaccount 59cd458e-e66e-4b60-b6d8-8f219379f9a5' to check the status of the update instance operation you initiated.
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:09 GMT
+                - Thu, 24 Aug 2023 08:29:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1323,12 +1321,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8aa79580-a4ec-4ff6-546b-43d4753ccbb6
+                - 14635d93-2594-467f-5116-4b21dfc61990
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 263.025002ms
+        duration: 175.4895ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1341,15 +1339,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 09464938-682e-4aad-36d7-28c21092aefd
+                - 748027df-885c-b298-91ae-751ba9c4a734
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1375,7 +1373,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:09 GMT
+                - Thu, 24 Aug 2023 08:29:03 GMT
             Expires:
                 - "0"
             Location:
@@ -1388,10 +1386,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1399,12 +1393,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 10cff180-67e7-40f8-4e95-bddee9b5f13f
+                - d387e472-5f01-4fd0-5aad-510ab01cb341
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 185.31353ms
+        duration: 116.9392ms
     - id: 20
       request:
         proto: ""
@@ -1417,7 +1411,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1425,9 +1419,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 09464938-682e-4aad-36d7-28c21092aefd
+                - 748027df-885c-b298-91ae-751ba9c4a734
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1448,14 +1442,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"62437e02-936a-462c-898b-e6449c7069d1","ready":true,"type":"update","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"45ac2e2a-0ac4-eb1f-875d-197a638e8585","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:09.297963Z","updated_at":"2023-08-01T14:12:09.4032Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","region":"cf-eu12","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:12:09.39236Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"8235be80-cadb-4ea7-9cf1-c7c62e3b37fd","ready":true,"type":"update","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4c7bca59-b7ac-38d4-843f-1efb4b167715","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:29:03.326248Z","updated_at":"2023-08-24T08:29:03.431029Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:29:03.4194Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:09 GMT
+                - Thu, 24 Aug 2023 08:29:03 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1477,12 +1471,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6c94423d-d707-4330-7016-a9a4c7a655b3
+                - 9638f2eb-dffa-434f-577f-761589d8ecec
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 110.488847ms
+        duration: 101.9159ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1495,15 +1489,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 3604f206-dc62-c014-8eda-dd952014e135
+                - ab2d2a0b-f33c-a7a5-c115-063ea4c2e238
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1529,7 +1523,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:14 GMT
+                - Thu, 24 Aug 2023 08:29:08 GMT
             Expires:
                 - "0"
             Location:
@@ -1542,10 +1536,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1553,12 +1543,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 0fba4223-9c81-4444-5066-377991432734
+                - c700ace3-8eb8-4728-4d5e-dd85f024a9b4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 224.306239ms
+        duration: 120.9737ms
     - id: 22
       request:
         proto: ""
@@ -1571,7 +1561,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1579,9 +1569,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 3604f206-dc62-c014-8eda-dd952014e135
+                - ab2d2a0b-f33c-a7a5-c115-063ea4c2e238
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1602,14 +1592,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"62437e02-936a-462c-898b-e6449c7069d1","ready":true,"type":"update","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"45ac2e2a-0ac4-eb1f-875d-197a638e8585","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:09.297963Z","updated_at":"2023-08-01T14:12:09.4032Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","region":"cf-eu12","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:12:09.39236Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"8235be80-cadb-4ea7-9cf1-c7c62e3b37fd","ready":true,"type":"update","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4c7bca59-b7ac-38d4-843f-1efb4b167715","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:29:03.326248Z","updated_at":"2023-08-24T08:29:03.431029Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:29:03.4194Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:14 GMT
+                - Thu, 24 Aug 2023 08:29:08 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1631,18 +1621,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ad4a55c0-28ed-497d-7a6f-5dfbe0f8d0e9
+                - e7863e53-178e-4884-60f8-71c4a841aa68
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 94.697338ms
+        duration: 79.8489ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1655,9 +1645,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 87a1c5c9-5e24-f066-a8ef-5dc36e9465c7
+                - d8ea277d-ec7e-5c5c-b0b3-283546d74176
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1668,18 +1658,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"841b5034-2918-44d2-9f8f-e2789a79298c","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:15 GMT
+                - Thu, 24 Aug 2023 08:29:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1690,21 +1680,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 22a624c2-206f-4538-618b-614fdc065e07
+                - e53f89bc-3a08-441b-5b48-3a5ec90f536c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 316.678527ms
+        duration: 440.1309ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1717,9 +1709,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 94292e18-e422-b65f-fd1f-9b1c511b7a83
+                - 331df006-b873-5b59-7461-858f8bd89946
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1730,18 +1722,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"36d5b251-9316-4f14-af32-779deaf6397c","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:16 GMT
+                - Thu, 24 Aug 2023 08:29:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1752,15 +1744,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 28704b8e-ee34-42d9-7a39-77b5d7b3b879
+                - 76e21880-c013-47f8-61aa-1cc15218a866
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 364.612342ms
+        duration: 316.169ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1773,15 +1767,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 90c639a6-bf73-082f-c693-24a8bb9ec943
+                - 7b6b766b-d50a-8a78-84a9-e1dc7aaabf3a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1807,7 +1801,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:16 GMT
+                - Thu, 24 Aug 2023 08:29:09 GMT
             Expires:
                 - "0"
             Location:
@@ -1820,10 +1814,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -1831,12 +1821,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4d49e910-fd35-4e5c-600b-92cfd9d37686
+                - ff4cd02d-5bb2-490c-5999-27266af6281d
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 171.752353ms
+        duration: 131.9419ms
     - id: 26
       request:
         proto: ""
@@ -1849,7 +1839,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -1857,9 +1847,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 90c639a6-bf73-082f-c693-24a8bb9ec943
+                - 7b6b766b-d50a-8a78-84a9-e1dc7aaabf3a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1880,14 +1870,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"62437e02-936a-462c-898b-e6449c7069d1","ready":true,"type":"update","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"45ac2e2a-0ac4-eb1f-875d-197a638e8585","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:09.297963Z","updated_at":"2023-08-01T14:12:09.4032Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","region":"cf-eu12","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:12:09.39236Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"8235be80-cadb-4ea7-9cf1-c7c62e3b37fd","ready":true,"type":"update","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4c7bca59-b7ac-38d4-843f-1efb4b167715","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:29:03.326248Z","updated_at":"2023-08-24T08:29:03.431029Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:29:03.4194Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:16 GMT
+                - Thu, 24 Aug 2023 08:29:09 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1909,18 +1899,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - df388640-b8b3-4426-62d7-4063c2f3d509
+                - c3049ab1-91e6-46f8-4901-8e248e73198f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 102.840878ms
+        duration: 129.3093ms
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1933,9 +1923,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 56e28885-9dc1-a1c1-f9a7-67d29c847d1a
+                - a475b884-d237-a569-fb67-7caaa2259d51
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -1946,18 +1936,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"8b2d04a7-4964-4459-bffb-53d3a2752efd","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:16 GMT
+                - Thu, 24 Aug 2023 08:29:10 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1968,21 +1958,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7f60d1c1-f423-483b-5602-0690d98174f2
+                - abc48b6d-04bd-43fb-47a8-43a77efd6ce3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 221.269172ms
+        duration: 633.2861ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1995,9 +1987,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - c34cbd8d-58eb-525e-6884-206b4d7d21f8
+                - a80bcbaa-a5ef-804b-951c-e917c396d53a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2008,18 +2000,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"68aa2734-71a1-43d6-840e-bd380d04b4c6","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:17 GMT
+                - Thu, 24 Aug 2023 08:29:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2030,15 +2022,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 182e7b35-e3cf-4a48-58e2-d84e8faa25f8
+                - 0b483876-ab72-4b3b-6b13-beeed5c21b1d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 309.51635ms
+        duration: 363.5608ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -2051,15 +2045,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - c2de7a21-3f03-9274-4836-2c334d32ebf6
+                - 81e04017-44ec-2b3c-5196-9ee4d6897e77
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2085,7 +2079,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:17 GMT
+                - Thu, 24 Aug 2023 08:29:11 GMT
             Expires:
                 - "0"
             Location:
@@ -2098,10 +2092,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -2109,12 +2099,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 73381b4b-baea-4140-7cbb-d376425666dc
+                - a5159467-cab5-4da5-5298-e0d94a258598
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 176.698261ms
+        duration: 108.9041ms
     - id: 30
       request:
         proto: ""
@@ -2127,7 +2117,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -2135,9 +2125,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - c2de7a21-3f03-9274-4836-2c334d32ebf6
+                - 81e04017-44ec-2b3c-5196-9ee4d6897e77
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2158,14 +2148,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"073615a0-bd4e-455e-b6fb-43577274b245","ready":true,"last_operation":{"id":"62437e02-936a-462c-898b-e6449c7069d1","ready":true,"type":"update","state":"succeeded","resource_id":"073615a0-bd4e-455e-b6fb-43577274b245","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"45ac2e2a-0ac4-eb1f-875d-197a638e8585","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-01T14:12:09.297963Z","updated_at":"2023-08-01T14:12:09.4032Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","subdomain":"integration-test-services-4ie3yr1a","platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","license_type":"SAPDEV","region":"cf-eu12","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-01T14:11:59.296781Z","updated_at":"2023-08-01T14:12:09.39236Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
+        body: '{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","ready":true,"last_operation":{"id":"8235be80-cadb-4ea7-9cf1-c7c62e3b37fd","ready":true,"type":"update","state":"succeeded","resource_id":"f164d5df-8178-436d-914f-b0bf024abd3b","resource_type":"/v1/service_instances","platform_id":"service-manager","correlation_id":"4c7bca59-b7ac-38d4-843f-1efb4b167715","reschedule":false,"reschedule_timestamp":"0001-01-01T00:00:00Z","deletion_scheduled":"0001-01-01T00:00:00Z","created_at":"2023-08-24T08:29:03.326248Z","updated_at":"2023-08-24T08:29:03.431029Z"},"name":"TF-TEST-AUDIT-LOG","service_plan_id":"02fed361-89c1-4560-82c3-0deaf93ac75b","platform_id":"service-manager","context":{"platform":"sapcp","origin":"sapcp","global_account_id":"03760ecf-9d89-4189-a92a-1c7efed09298","subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","region":"cf-eu12","zone_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","license_type":"SAPDEV","subdomain":"integration-test-services-4ie3yr1a","crm_customer_id":"","instance_name":"TF-TEST-AUDIT-LOG"},"usable":true,"subaccount_id":"59cd458e-e66e-4b60-b6d8-8f219379f9a5","protected":null,"created_at":"2023-08-24T08:28:54.185635Z","updated_at":"2023-08-24T08:29:03.4194Z","labels":"subaccount_id = 59cd458e-e66e-4b60-b6d8-8f219379f9a5"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:17 GMT
+                - Thu, 24 Aug 2023 08:29:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2187,18 +2177,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5b2fbbee-b087-4e8e-4146-1b2dfaafd690
+                - dd776e29-2204-4d0a-793d-c9cb2d967534
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 94.468165ms
+        duration: 127.2648ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2211,9 +2201,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - e69d133d-b3a9-a1f0-c199-2f0ecfb76df9
+                - d209ee86-0024-e301-25b1-178cb46184b1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2224,18 +2214,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"cc281196-c666-4773-bad4-282f54a38f7f","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:18 GMT
+                - Thu, 24 Aug 2023 08:29:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2246,21 +2236,23 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5287fa81-ebc3-44e0-780f-da1d00f13fcc
+                - 10157bce-1b4c-4abd-78ce-3b0c2e960343
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 270.789373ms
+        duration: 520.6804ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 127
+        content_length: 118
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -2273,9 +2265,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 92f28fbd-85b0-b6e4-b36f-19179459a5c4
+                - 5eb2f472-9da5-9cea-4b49-3192f24d4cd6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.38.0
@@ -2286,18 +2278,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 162
+        content_length: 153
         uncompressed: false
-        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        body: '{"issuer":"identity.provider.test","refreshToken":"e144b4f2-a9e4-4c38-abea-5222826bac9e","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "162"
+                - "153"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:18 GMT
+                - Thu, 24 Aug 2023 08:29:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2308,15 +2300,17 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9916e334-1fa2-4e7e-5d9d-e38b193ed306
+                - 3a5b6eba-7fd9-4e36-68c1-589f3a16add8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 234.924818ms
+        duration: 446.0647ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -2329,15 +2323,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","id":"073615a0-bd4e-455e-b6fb-43577274b245","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"confirm":"true","id":"f164d5df-8178-436d-914f-b0bf024abd3b","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 8fcb5105-4e9f-3e92-2736-cf9cff3e18dc
+                - afaa6f82-402c-a1e0-d44f-39f6e48763d7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2363,7 +2357,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:18 GMT
+                - Thu, 24 Aug 2023 08:29:12 GMT
             Expires:
                 - "0"
             Location:
@@ -2376,10 +2370,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -2387,12 +2377,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - cd86abe4-ef4c-41d5-435c-c8adad8cffc3
+                - 09248c36-65d4-450d-5c26-42bca47f21a6
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 174.591685ms
+        duration: 114.175ms
     - id: 34
       request:
         proto: ""
@@ -2405,7 +2395,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"confirm":"true","id":"073615a0-bd4e-455e-b6fb-43577274b245","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"confirm":"true","id":"f164d5df-8178-436d-914f-b0bf024abd3b","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -2413,9 +2403,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?delete
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 8fcb5105-4e9f-3e92-2736-cf9cff3e18dc
+                - afaa6f82-402c-a1e0-d44f-39f6e48763d7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2443,7 +2433,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:18 GMT
+                - Thu, 24 Aug 2023 08:29:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2465,12 +2455,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a09f6f2c-b828-4f0a-6611-38c3d04c98d3
+                - 9e737991-c17b-4c68-754c-2a047c1619d0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 347.672205ms
+        duration: 340.882ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2483,15 +2473,15 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c5e299f-d547-23c8-a969-9af88a7f1d77
+                - 049e7568-6b41-3ae0-7d69-76146cdb5753
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2517,7 +2507,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 01 Aug 2023 14:12:24 GMT
+                - Thu, 24 Aug 2023 08:29:18 GMT
             Expires:
                 - "0"
             Location:
@@ -2530,10 +2520,6 @@ interactions:
                 - max-age=31536000; includeSubDomains; preload;
             X-Content-Type-Options:
                 - nosniff
-            X-Cpcli-Refreshtoken:
-                - redacted
-            X-Cpcli-Replacementrefreshtoken:
-                - redacted
             X-Cpcli-Subdomain:
                 - integration-test-services-4ie3yr1a
             X-Frame-Options:
@@ -2541,12 +2527,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - d2c300c3-d1f9-432d-6d1b-20b5770d7507
+                - 72f4a070-50a6-4cfb-40fb-7e269adc27e8
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 586.442986ms
+        duration: 135.5119ms
     - id: 36
       request:
         proto: ""
@@ -2559,7 +2545,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"id":"073615a0-bd4e-455e-b6fb-43577274b245","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
+            {"paramValues":{"id":"f164d5df-8178-436d-914f-b0bf024abd3b","parameters":"false","subaccount":"59cd458e-e66e-4b60-b6d8-8f219379f9a5"}}
         form: {}
         headers:
             Content-Type:
@@ -2567,9 +2553,9 @@ interactions:
             Referer:
                 - https://cpcli.cf.sap.hana.ondemand.com/command/v2.38.0/services/instance?get
             User-Agent:
-                - Terraform/1.5.0 terraform-provider-btp/dev
+                - Terraform/1.5.5 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c5e299f-d547-23c8-a969-9af88a7f1d77
+                - 049e7568-6b41-3ae0-7d69-76146cdb5753
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2598,7 +2584,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 01 Aug 2023 14:12:24 GMT
+                - Thu, 24 Aug 2023 08:29:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2620,9 +2606,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 26efd110-15e4-4666-42ad-8619f810e1d0
+                - 01b3debc-2bd9-4a22-53f7-beba6d3d9e92
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 105.087675ms
+        duration: 107.4135ms


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR contains a workaround for the creation of service instances that return a non-JSON response when creation is triggered. This is currently the case for some services like HANA Cloud that return a 202 response
* The workaround is temporary and marked as TODO to be tracked via Sonar Cloud

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: temporary workaround
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
