### PR TITLE
fix: nil pointer exception in subaccounts entitlement read

### DIFF
--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -152,8 +152,12 @@ func (rs *subaccountEntitlementResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	updatedState, diags := subaccountEntitlementValueFrom(ctx, *entitlement)
+	if entitlement == nil {
+		resp.Diagnostics.AddError("API Error Reading Resource Entitlement (Subaccount)", "Resource not found")
+		return
+	}
 
+	updatedState, diags := subaccountEntitlementValueFrom(ctx, *entitlement)
 	resp.Diagnostics.Append(diags...)
 
 	diags = resp.State.Set(ctx, &updatedState)


### PR DESCRIPTION
## Purpose

* Checking for `nil` entitlement retrieved during `READ` of resource. 
* Fixes #395 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

* Additional test steps

```
- Create a subaccount with an entitlement via terraform
- Manually remove the entitlement from the subaccount, leaving it in the terraform state
- Execute a "terraform plan"
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
* The result of the additional test step should be an error message during the plan

## Other Information

Manual deletion of resource needs to be handled by operations.  Feasible options are:

* Execute a `terraform plan` using the `replace` option (see [documentation](https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address))
* Remove the resource from the state via `terraform rm` (see [documentation](https://developer.hashicorp.com/terraform/cli/commands/state/rm))


## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
