### PR TITLE
fix: Only add planName to subscribe request if it's not empty

### DIFF
--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -99,12 +99,16 @@ func (f *accountsSubaccountFacade) Delete(ctx context.Context, subaccountId stri
 }
 
 func (f *accountsSubaccountFacade) Subscribe(ctx context.Context, subaccountId string, appName string, planName string, parameters string) (saas_manager_service.SubscriptionAssignmentResponseObject, CommandResponse, error) {
-	return doExecute[saas_manager_service.SubscriptionAssignmentResponseObject](f.cliClient, ctx, NewSubscribeRequest(f.getCommand(), map[string]string{
+	commandOptions := map[string]string{
 		"subaccount":         subaccountId,
 		"appName":            appName,
-		"planName":           planName,
 		"subscriptionParams": parameters,
-	}))
+	}
+
+	if len(planName) > 0 {
+		commandOptions["planName"] = planName
+	}
+	return doExecute[saas_manager_service.SubscriptionAssignmentResponseObject](f.cliClient, ctx, NewSubscribeRequest(f.getCommand(), commandOptions))
 }
 
 func (f *accountsSubaccountFacade) Unsubscribe(ctx context.Context, subaccountId string, appName string) (saas_manager_service.SubscriptionAssignmentResponseObject, CommandResponse, error) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
PR for  #342 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
My colleague Thanh opened a pull request [here](https://github.com/SAP/terraform-provider-btp/pull/363) but he is not working with us anymore, so I'm taking his subject.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [ ] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
