### PR TITLE
feat: support login with id token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ provider "btp" {
 
 - `cli_server_url` (String) The URL of the BTP CLI server (e.g. `https://cpcli.cf.eu10.hana.ondemand.com`).
 - `idp` (String) The identity provider to be used for authentication (default: SAP ID service with origin `sap.default`).
-- `idtoken` (String, Sensitive) A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable.
+- `idtoken` (String, Sensitive) A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable.(SAP-internal usage only)
 - `password` (String, Sensitive) Your password. Note that two-factor authentication is not supported. This can also be sourced from the `BTP_PASSWORD` environment variable.
 - `username` (String) Your user name, usually an e-mail address. This can also be sourced from the `BTP_USERNAME` environment variable.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ provider "btp" {
 
 - `cli_server_url` (String) The URL of the BTP CLI server (e.g. `https://cpcli.cf.eu10.hana.ondemand.com`).
 - `idp` (String) The identity provider to be used for authentication (default: SAP ID service with origin `sap.default`).
+- `idtoken` (String, Sensitive) A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable.
 - `password` (String, Sensitive) Your password. Note that two-factor authentication is not supported. This can also be sourced from the `BTP_PASSWORD` environment variable.
 - `username` (String) Your user name, usually an e-mail address. This can also be sourced from the `BTP_USERNAME` environment variable.
 

--- a/internal/btpcli/client_test.go
+++ b/internal/btpcli/client_test.go
@@ -242,7 +242,7 @@ func TestV2Client_IdTokenLogin(t *testing.T) {
 			loginRequest: NewIdTokenLoginRequest("", "subdomain", "idToken"),
 			simulation: v2SimulationConfig{
 				srvReturnStatus: http.StatusTeapot,
-				expectErrorMsg:  "Received response with unexpected status [Status: 418; Correlation ID: fake-correlation-id]",
+				expectErrorMsg:  "received response with unexpected status [Status: 418; Correlation ID: fake-correlation-id]",
 			},
 		},
 	}

--- a/internal/btpcli/client_test.go
+++ b/internal/btpcli/client_test.go
@@ -166,6 +166,99 @@ func TestV2Client_Login(t *testing.T) {
 	}
 }
 
+func TestV2Client_IdTokenLogin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		description string
+
+		loginRequest *IdTokenLoginRequest
+		simulation   v2SimulationConfig
+	}{
+		{
+			description:  "happy path",
+			loginRequest: NewIdTokenLoginRequest("", "subdomain", "idToken"),
+			simulation: v2SimulationConfig{
+				srvExpectBody:    `{"customIdp":"","subdomain":"subdomain","idToken":"idToken"}`,
+				srvReturnStatus:  http.StatusOK,
+				srvReturnContent: ``,
+				srvReturnHeader: map[string]string{
+					HeaderCLIRefreshToken: "sessionid",
+				},
+				expectResponse: struct{}{},
+				expectClientSession: &Session{
+					RefreshToken:           "sessionid",
+					IdentityProvider:       "",
+					GlobalAccountSubdomain: "subdomain",
+					LoggedInUser:           nil,
+				},
+			},
+		},
+		{
+			description:  "happy path - with custom idp",
+			loginRequest: NewIdTokenLoginRequest("my.custom.idp", "subdomain", "idToken"),
+			simulation: v2SimulationConfig{
+				srvExpectBody:    `{"customIdp":"my.custom.idp","subdomain":"subdomain","idToken":"idToken"}`,
+				srvReturnStatus:  http.StatusOK,
+				srvReturnContent: ``,
+				srvReturnHeader: map[string]string{
+					HeaderCLIRefreshToken: "sessionid",
+				},
+				expectResponse: struct{}{},
+				expectClientSession: &Session{
+					RefreshToken:           "sessionid",
+					IdentityProvider:       "my.custom.idp",
+					GlobalAccountSubdomain: "subdomain",
+					LoggedInUser:           nil,
+				},
+			},
+		},
+		{
+			description:  "error path - user is lacking permissions to globalaccount [403]",
+			loginRequest: NewIdTokenLoginRequest("", "subdomain", "idToken"),
+			simulation: v2SimulationConfig{
+				srvReturnStatus: http.StatusForbidden,
+				expectErrorMsg:  "You cannot access global account 'subdomain'. Make sure you have at least read access to the global account, a directory, or a subaccount. [Status: 403; Correlation ID: fake-correlation-id]",
+			},
+		},
+		{
+			description:  "error path - outdated protocol version [412]",
+			loginRequest: NewIdTokenLoginRequest("", "subdomain", "idToken"),
+			simulation: v2SimulationConfig{
+				srvReturnStatus: http.StatusPreconditionFailed,
+				expectErrorMsg:  "Login failed due to outdated provider version. Update to the latest version of the provider. [Status: 412; Correlation ID: fake-correlation-id]",
+			},
+		},
+		{
+			description:  "error path - login request times out [504]]",
+			loginRequest: NewIdTokenLoginRequest("", "subdomain", "idToken"),
+			simulation: v2SimulationConfig{
+				srvReturnStatus: http.StatusGatewayTimeout,
+				expectErrorMsg:  "Login timed out. Please try again later. [Status: 504; Correlation ID: fake-correlation-id]",
+			},
+		},
+		{
+			description:  "error path - unexpected error",
+			loginRequest: NewIdTokenLoginRequest("", "subdomain", "idToken"),
+			simulation: v2SimulationConfig{
+				srvReturnStatus: http.StatusTeapot,
+				expectErrorMsg:  "Received response with unexpected status [Status: 418; Correlation ID: fake-correlation-id]",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			test.simulation.srvExpectPath = path.Join("/login", cliTargetProtocolVersion, "idtoken")
+			test.simulation.callFunctionUnderTest = func(ctx context.Context, uut *v2Client) (any, error) {
+				return struct{}{}, uut.IdTokenLogin(ctx, test.loginRequest)
+			}
+
+			simulateV2Call(t, test.simulation)
+		})
+	}
+}
+
 func TestV2Client_Logout(t *testing.T) {
 	t.Parallel()
 
@@ -348,6 +441,9 @@ type v2SimulationConfig struct {
 	// the content the fake api server shall respond
 	srvReturnContent string
 
+	// the header values the fake api server shall return
+	srvReturnHeader map[string]string
+
 	// triggers the function under test on the uut
 	callFunctionUnderTest func(ctx context.Context, uut *v2Client) (any, error)
 
@@ -379,6 +475,9 @@ func simulateV2Call(t *testing.T, config v2SimulationConfig) {
 				assert.Equal(t, config.srvExpectBody, strings.TrimSpace(string(b)))
 			}
 
+			for key, value := range config.srvReturnHeader {
+				w.Header().Add(key, value)
+			}
 			w.WriteHeader(config.srvReturnStatus)
 			fmt.Fprintf(w, config.srvReturnContent)
 		}

--- a/internal/btpcli/clienttypes.go
+++ b/internal/btpcli/clienttypes.go
@@ -20,11 +20,25 @@ func NewLoginRequestWithCustomIDP(idp string, globalaccountSubdomain string, use
 	}
 }
 
+func NewIdTokenLoginRequest(idp string, globalaccountSubdomain string, idToken string) *IdTokenLoginRequest {
+	return &IdTokenLoginRequest{
+		IdentityProvider:       idp,
+		GlobalAccountSubdomain: globalaccountSubdomain,
+		IdToken:                idToken,
+	}
+}
+
 type LoginRequest struct {
 	IdentityProvider       string `json:"customIdp"`
 	GlobalAccountSubdomain string `json:"subdomain"`
 	Username               string `json:"userName"`
 	Password               string `json:"password"`
+}
+
+type IdTokenLoginRequest struct {
+	IdentityProvider       string `json:"customIdp"`
+	GlobalAccountSubdomain string `json:"subdomain"`
+	IdToken                string `json:"idToken"`
 }
 
 type LoginResponse struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func (p *btpcliProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 				Sensitive:           true,
 			},
 			"idtoken": schema.StringAttribute{
-				MarkdownDescription: "A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable.",
+				MarkdownDescription: "A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable.(SAP-internal usage only)",
 				Optional:            true,
 				Sensitive:           true,
 			},


### PR DESCRIPTION
## Purpose
Adding support for id token login to the provider configuration. The id token replaces username and password and is passed to a new special login endpoint of the btp CLI server.
The resulting session id is read from a response header. Currently, the response does not contain any authentication info, i.e. the terraform provider does not support the whoami datasource when logging in via id token.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
The automated tests only contain unit tests for the id token login since there is no appropriate API available to retrieve an id token and the required btp CLI server release is still to come. Therefore, the functionality was tested manually on a local machine using a dev setup to retrieve an id token and run the terraform provider against a development btp CLI server.
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information

Follow up for enhancement of authentication flows is issue #408 

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked. 
