### PR TITLE
feat: add app name to data sources for roles

### DIFF
--- a/docs/data-sources/directory_roles.md
+++ b/docs/data-sources/directory_roles.md
@@ -40,6 +40,7 @@ data "btp_directory_roles" "all" {
 Read-Only:
 
 - `app_id` (String) The ID of the xsuaa application.
+- `app_name` (String) The name of the xsuaa application.
 - `description` (String) The description of the role.
 - `name` (String) The name of the role.
 - `read_only` (Boolean) Shows whether the role can be modified or not.

--- a/docs/data-sources/directory_roles.md
+++ b/docs/data-sources/directory_roles.md
@@ -39,8 +39,8 @@ data "btp_directory_roles" "all" {
 
 Read-Only:
 
-- `app_id` (String) The ID of the xsuaa application.
-- `app_name` (String) The name of the xsuaa application.
+- `app_id` (String) The id of the application that provides the role template and the role.
+- `app_name` (String) The name of the application that provides the role template and the role.
 - `description` (String) The description of the role.
 - `name` (String) The name of the role.
 - `read_only` (Boolean) Shows whether the role can be modified or not.

--- a/docs/data-sources/globalaccount_roles.md
+++ b/docs/data-sources/globalaccount_roles.md
@@ -34,6 +34,7 @@ data "btp_globalaccount_roles" "all" {}
 Read-Only:
 
 - `app_id` (String) The ID of the xsuaa application.
+- `app_name` (String) The name of the xsuaa application.
 - `description` (String) The description of the role.
 - `name` (String) The name of the role.
 - `read_only` (Boolean) Shows whether the role can be modified or not.

--- a/docs/data-sources/globalaccount_roles.md
+++ b/docs/data-sources/globalaccount_roles.md
@@ -33,8 +33,8 @@ data "btp_globalaccount_roles" "all" {}
 
 Read-Only:
 
-- `app_id` (String) The ID of the xsuaa application.
-- `app_name` (String) The name of the xsuaa application.
+- `app_id` (String) The id of the application that provides the role template and the role.
+- `app_name` (String) The name of the application that provides the role template and the role.
 - `description` (String) The description of the role.
 - `name` (String) The name of the role.
 - `read_only` (Boolean) Shows whether the role can be modified or not.

--- a/docs/data-sources/subaccount_roles.md
+++ b/docs/data-sources/subaccount_roles.md
@@ -40,6 +40,7 @@ data "btp_subaccount_roles" "all" {
 Read-Only:
 
 - `app_id` (String) The ID of the xsuaa application.
+- `app_name` (String) The name of the xsuaa application.
 - `description` (String) The description of the role.
 - `name` (String) The name of the role.
 - `read_only` (Boolean) Shows whether the role can be modified or not.

--- a/docs/data-sources/subaccount_roles.md
+++ b/docs/data-sources/subaccount_roles.md
@@ -39,8 +39,8 @@ data "btp_subaccount_roles" "all" {
 
 Read-Only:
 
-- `app_id` (String) The ID of the xsuaa application.
-- `app_name` (String) The name of the xsuaa application.
+- `app_id` (String) The id of the application that provides the role template and the role.
+- `app_name` (String) The name of the application that provides the role template and the role.
 - `description` (String) The description of the role.
 - `name` (String) The name of the role.
 - `read_only` (Boolean) Shows whether the role can be modified or not.

--- a/internal/provider/datasource_directory_roles.go
+++ b/internal/provider/datasource_directory_roles.go
@@ -79,7 +79,7 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"app_id": schema.StringAttribute{
-							MarkdownDescription: "The ID of the xsuaa application.",
+							MarkdownDescription: "The id of the application that provides the role template and the role.",
 							Computed:            true,
 						},
 						"role_template_name": schema.StringAttribute{
@@ -95,7 +95,7 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"app_name": schema.StringAttribute{
-							MarkdownDescription: "The name of the xsuaa application.",
+							MarkdownDescription: "The name of the application that provides the role template and the role.",
 							Computed:            true,
 						},
 						"scopes": schema.ListNestedAttribute{

--- a/internal/provider/datasource_directory_roles.go
+++ b/internal/provider/datasource_directory_roles.go
@@ -24,6 +24,7 @@ type directoryRolesValue struct {
 	/* OUTPUT */
 	Description types.String         `tfsdk:"description"`
 	IsReadOnly  types.Bool           `tfsdk:"read_only"`
+	AppName     types.String         `tfsdk:"app_name"`
 	Scopes      []directoryRoleScope `tfsdk:"scopes"`
 }
 
@@ -93,6 +94,10 @@ __Further documentation:__
 							MarkdownDescription: "Shows whether the role can be modified or not.",
 							Computed:            true,
 						},
+						"app_name": schema.StringAttribute{
+							MarkdownDescription: "The name of the xsuaa application.",
+							Computed:            true,
+						},
 						"scopes": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
@@ -159,6 +164,7 @@ func (ds *directoryRolesDataSource) Read(ctx context.Context, req datasource.Rea
 			RoleTemplateName:  types.StringValue(role.RoleTemplateName),
 			Description:       types.StringValue(role.Description),
 			IsReadOnly:        types.BoolValue(role.IsReadOnly),
+			AppName:           types.StringValue(role.AppName),
 			Scopes:            []directoryRoleScope{},
 		}
 

--- a/internal/provider/datasource_directory_roles_test.go
+++ b/internal/provider/datasource_directory_roles_test.go
@@ -26,7 +26,7 @@ func TestDataSourceDirectoryRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_directory_roles.uut", "directory_id", "05368777-4934-41e8-9f3c-6ec5f4d564b9"),
 						resource.TestCheckResourceAttr("data.btp_directory_roles.uut", "values.#", "8"),
-						resource.TestMatchResourceAttr("data.btp_directory_roles.uut", "values.app_name", regexp.MustCompile(`(.*?)`)),
+						resource.TestMatchResourceAttr("data.btp_directory_roles.uut", "values.0.app_name", regexp.MustCompile(`(.*?)`)),
 					),
 				},
 			},

--- a/internal/provider/datasource_directory_roles_test.go
+++ b/internal/provider/datasource_directory_roles_test.go
@@ -26,6 +26,7 @@ func TestDataSourceDirectoryRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_directory_roles.uut", "directory_id", "05368777-4934-41e8-9f3c-6ec5f4d564b9"),
 						resource.TestCheckResourceAttr("data.btp_directory_roles.uut", "values.#", "8"),
+						resource.TestMatchResourceAttr("data.btp_directory_roles.uut", "values.app_name", regexp.MustCompile(`(.*?)`)),
 					),
 				},
 			},

--- a/internal/provider/datasource_directory_roles_test.go
+++ b/internal/provider/datasource_directory_roles_test.go
@@ -26,7 +26,7 @@ func TestDataSourceDirectoryRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_directory_roles.uut", "directory_id", "05368777-4934-41e8-9f3c-6ec5f4d564b9"),
 						resource.TestCheckResourceAttr("data.btp_directory_roles.uut", "values.#", "8"),
-						resource.TestMatchResourceAttr("data.btp_directory_roles.uut", "values.0.app_name", regexp.MustCompile(`(.*?)`)),
+						resource.TestCheckResourceAttrSet("data.btp_directory_roles.uut", "values.0.app_name"),
 					),
 				},
 			},

--- a/internal/provider/datasource_globalaccount_roles.go
+++ b/internal/provider/datasource_globalaccount_roles.go
@@ -22,6 +22,7 @@ type globalaccountRolesValue struct {
 	/* OUTPUT */
 	Description types.String             `tfsdk:"description"`
 	IsReadOnly  types.Bool               `tfsdk:"read_only"`
+	AppName     types.String             `tfsdk:"app_name"`
 	Scopes      []globalaccountRoleScope `tfsdk:"scopes"`
 }
 
@@ -80,6 +81,10 @@ __Further documentation:__
 						},
 						"read_only": schema.BoolAttribute{
 							MarkdownDescription: "Shows whether the role can be modified or not.",
+							Computed:            true,
+						},
+						"app_name": schema.StringAttribute{
+							MarkdownDescription: "The name of the xsuaa application.",
 							Computed:            true,
 						},
 						"scopes": schema.ListNestedAttribute{
@@ -148,6 +153,7 @@ func (ds *globalaccountRolesDataSource) Read(ctx context.Context, req datasource
 			RoleTemplateName:  types.StringValue(role.RoleTemplateName),
 			Description:       types.StringValue(role.Description),
 			IsReadOnly:        types.BoolValue(role.IsReadOnly),
+			AppName:           types.StringValue(role.AppName),
 			Scopes:            []globalaccountRoleScope{},
 		}
 

--- a/internal/provider/datasource_globalaccount_roles.go
+++ b/internal/provider/datasource_globalaccount_roles.go
@@ -68,7 +68,7 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"app_id": schema.StringAttribute{
-							MarkdownDescription: "The ID of the xsuaa application.",
+							MarkdownDescription: "The id of the application that provides the role template and the role.",
 							Computed:            true,
 						},
 						"role_template_name": schema.StringAttribute{
@@ -84,7 +84,7 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"app_name": schema.StringAttribute{
-							MarkdownDescription: "The name of the xsuaa application.",
+							MarkdownDescription: "The name of the application that provides the role template and the role.",
 							Computed:            true,
 						},
 						"scopes": schema.ListNestedAttribute{

--- a/internal/provider/datasource_globalaccount_roles_test.go
+++ b/internal/provider/datasource_globalaccount_roles_test.go
@@ -26,7 +26,7 @@ func TestDataSourceGlobalaccountRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "id", "terraformintcanary"),
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "values.#", "11"),
-						resource.TestMatchResourceAttr("data.btp_globalaccount_roles.uut", "values.app_name", regexp.MustCompile(`(.*?)`)),
+						resource.TestMatchResourceAttr("data.btp_globalaccount_roles.uut", "values.0.app_name", regexp.MustCompile(`(.*?)`)),
 					),
 				},
 			},

--- a/internal/provider/datasource_globalaccount_roles_test.go
+++ b/internal/provider/datasource_globalaccount_roles_test.go
@@ -26,6 +26,7 @@ func TestDataSourceGlobalaccountRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "id", "terraformintcanary"),
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "values.#", "11"),
+						resource.TestMatchResourceAttr("data.btp_globalaccount_roles.uut", "values.app_name", regexp.MustCompile(`(.*?)`)),
 					),
 				},
 			},

--- a/internal/provider/datasource_globalaccount_roles_test.go
+++ b/internal/provider/datasource_globalaccount_roles_test.go
@@ -26,7 +26,7 @@ func TestDataSourceGlobalaccountRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "id", "terraformintcanary"),
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "values.#", "11"),
-						resource.TestMatchResourceAttr("data.btp_globalaccount_roles.uut", "values.0.app_name", regexp.MustCompile(`(.*?)`)),
+						resource.TestCheckResourceAttrSet("data.btp_globalaccount_roles.uut", "values.0.app_name"),
 					),
 				},
 			},

--- a/internal/provider/datasource_subaccount_roles.go
+++ b/internal/provider/datasource_subaccount_roles.go
@@ -79,7 +79,7 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"app_id": schema.StringAttribute{
-							MarkdownDescription: "The ID of the xsuaa application.",
+							MarkdownDescription: "The id of the application that provides the role template and the role.",
 							Computed:            true,
 						},
 						"role_template_name": schema.StringAttribute{
@@ -95,7 +95,7 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"app_name": schema.StringAttribute{
-							MarkdownDescription: "The name of the xsuaa application.",
+							MarkdownDescription: "The name of the application that provides the role template and the role.",
 							Computed:            true,
 						},
 						"scopes": schema.ListNestedAttribute{

--- a/internal/provider/datasource_subaccount_roles.go
+++ b/internal/provider/datasource_subaccount_roles.go
@@ -24,6 +24,7 @@ type subaccountRolesValue struct {
 	/* OUTPUT */
 	Description types.String          `tfsdk:"description"`
 	IsReadOnly  types.Bool            `tfsdk:"read_only"`
+	AppName     types.String          `tfsdk:"app_name"`
 	Scopes      []subaccountRoleScope `tfsdk:"scopes"`
 }
 
@@ -93,6 +94,10 @@ __Further documentation:__
 							MarkdownDescription: "Shows whether the role can be modified or not.",
 							Computed:            true,
 						},
+						"app_name": schema.StringAttribute{
+							MarkdownDescription: "The name of the xsuaa application.",
+							Computed:            true,
+						},
 						"scopes": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
@@ -158,6 +163,7 @@ func (ds *subaccountRolesDataSource) Read(ctx context.Context, req datasource.Re
 			RoleTemplateName:  types.StringValue(role.RoleTemplateName),
 			Description:       types.StringValue(role.Description),
 			IsReadOnly:        types.BoolValue(role.IsReadOnly),
+			AppName:           types.StringValue(role.AppName),
 			Scopes:            []subaccountRoleScope{},
 		}
 

--- a/internal/provider/datasource_subaccount_roles_test.go
+++ b/internal/provider/datasource_subaccount_roles_test.go
@@ -26,7 +26,7 @@ func TestDataSourceSubaccountRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_subaccount_roles.uut", "subaccount_id", "ef23ace8-6ade-4d78-9c1f-8df729548bbf"),
 						resource.TestCheckResourceAttr("data.btp_subaccount_roles.uut", "values.#", "24"),
-						resource.TestMatchResourceAttr("data.btp_subaccount_roles.uut", "values.0.app_name", regexp.MustCompile(`(.*?)`)),
+						resource.TestCheckResourceAttrSet("data.btp_subaccount_roles.uut", "values.0.app_name"),
 					),
 				},
 			},

--- a/internal/provider/datasource_subaccount_roles_test.go
+++ b/internal/provider/datasource_subaccount_roles_test.go
@@ -26,6 +26,7 @@ func TestDataSourceSubaccountRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_subaccount_roles.uut", "subaccount_id", "ef23ace8-6ade-4d78-9c1f-8df729548bbf"),
 						resource.TestCheckResourceAttr("data.btp_subaccount_roles.uut", "values.#", "24"),
+						resource.TestMatchResourceAttr("data.btp_subaccount_roles.uut", "values.app_name", regexp.MustCompile(`(.*?)`)),
 					),
 				},
 			},

--- a/internal/provider/datasource_subaccount_roles_test.go
+++ b/internal/provider/datasource_subaccount_roles_test.go
@@ -26,7 +26,7 @@ func TestDataSourceSubaccountRoles(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.btp_subaccount_roles.uut", "subaccount_id", "ef23ace8-6ade-4d78-9c1f-8df729548bbf"),
 						resource.TestCheckResourceAttr("data.btp_subaccount_roles.uut", "values.#", "24"),
-						resource.TestMatchResourceAttr("data.btp_subaccount_roles.uut", "values.app_name", regexp.MustCompile(`(.*?)`)),
+						resource.TestMatchResourceAttr("data.btp_subaccount_roles.uut", "values.0.app_name", regexp.MustCompile(`(.*?)`)),
 					),
 				},
 			},

--- a/internal/provider/fixtures/datasource_directory_roles.not_security_enabled.yaml
+++ b/internal/provider/fixtures/datasource_directory_roles.not_security_enabled.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - c85bdc00-4654-c4f0-978a-9dccb1381169
+                - 11d05ccc-a5c6-2306-ba17-2915123b7e07
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:15 GMT
+                - Wed, 06 Sep 2023 14:17:01 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bd5a8b78-16f3-4306-76b7-c7cee04c43d8
+                - fe064a6e-44ae-469c-6c63-64ce12c70dd6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 394.762ms
+        duration: 1.2037022s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - fff8ccc9-30be-43e3-5ef5-a7d3068dc247
+                - f03efc1e-f0ce-3029-7c3d-47a91b3d8acf
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:15 GMT
+                - Wed, 06 Sep 2023 14:17:02 GMT
             Expires:
                 - "0"
             Pragma:
@@ -127,9 +127,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a8bf476d-654f-48d5-60dd-323c61739358
+                - 50d92d56-fe26-4be4-4c09-05a6265f7bba
             X-Xss-Protection:
                 - "0"
         status: 403 Forbidden
         code: 403
-        duration: 109.161ms
+        duration: 152.8658ms

--- a/internal/provider/fixtures/datasource_directory_roles.yaml
+++ b/internal/provider/fixtures/datasource_directory_roles.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 827dc05d-2357-5586-e97c-eee57649e7f9
+                - 8dc1710c-e9a6-b0c8-f645-1c50f786e32d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:09 GMT
+                - Wed, 06 Sep 2023 14:16:55 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 707dfcb4-fd65-4ae4-4289-059cf91ab26d
+                - 2b6ec678-dc10-4a7e-6039-0c4fc9a3a334
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 438.7661ms
+        duration: 770.3461ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b11daf64-c0e7-439f-6b27-371fd876e28c
+                - 02b98de0-48ec-4ba3-78f0-b256e50e8efb
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:10 GMT
+                - Wed, 06 Sep 2023 14:16:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -129,12 +129,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ef18af6f-fdf4-4e89-6a89-2326b88faf8a
+                - 6563648a-e82d-4f6d-6d6f-5b06b68ef3c7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 349.4278ms
+        duration: 437.423ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -155,7 +155,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7e2f9fba-5148-0389-0ce7-d0ceaed839ef
+                - bbdcece8-9199-c92a-922b-775528db76f4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -177,7 +177,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:10 GMT
+                - Wed, 06 Sep 2023 14:16:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -193,12 +193,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1d0ee4e7-0b7d-4449-5730-8319de61ca42
+                - f1079818-b399-4981-4233-9af3b02ba6f9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 466.4285ms
+        duration: 367.659ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 70f9caba-df71-1d41-866e-58a04e40059e
+                - 642cb5f8-1087-9177-945c-c72fb412b071
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -245,7 +245,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:11 GMT
+                - Wed, 06 Sep 2023 14:16:56 GMT
             Expires:
                 - "0"
             Pragma:
@@ -263,12 +263,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 37a88ab0-5927-4489-73f5-b720ed8bd80e
+                - 71d03fb4-f30d-47f5-5a9f-f743b850c235
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 348.4244ms
+        duration: 335.1015ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -289,7 +289,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 274eb70a-ca3a-ccfb-4f77-1388c75904cc
+                - 428fbb76-7780-2328-1f19-c7f9e2d5e854
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -311,7 +311,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:11 GMT
+                - Wed, 06 Sep 2023 14:16:57 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,12 +327,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8e6ddbec-215e-465f-6cb6-bba0253eb2e9
+                - 9b932bcc-8af5-4c4f-7fc7-d9384978b91b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 385.8441ms
+        duration: 604.7901ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -353,7 +353,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d72a80d4-cdcd-ab19-7482-f130ced3454c
+                - fe459dfa-6bef-23d6-351a-b05d7ce8d36a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -379,7 +379,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:12 GMT
+                - Wed, 06 Sep 2023 14:16:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -397,12 +397,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - da8fe3e0-e4f1-4113-5ad6-2ce5380dec6f
+                - 2679574f-61ed-4e8a-758f-1d5520867f1b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 309.4971ms
+        duration: 395.3454ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -423,7 +423,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 5d0a7a75-8d46-1978-8873-1385346075c0
+                - 30cd3089-702c-c25c-8757-9d84f8bdd264
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -445,7 +445,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:12 GMT
+                - Wed, 06 Sep 2023 14:16:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -461,12 +461,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4614ee6a-d5eb-4fc2-6001-1f0ec0163c70
+                - 6f5c8a25-14ec-4cf9-6f64-062b5cef89e4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 498.87ms
+        duration: 321.8611ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -487,7 +487,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ccf9ab2b-a6b5-84f8-6913-3ce9d58efbf5
+                - e0e2c8bb-75f3-e66a-06f8-0bbe051a27c6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -513,7 +513,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:13 GMT
+                - Wed, 06 Sep 2023 14:16:58 GMT
             Expires:
                 - "0"
             Pragma:
@@ -531,12 +531,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8ffbd779-d62a-4cd9-7542-cc0c5e1171a9
+                - a4f77653-1fe2-4e84-747a-8e4331e483e5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 349.0039ms
+        duration: 391.4438ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -557,7 +557,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 14d2111b-6d29-59b9-2723-3058d511489f
+                - 82334395-e546-1332-524d-e6190f431fa4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:13 GMT
+                - Wed, 06 Sep 2023 14:16:59 GMT
             Expires:
                 - "0"
             Pragma:
@@ -595,12 +595,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a069361b-8080-433b-6937-720dd9d4b4cf
+                - e180d082-6d43-4bd9-6cb7-fd5c01cc2d68
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 342.2471ms
+        duration: 806.4575ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -621,7 +621,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - f37959ab-6951-b406-3cea-af7b5898a9cb
+                - 152243b1-31ff-a8e3-d442-d2b046c13be5
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -647,7 +647,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:13 GMT
+                - Wed, 06 Sep 2023 14:17:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -665,12 +665,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 330c48d6-c5cf-4ce4-62a8-1fa369dfc780
+                - 454c6ae1-cd77-42e7-4a41-e34318662de2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 322.9103ms
+        duration: 273.3707ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -691,7 +691,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 333cb636-1355-d60b-4ae7-09ec8b33b66e
+                - a64c6d4b-d9ad-f6df-807c-d5c080b68a79
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -713,7 +713,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:14 GMT
+                - Wed, 06 Sep 2023 14:17:00 GMT
             Expires:
                 - "0"
             Pragma:
@@ -729,9 +729,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9714add9-8a7d-4ba0-64ec-7fb915391f5b
+                - 0c18b5a1-2d4d-4302-6d99-5b1eb0d841b5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 592.6114ms
+        duration: 390.3916ms

--- a/internal/provider/fixtures/datasource_globalaccount_roles.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_roles.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 47d73e75-175c-b51d-7541-94959b157ebf
+                - aa2003a0-ea25-cc34-30f5-7dce4c0898b7
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:53 GMT
+                - Wed, 06 Sep 2023 14:16:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ed8dadf5-fd52-4f60-48f8-c417c44343fb
+                - 5d76a6e8-748f-4508-4c69-b4da4f44e44a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 431.8598ms
+        duration: 1.5218428s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 945181e6-778a-ce22-584b-9d5d8cd59bbc
+                - 59adb937-6393-00b1-6002-9df0c11809df
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:53 GMT
+                - Wed, 06 Sep 2023 14:16:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -129,12 +129,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ae1daff1-d808-4361-5d4f-a05f75607cf0
+                - 2af1eb55-fa08-482c-6265-c416e7c30a62
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.8797ms
+        duration: 314.5298ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -155,7 +155,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - cfa26491-0605-25d7-dc77-c7a3c325db2e
+                - 94759b69-9cbc-f465-6a23-f9499bb514f9
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -177,7 +177,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:54 GMT
+                - Wed, 06 Sep 2023 14:16:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -193,12 +193,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e15d7660-1d08-465b-6799-2e040019b044
+                - 529cc084-ed2a-46bd-63d1-7b8466453f99
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 955.5374ms
+        duration: 353.2772ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -219,7 +219,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 018e5d61-c615-7474-1080-99391f74bbbd
+                - 09826613-00ab-6a7f-8b66-fcbac86ab3a2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -245,7 +245,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:54 GMT
+                - Wed, 06 Sep 2023 14:16:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -263,12 +263,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f2efa0e6-394a-402c-5e09-72b20737d0ba
+                - 6dcb2930-d144-449c-6264-02cf36b015db
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.1592ms
+        duration: 312.6926ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -289,7 +289,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 797d702b-bbf0-6200-d005-928e8dfbff5a
+                - 7bdccbd2-7a3f-d143-9280-08837c1b459c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -311,7 +311,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:55 GMT
+                - Wed, 06 Sep 2023 14:16:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -327,12 +327,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7ef4522d-1dc7-4df6-4f52-6add7b92cde5
+                - a7dd8b74-017b-47ca-534b-78adbbdfac61
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 397.8408ms
+        duration: 705.4029ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -353,7 +353,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a4f22182-e15d-caf4-c8f2-b49c44757dd2
+                - bf29d2ea-8e2d-d4d7-063e-f4ea2e8f9377
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -379,7 +379,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:55 GMT
+                - Wed, 06 Sep 2023 14:16:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -397,12 +397,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 78ce874b-4ed3-4eb0-57b6-d116bf9d7ffa
+                - cd01f01f-4894-476d-798e-03350e927f8f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 263.875ms
+        duration: 279.3987ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -423,7 +423,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 163be852-d46e-657c-d9d0-8507a213e067
+                - 7ecfa155-846f-07d3-893b-b9ff45adaf15
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -445,7 +445,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:56 GMT
+                - Wed, 06 Sep 2023 14:16:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -461,12 +461,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1154a206-3129-421d-4519-3fda4f3e45a0
+                - 5e0c3068-184d-4039-759a-e3c0f541a199
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 313.335ms
+        duration: 376.0707ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -487,7 +487,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - aca48251-5103-09c2-b8d7-98a4a2f53236
+                - 3dc37cb3-a546-c20c-5b1e-b930feb239b6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -513,7 +513,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:56 GMT
+                - Wed, 06 Sep 2023 14:16:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -531,12 +531,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 98c21a2f-553a-4207-68a5-5140dc4f5c23
+                - db9e3131-ab6e-4d2e-663f-a80413ccda9e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 261.5365ms
+        duration: 217.176ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -557,7 +557,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7ed008aa-dc43-3764-25ed-b540b94bf3a3
+                - 86f97601-169c-5c57-47fc-6004b485c8a4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:57 GMT
+                - Wed, 06 Sep 2023 14:16:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -595,12 +595,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 85dcfc48-a436-44bf-5aad-bd49846df4fa
+                - cab9fcca-77f0-44fb-77a4-ae54ca33009b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 924.9283ms
+        duration: 465.3127ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -621,7 +621,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 23426086-5e26-fb79-8d9e-de60833aaefa
+                - 65396125-91d7-04bf-279a-137d0001e8b6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -647,7 +647,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:57 GMT
+                - Wed, 06 Sep 2023 14:16:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -665,12 +665,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f59db8a8-ce0d-4184-750d-261cc029991c
+                - fde65ce0-c3f5-4062-420e-4c43dfa02cee
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 249.5225ms
+        duration: 247.6971ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -691,7 +691,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4bdf8708-7f8b-0e7b-4d2a-5d3da91ea1d3
+                - 7f31bb82-1477-90dc-9b60-8bcf5877ee13
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -713,7 +713,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:41:58 GMT
+                - Wed, 06 Sep 2023 14:16:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -729,9 +729,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 48fede8b-b6b1-4330-70c8-cffbf7b4bb06
+                - cda9eba1-bbac-4874-7100-1d10ea9b51e3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 362.0613ms
+        duration: 1.169479s

--- a/internal/provider/fixtures/datasource_subaccount_roles.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_roles.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 746e5ee8-cc64-c04a-5340-1256c2208146
+                - 4fb98637-769d-27aa-5302-f2603a25e658
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:45:57 GMT
+                - Wed, 06 Sep 2023 14:17:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1fce2a8f-2929-4b66-71f5-eae678a8c313
+                - 2d0982ca-e6c9-451b-7f1e-3bb5e594651b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 514.9991ms
+        duration: 518.3102ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4a283e86-b3fc-c0b2-1f77-196149b18f52
+                - c5846d4e-49dc-8a08-9d39-6fbd181f9699
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:45:57 GMT
+                - Wed, 06 Sep 2023 14:17:28 GMT
             Expires:
                 - "0"
             Location:
@@ -131,12 +131,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - aa80c3ce-66d7-4472-4306-9d19da4653b0
+                - 5b4429fc-a8ea-4191-6b6b-504a84252d27
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 127.0647ms
+        duration: 106.655ms
     - id: 2
       request:
         proto: ""
@@ -159,7 +159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4a283e86-b3fc-c0b2-1f77-196149b18f52
+                - c5846d4e-49dc-8a08-9d39-6fbd181f9699
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -187,7 +187,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:45:58 GMT
+                - Wed, 06 Sep 2023 14:17:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -209,12 +209,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 97a1b8f1-f5e7-429e-574b-2c49a670ac3f
+                - 6f2041d5-3c45-4743-4ea7-97830a154883
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 226.3938ms
+        duration: 306.7575ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -235,7 +235,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - f5bd5dad-eef7-df22-2c2f-304906c3dfef
+                - 7fb5ec49-2e90-aca8-79b7-0d02e0602b80
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -257,7 +257,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:45:58 GMT
+                - Wed, 06 Sep 2023 14:17:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -273,12 +273,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0a31a419-1206-45ae-4eb5-379a02c6bf30
+                - 67c453cb-5dd8-4611-4484-1ed73a2afe9e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 599.1901ms
+        duration: 1.0731799s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -299,7 +299,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 26ea838a-287b-94be-69c0-7ae56d7e5ad1
+                - df5d2f22-88fe-4031-5d8e-92b206ab49fb
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -325,7 +325,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:45:59 GMT
+                - Wed, 06 Sep 2023 14:17:29 GMT
             Expires:
                 - "0"
             Location:
@@ -345,12 +345,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f67e3c86-5797-4943-5476-2e17dd8ad744
+                - 34aabd09-e092-430d-4c86-964689d028b4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 131.7275ms
+        duration: 126.0344ms
     - id: 5
       request:
         proto: ""
@@ -373,7 +373,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 26ea838a-287b-94be-69c0-7ae56d7e5ad1
+                - df5d2f22-88fe-4031-5d8e-92b206ab49fb
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -401,7 +401,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:45:59 GMT
+                - Wed, 06 Sep 2023 14:17:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -423,12 +423,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6b855e8f-f3cc-4978-497d-cce75a6e375a
+                - f48991c3-bbb4-4ac9-567c-45f9f8d2c34b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 171.2035ms
+        duration: 213.8406ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -449,7 +449,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 5dd621e7-f3cd-df43-d36f-7862827126ac
+                - 67959894-9165-2d32-2d7b-d2c958ba8dfd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -471,7 +471,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:45:59 GMT
+                - Wed, 06 Sep 2023 14:17:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1e278ab0-b472-464e-62d9-0d8255a27d68
+                - bed16d14-8487-44ad-7081-2049e4b69e2e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 344.1076ms
+        duration: 325.7049ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 42a15fe7-55dc-f185-4658-bc5bf6f232a0
+                - 88badef6-5519-6480-a20f-f427c691f749
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -539,7 +539,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:45:59 GMT
+                - Wed, 06 Sep 2023 14:17:30 GMT
             Expires:
                 - "0"
             Location:
@@ -559,12 +559,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 635340d3-5621-46d2-773a-e40c686b6383
+                - 9f9c17e0-8a6d-4bda-524a-3010474e1be3
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 109.3547ms
+        duration: 120.8735ms
     - id: 8
       request:
         proto: ""
@@ -587,7 +587,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 42a15fe7-55dc-f185-4658-bc5bf6f232a0
+                - 88badef6-5519-6480-a20f-f427c691f749
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -615,7 +615,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:46:00 GMT
+                - Wed, 06 Sep 2023 14:17:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -637,12 +637,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4526a4bc-0ac0-4c89-6896-3d65aba54120
+                - 00174966-4a4d-4091-52b8-f327c04d4cd9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 146.4279ms
+        duration: 256.1029ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -663,7 +663,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ebda89f4-4d79-5e76-8c45-6cd2e2c580c6
+                - d6cbea33-30bc-da69-38e2-ab565b022641
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -685,7 +685,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:46:00 GMT
+                - Wed, 06 Sep 2023 14:17:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,12 +701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8c972ae9-cfe7-4af6-4e65-fd71c0324131
+                - e5799e61-86dc-4299-5ba7-116a62cc2094
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 333.5662ms
+        duration: 702.5761ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -727,7 +727,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7df21f8d-3562-be7e-107b-f7d47b5fa94b
+                - 8862e3ff-231e-eb23-13ad-2eb5f77f75a7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -753,7 +753,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:46:00 GMT
+                - Wed, 06 Sep 2023 14:17:31 GMT
             Expires:
                 - "0"
             Location:
@@ -773,12 +773,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 26f9a4e2-99b6-4df1-7e29-b78ecc2e1d70
+                - d334351a-9a1b-4589-6e59-c2f32157ae13
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 145.5996ms
+        duration: 134.6126ms
     - id: 11
       request:
         proto: ""
@@ -801,7 +801,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7df21f8d-3562-be7e-107b-f7d47b5fa94b
+                - 8862e3ff-231e-eb23-13ad-2eb5f77f75a7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -829,7 +829,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:46:00 GMT
+                - Wed, 06 Sep 2023 14:17:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -851,12 +851,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3c4ae5a5-7dc9-4ca2-578b-cd643f70ed06
+                - fbf9ae05-2370-4adc-4778-083044c2ce46
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 139.8216ms
+        duration: 189.05ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -877,7 +877,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d07b2672-e183-6256-116e-874ebaefa0ce
+                - 566f04c8-d731-6d0a-bc41-3a254c26edb4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -899,7 +899,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:46:01 GMT
+                - Wed, 06 Sep 2023 14:17:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -915,12 +915,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6018c121-961f-4b50-479d-fef5f472fdaa
+                - 5655a82e-95be-44af-5e98-e4f9b410f632
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 893.1871ms
+        duration: 351.9353ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -941,7 +941,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d8ffa0f0-26a0-1361-08b1-28d543cffcb1
+                - 688525e3-7096-0180-ccad-28ce5f7b0f12
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -967,7 +967,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:46:01 GMT
+                - Wed, 06 Sep 2023 14:17:32 GMT
             Expires:
                 - "0"
             Location:
@@ -987,12 +987,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 6099afc1-4a27-4616-566a-7b715cc01a32
+                - e848be00-7408-4f0a-6dda-70f465da111a
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 122.0096ms
+        duration: 129.9938ms
     - id: 14
       request:
         proto: ""
@@ -1015,7 +1015,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d8ffa0f0-26a0-1361-08b1-28d543cffcb1
+                - 688525e3-7096-0180-ccad-28ce5f7b0f12
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1043,7 +1043,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:46:02 GMT
+                - Wed, 06 Sep 2023 14:17:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1065,12 +1065,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 22ab0a70-2a8d-4037-4f21-173eaefdca50
+                - d89862da-fa21-4cb8-7d07-fc5914f88adb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 165.5572ms
+        duration: 177.3825ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1091,7 +1091,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 35f82443-f98a-9867-2a44-d09102d3ba29
+                - 12930cd2-709d-69b7-6ce1-efab2036a00d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1113,7 +1113,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:46:02 GMT
+                - Wed, 06 Sep 2023 14:17:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1129,9 +1129,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7f88cb3b-a37a-4fe6-4d82-8076592831f5
+                - 93ec4c1b-a3b7-42ec-65f0-da4e35408838
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 408.6522ms
+        duration: 819.9835ms


### PR DESCRIPTION
## Purpose

* In order to create customer-defined role collections the app name is needed for filtering the results of all available roles in a subaccount/directory/globalaccount. This PR introduces the field to the corresponding data sources.
* Closes #413 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

The API for getting a dedicated single role does not return this field. Consequently,  we added the field exclusively to the "list" data sources

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
