### PR TITLE
feat: subscription with empty plan name

### DIFF
--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -105,6 +105,7 @@ func (f *accountsSubaccountFacade) Subscribe(ctx context.Context, subaccountId s
 		"subscriptionParams": parameters,
 	}
 
+	// The plan name can be empty in case of subscrioption hosted in the same account
 	if len(planName) > 0 {
 		commandOptions["planName"] = planName
 	}

--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -105,7 +105,7 @@ func (f *accountsSubaccountFacade) Subscribe(ctx context.Context, subaccountId s
 		"subscriptionParams": parameters,
 	}
 
-	// The plan name can be empty in case of subscrioption hosted in the same account
+	// The plan name can be empty in case of subscription hosted in the same account. In this case the plan name is not required and must not be transferred to the API call.
 	if len(planName) > 0 {
 		commandOptions["planName"] = planName
 	}

--- a/internal/btpcli/facade_accounts_subaccount.go
+++ b/internal/btpcli/facade_accounts_subaccount.go
@@ -99,12 +99,16 @@ func (f *accountsSubaccountFacade) Delete(ctx context.Context, subaccountId stri
 }
 
 func (f *accountsSubaccountFacade) Subscribe(ctx context.Context, subaccountId string, appName string, planName string, parameters string) (saas_manager_service.SubscriptionAssignmentResponseObject, CommandResponse, error) {
-	return doExecute[saas_manager_service.SubscriptionAssignmentResponseObject](f.cliClient, ctx, NewSubscribeRequest(f.getCommand(), map[string]string{
+	commandOptions := map[string]string{
 		"subaccount":         subaccountId,
 		"appName":            appName,
-		"planName":           planName,
 		"subscriptionParams": parameters,
-	}))
+	}
+
+	if len(planName) > 0 {
+		commandOptions["planName"] = planName
+	}
+	return doExecute[saas_manager_service.SubscriptionAssignmentResponseObject](f.cliClient, ctx, NewSubscribeRequest(f.getCommand(), commandOptions))
 }
 
 func (f *accountsSubaccountFacade) Unsubscribe(ctx context.Context, subaccountId string, appName string) (saas_manager_service.SubscriptionAssignmentResponseObject, CommandResponse, error) {

--- a/internal/btpcli/facade_accounts_subaccount_test.go
+++ b/internal/btpcli/facade_accounts_subaccount_test.go
@@ -185,6 +185,7 @@ func TestAccountsSubaccountFacade_Subscribe(t *testing.T) {
 	subaccountId := "6aa64c2f-38c1-49a9-b2e8-cf9fea769b7f"
 	appName := "SAPLaunchpad"
 	planName := "free"
+	planNameEmpty := ""
 	parameters := "{}"
 
 	t.Run("constructs the CLI params correctly", func(t *testing.T) {
@@ -204,6 +205,28 @@ func TestAccountsSubaccountFacade_Subscribe(t *testing.T) {
 		defer srv.Close()
 
 		_, res, err := uut.Accounts.Subaccount.Subscribe(context.TODO(), subaccountId, appName, planName, parameters)
+
+		if assert.True(t, srvCalled) && assert.NoError(t, err) {
+			assert.Equal(t, 200, res.StatusCode)
+		}
+	})
+
+	t.Run("constructs the CLI params correctly with empty plan", func(t *testing.T) {
+		var srvCalled bool
+
+		uut, srv := prepareClientFacadeForTest(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			srvCalled = true
+
+			assertCall(t, r, command, ActionSubscribe, map[string]string{
+				"subaccount":         subaccountId,
+				"appName":            appName,
+				"subscriptionParams": parameters,
+			})
+
+		}))
+		defer srv.Close()
+
+		_, res, err := uut.Accounts.Subaccount.Subscribe(context.TODO(), subaccountId, appName, planNameEmpty, parameters)
 
 		if assert.True(t, srvCalled) && assert.NoError(t, err) {
 			assert.Equal(t, 200, res.StatusCode)


### PR DESCRIPTION
## Purpose

* This PR enables the option to provide an empty plan name when executing an app subscription. This scenario can occur if the subscribing account is in the same account as the one providing the app subscription
* Fixes #342 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
