### PR TITLE
feat: improve id token login

### DIFF
--- a/internal/btpcli/clienttypes.go
+++ b/internal/btpcli/clienttypes.go
@@ -20,9 +20,8 @@ func NewLoginRequestWithCustomIDP(idp string, globalaccountSubdomain string, use
 	}
 }
 
-func NewIdTokenLoginRequest(idp string, globalaccountSubdomain string, idToken string) *IdTokenLoginRequest {
+func NewIdTokenLoginRequest(globalaccountSubdomain string, idToken string) *IdTokenLoginRequest {
 	return &IdTokenLoginRequest{
-		IdentityProvider:       idp,
 		GlobalAccountSubdomain: globalaccountSubdomain,
 		IdToken:                idToken,
 	}
@@ -36,7 +35,6 @@ type LoginRequest struct {
 }
 
 type IdTokenLoginRequest struct {
-	IdentityProvider       string `json:"customIdp"`
 	GlobalAccountSubdomain string `json:"subdomain"`
 	IdToken                string `json:"idToken"`
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -276,6 +276,47 @@ func notContainsCheckFunc(unexpectedSubString string) testingResource.CheckResou
 	}
 }
 
+func TestProvider_ConfigurationWithIdToken(t *testing.T) {
+	t.Run("error path - attribute conflicts with idtoken", func(t *testing.T) {
+		testingResource.Test(t, testingResource.TestCase{
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: getProviders(nil),
+			Steps: []testingResource.TestStep{
+				{
+					Config: `
+provider "btp" {
+	globalaccount  = "terraformintcanary"
+	username       = "username"
+	idtoken        = "idtoken"
+}
+data "btp_whoami" "me" {}`,
+					ExpectError: regexp.MustCompile(`Attribute "username" cannot be specified when "idtoken" is specified`),
+				},
+				{
+					Config: `
+provider "btp" {
+	globalaccount  = "terraformintcanary"
+	password       = "password"
+	idtoken        = "idtoken"
+}
+data "btp_whoami" "me" {}`,
+					ExpectError: regexp.MustCompile(`Attribute "password" cannot be specified when "idtoken" is specified`),
+				},
+				{
+					Config: `
+provider "btp" {
+	globalaccount  = "terraformintcanary"
+	idp            = "idp"
+	idtoken        = "idtoken"
+}
+data "btp_whoami" "me" {}`,
+					ExpectError: regexp.MustCompile(`Attribute "idp" cannot be specified when "idtoken" is specified`),
+				},
+			},
+		})
+	})
+}
+
 func TestProvider_HasResources(t *testing.T) {
 	expectedResources := []string{
 		"btp_directory",


### PR DESCRIPTION
## Purpose

This is a follow up for PR #406 adapting latest changes to the idtoken login endpoint in the btp CLI server.

The idtoken based login is now providing authentication information and is therefore compatible again with the btp_whoami data source.

Furthermore, the error handling on server side was improved which is resulting in more helpful error messages for the terraform user.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [ ] The PR has the matching labels assigned to it.
* [ ] The PR has a milestone assigned to it.
* [ ] If the PR closes an issue, the issue is referenced.
* [ ] Possible follow-up items are created and linked.
