### PR TITLE
chore: pin Terraform CLI version to 1.5.x

### DIFF
--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -3,7 +3,9 @@
 	"image": "mcr.microsoft.com/devcontainers/go:1.21-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/terraform:1": {},
+		"ghcr.io/devcontainers/features/terraform:1": {
+			"version": "1.5.7"
+		},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {

--- a/.devcontainer/withenvfile/devcontainer.json
+++ b/.devcontainer/withenvfile/devcontainer.json
@@ -3,7 +3,9 @@
 	"image": "mcr.microsoft.com/devcontainers/go:1.21-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/terraform:1": {},
+		"ghcr.io/devcontainers/features/terraform:1": {
+			"version": "1.5.7"
+		},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           - '1.2.*'
           - '1.3.*'
           - '1.4.*'
-          - '1.5.x'
+          - '1.5.*'
     steps:
       - uses: actions/checkout@v4 # v4.0.0
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0


### PR DESCRIPTION
## Purpose

* This PR pins the Terraform binaries (falling under BUSL/BSL license with the update to 1.6) to 1.5.7
* This is in response to the request of the SAP OSPO and their ongoing clarification with Hashicorp
* The change does not impact the provider but the dev container definition as well as the test matrix

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: version pinning
```

## How to Test

Create a new dev container

## What to Check

Verify that the following are valid:

Terraform CLI version is 1.5.7

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
