### PR TITLE
feat: support update of subaccount trust configurations

### DIFF
--- a/docs/data-sources/subaccount_trust_configuration.md
+++ b/docs/data-sources/subaccount_trust_configuration.md
@@ -45,11 +45,15 @@ data "btp_subaccount_trust_configuration" "custom" {
 
 ### Read-Only
 
+- `auto_create_shadow_users` (Boolean) Shows whether any user from the tenant can log in. If not set, only the ones who already have a shadow user can log in.
+- `available_for_user_logon` (Boolean) Shows whether end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
 - `description` (String) The description of the trust configuration.
-- `id` (String) The ID of the trust configuration.
-- `identity_provider` (String) The name of the identity provider.
-- `name` (String) The name of the trust configuration.
+- `domain` (String) The tenant's domain which should be used for user logon.
+- `id` (String, Deprecated) The origin of the identity provider.
+- `identity_provider` (String) The name of the Identity Authentication tenant the subaccount is connected to.
+- `link_text` (String) Short string that helps users to identify the link for login.
+- `name` (String) The display name of the trust configuration.
 - `protocol` (String) The protocol used to establish trust with the identity provider.
 - `read_only` (Boolean) Shows whether the trust configuration can be modified.
-- `status` (String) Shows whether the identity provider is currently active or not.
+- `status` (String) Shows whether the identity provider is currently 'active' or 'inactive'.
 - `type` (String) The trust type.

--- a/docs/data-sources/subaccount_trust_configurations.md
+++ b/docs/data-sources/subaccount_trust_configurations.md
@@ -44,12 +44,16 @@ data "btp_subaccount_trust_configurations" "all" {
 
 Read-Only:
 
+- `auto_create_shadow_users` (Boolean) Shows whether any user from the tenant can log in. If not set, only the ones who already have a shadow user can log in.
+- `available_for_user_logon` (Boolean) Shows whether end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
 - `description` (String) The description of the trust configuration.
-- `id` (String) The ID of the trust configuration.
-- `identity_provider` (String) The name of the identity provider.
-- `name` (String) The name of the trust configuration.
+- `domain` (String) The tenant's domain which should be used for user logon.
+- `id` (String, Deprecated) The origin of the identity provider.
+- `identity_provider` (String) The name of the Identity Authentication tenant the subaccount is connected to.
+- `link_text` (String) Short string that helps users to identify the link for login.
+- `name` (String) The display name of the trust configuration.
 - `origin` (String) The origin of the identity provider.
 - `protocol` (String) The protocol used to establish trust with the identity provider.
 - `read_only` (Boolean) Shows whether the trust configuration can be modified.
-- `status` (String) Shows whether the identity provider is currently active or not.
+- `status` (String) Shows whether the identity provider is currently 'active' or 'inactive'.
 - `type` (String) The trust type.

--- a/docs/resources/subaccount_trust_configuration.md
+++ b/docs/resources/subaccount_trust_configuration.md
@@ -39,21 +39,25 @@ resource "btp_subaccount_trust_configuration" "fully_customized" {
 
 ### Required
 
-- `identity_provider` (String) The name of the Identity Authentication tenant that you want the subaccount to connect.
+- `identity_provider` (String) The name of the Identity Authentication tenant that you want to connect to the subaccount.
 - `subaccount_id` (String) The ID of the subaccount.
 
 ### Optional
 
-- `description` (String) A description for the identity provider.
-- `name` (String) The name of the identity provider.
-- `origin` (String) The origin of the identity provider.
+- `auto_create_shadow_users` (Boolean) Determines that any user from the tenant can log in. If not set, only the ones who already have a shadow user can log in.
+- `available_for_user_logon` (Boolean) Determines that end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
+- `description` (String) Description of the trust configuration.
+- `domain` (String) The tenant's domain which should be used for user logon.
+- `link_text` (String) Short string that helps users to identify the link for login.
+- `name` (String) The display name of the trust configuration.
+- `status` (String) Determines whether the identity provider is currently 'active' or 'inactive'.
 
 ### Read-Only
 
-- `id` (String) The origin of the identity provider.
+- `id` (String, Deprecated) The origin of the identity provider.
+- `origin` (String) The origin of the identity provider.
 - `protocol` (String) The protocol used to establish trust with the identity provider.
 - `read_only` (Boolean) Shows whether the trust configuration can be modified.
-- `status` (String) Shows whether the identity provider is currently active or not.
 - `type` (String) The trust type.
 
 

--- a/internal/btpcli/facade_security_trust.go
+++ b/internal/btpcli/facade_security_trust.go
@@ -45,7 +45,7 @@ func (f *securityTrustFacade) GetBySubaccount(ctx context.Context, subaccountId 
 	}))
 }
 
-type TrustConfigurationInput struct {
+type TrustConfigurationCreateInput struct {
 	IdentityProvider string  `btpcli:"iasTenantUrl"`
 	Name             *string `btpcli:"name"`
 	Description      *string `btpcli:"description"`
@@ -53,7 +53,7 @@ type TrustConfigurationInput struct {
 	Domain           *string `btpcli:"domain"`
 }
 
-func (f *securityTrustFacade) CreateByGlobalAccount(ctx context.Context, args TrustConfigurationInput) (xsuaa_trust.ModifyTrustConfigurationResponseObject, CommandResponse, error) {
+func (f *securityTrustFacade) CreateByGlobalAccount(ctx context.Context, args TrustConfigurationCreateInput) (xsuaa_trust.ModifyTrustConfigurationResponseObject, CommandResponse, error) {
 	params, err := tfutils.ToBTPCLIParamsMap(args)
 
 	if err != nil {
@@ -65,7 +65,7 @@ func (f *securityTrustFacade) CreateByGlobalAccount(ctx context.Context, args Tr
 	return doExecute[xsuaa_trust.ModifyTrustConfigurationResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
 }
 
-func (f *securityTrustFacade) CreateBySubaccount(ctx context.Context, subaccountId string, args TrustConfigurationInput) (xsuaa_trust.ModifyTrustConfigurationResponseObject, CommandResponse, error) {
+func (f *securityTrustFacade) CreateBySubaccount(ctx context.Context, subaccountId string, args TrustConfigurationCreateInput) (xsuaa_trust.ModifyTrustConfigurationResponseObject, CommandResponse, error) {
 	params, err := tfutils.ToBTPCLIParamsMap(args)
 
 	if err != nil {
@@ -75,6 +75,31 @@ func (f *securityTrustFacade) CreateBySubaccount(ctx context.Context, subaccount
 	params["subaccount"] = subaccountId
 
 	return doExecute[xsuaa_trust.ModifyTrustConfigurationResponseObject](f.cliClient, ctx, NewCreateRequest(f.getCommand(), params))
+}
+
+type TrustConfigurationUpdateInput struct {
+	OriginKey             string  `btpcli:"originKey"`
+	IdentityProvider      string  `btpcli:"iasTenantUrl"`
+	Name                  *string `btpcli:"name"`
+	Description           *string `btpcli:"description"`
+	Domain                *string `btpcli:"domain"`
+	LinkText              *string `btpcli:"linkText"`
+	AvailableForUserLogon bool    `btpcli:"userLogon"`
+	AutoCreateShadowUsers bool    `btpcli:"shadowUsers"`
+	Status                string  `btpcli:"status"`
+}
+
+func (f *securityTrustFacade) UpdateBySubaccount(ctx context.Context, subaccountId string, args TrustConfigurationUpdateInput) (xsuaa_trust.TrustConfigurationResponseObject, CommandResponse, error) {
+	params, err := tfutils.ToBTPCLIParamsMap(args)
+
+	if err != nil {
+		return xsuaa_trust.TrustConfigurationResponseObject{}, CommandResponse{}, err
+	}
+
+	params["subaccount"] = subaccountId
+	params["refreshTrust"] = "true"
+
+	return doExecute[xsuaa_trust.TrustConfigurationResponseObject](f.cliClient, ctx, NewUpdateRequest(f.getCommand(), params))
 }
 
 func (f *securityTrustFacade) DeleteByGlobalAccount(ctx context.Context, originKey string) (xsuaa_trust.ModifyTrustConfigurationResponseObject, CommandResponse, error) {

--- a/internal/btpcli/types/xsuaa_trust/trust_configuration_response_object.go
+++ b/internal/btpcli/types/xsuaa_trust/trust_configuration_response_object.go
@@ -1,19 +1,16 @@
 package xsuaa_trust
 
 type TrustConfigurationResponseObject struct {
-	// The name of the identity provider.
-	Name string `json:"name,omitempty"`
-	// The origin of the identity provider.
-	OriginKey   string `json:"originKey,omitempty"`
-	TypeOfTrust string `json:"typeOfTrust,omitempty"`
-	// Whether the identity provider is currently active or not.
-	Status string `json:"status,omitempty"`
-	// A description for the identity provider.
-	Description string `json:"description,omitempty"`
-	// The protocol used to establish trust with the identity provider.
-	Protocol string `json:"protocol,omitempty"`
-	// Whether the trust configuration can be modified.
-	ReadOnly bool `json:"readOnly,omitempty"`
-	// Name of the identity provider
-	IdentityProvider string `json:"identityProvider,omitempty"`
+	Name                         string `json:"name,omitempty"`
+	OriginKey                    string `json:"originKey,omitempty"`
+	TypeOfTrust                  string `json:"typeOfTrust,omitempty"`
+	Status                       string `json:"status,omitempty"`
+	Description                  string `json:"description,omitempty"`
+	IdentityProvider             string `json:"identityProvider,omitempty"`
+	Domain                       string `json:"domain,omitempty"`
+	LinkTextForUserLogon         string `json:"linkTextForUserLogon,omitempty"`
+	AvailableForUserLogon        string `json:"availableForUserLogon,omitempty"`
+	CreateShadowUsersDuringLogon string `json:"createShadowUsersDuringLogon,omitempty"`
+	Protocol                     string `json:"protocol,omitempty"`
+	ReadOnly                     bool   `json:"readOnly,omitempty"`
 }

--- a/internal/provider/datasource_subaccount_trust_configuration.go
+++ b/internal/provider/datasource_subaccount_trust_configuration.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -58,31 +57,48 @@ __Further documentation:__
 				},
 			},
 			"id": schema.StringAttribute{
-				MarkdownDescription: "The ID of the trust configuration.",
+				DeprecationMessage:  "Use the `origin` attribute instead",
+				MarkdownDescription: "The origin of the identity provider.",
+				Computed:            true,
+			},
+			"identity_provider": schema.StringAttribute{
+				MarkdownDescription: "The name of the Identity Authentication tenant the subaccount is connected to.",
+				Computed:            true,
+			},
+			"domain": schema.StringAttribute{
+				MarkdownDescription: "The tenant's domain which should be used for user logon.",
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "The name of the trust configuration.",
+				MarkdownDescription: "The display name of the trust configuration.",
 				Computed:            true,
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "The description of the trust configuration.",
 				Computed:            true,
 			},
+			"link_text": schema.StringAttribute{
+				MarkdownDescription: "Short string that helps users to identify the link for login.",
+				Computed:            true,
+			},
+			"available_for_user_logon": schema.BoolAttribute{
+				MarkdownDescription: "Shows whether end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.",
+				Computed:            true,
+			},
+			"auto_create_shadow_users": schema.BoolAttribute{
+				MarkdownDescription: "Shows whether any user from the tenant can log in. If not set, only the ones who already have a shadow user can log in.",
+				Computed:            true,
+			},
+			"status": schema.StringAttribute{
+				MarkdownDescription: "Shows whether the identity provider is currently 'active' or 'inactive'.",
+				Computed:            true,
+			},
 			"type": schema.StringAttribute{
 				MarkdownDescription: "The trust type.",
 				Computed:            true,
 			},
-			"identity_provider": schema.StringAttribute{
-				MarkdownDescription: "The name of the identity provider.",
-				Computed:            true,
-			},
 			"protocol": schema.StringAttribute{
 				MarkdownDescription: "The protocol used to establish trust with the identity provider.",
-				Computed:            true,
-			},
-			"status": schema.StringAttribute{
-				MarkdownDescription: "Shows whether the identity provider is currently active or not.",
 				Computed:            true,
 			},
 			"read_only": schema.BoolAttribute{

--- a/internal/provider/datasource_subaccount_trust_configurations.go
+++ b/internal/provider/datasource_subaccount_trust_configurations.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -18,9 +17,9 @@ func newSubaccountTrustConfigurationsDataSource() datasource.DataSource {
 }
 
 type subaccountTrustConfigurationsDataSourceConfig struct {
-	Id           types.String                          `tfsdk:"id"`
-	SubaccountId types.String                          `tfsdk:"subaccount_id"`
-	Values       []globalaccountTrustConfigurationType `tfsdk:"values"`
+	Id           types.String                                `tfsdk:"id"`
+	SubaccountId types.String                                `tfsdk:"subaccount_id"`
+	Values       []subaccountTrustConfigurationListEntryType `tfsdk:"values"`
 }
 
 type subaccountTrustConfigurationsDataSource struct {
@@ -69,31 +68,48 @@ __Further documentation:__
 							Computed:            true,
 						},
 						"id": schema.StringAttribute{
-							MarkdownDescription: "The ID of the trust configuration.",
+							DeprecationMessage:  "Use the `origin` attribute instead",
+							MarkdownDescription: "The origin of the identity provider.",
+							Computed:            true,
+						},
+						"identity_provider": schema.StringAttribute{
+							MarkdownDescription: "The name of the Identity Authentication tenant the subaccount is connected to.",
+							Computed:            true,
+						},
+						"domain": schema.StringAttribute{
+							MarkdownDescription: "The tenant's domain which should be used for user logon.",
 							Computed:            true,
 						},
 						"name": schema.StringAttribute{
-							MarkdownDescription: "The name of the trust configuration.",
+							MarkdownDescription: "The display name of the trust configuration.",
 							Computed:            true,
 						},
 						"description": schema.StringAttribute{
 							MarkdownDescription: "The description of the trust configuration.",
 							Computed:            true,
 						},
+						"link_text": schema.StringAttribute{
+							MarkdownDescription: "Short string that helps users to identify the link for login.",
+							Computed:            true,
+						},
+						"available_for_user_logon": schema.BoolAttribute{
+							MarkdownDescription: "Shows whether end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.",
+							Computed:            true,
+						},
+						"auto_create_shadow_users": schema.BoolAttribute{
+							MarkdownDescription: "Shows whether any user from the tenant can log in. If not set, only the ones who already have a shadow user can log in.",
+							Computed:            true,
+						},
+						"status": schema.StringAttribute{
+							MarkdownDescription: "Shows whether the identity provider is currently 'active' or 'inactive'.",
+							Computed:            true,
+						},
 						"type": schema.StringAttribute{
 							MarkdownDescription: "The trust type.",
 							Computed:            true,
 						},
-						"identity_provider": schema.StringAttribute{
-							MarkdownDescription: "The name of the identity provider.",
-							Computed:            true,
-						},
 						"protocol": schema.StringAttribute{
 							MarkdownDescription: "The protocol used to establish trust with the identity provider.",
-							Computed:            true,
-						},
-						"status": schema.StringAttribute{
-							MarkdownDescription: "Shows whether the identity provider is currently active or not.",
 							Computed:            true,
 						},
 						"read_only": schema.BoolAttribute{
@@ -126,10 +142,10 @@ func (ds *subaccountTrustConfigurationsDataSource) Read(ctx context.Context, req
 	}
 
 	data.Id = data.SubaccountId
-	data.Values = []globalaccountTrustConfigurationType{}
+	data.Values = []subaccountTrustConfigurationListEntryType{}
 
 	for _, trustConfig := range cliRes {
-		trustConfigValue, diags := globalaccountTrustConfigurationFromValue(ctx, trustConfig)
+		trustConfigValue, diags := subaccountTrustConfigurationFromListEntry(ctx, trustConfig)
 		resp.Diagnostics.Append(diags...)
 
 		data.Values = append(data.Values, trustConfigValue)

--- a/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_exists.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_exists.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - cc29a739-c7ef-be24-258a-5586bd45641c
+                - f2e75f3d-698e-e5d7-3401-ee8fb338885b
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:45 GMT
+                - Tue, 26 Sep 2023 10:49:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6df9d873-d7ed-427a-66a0-62bebc4a9576
+                - 104e3479-4ba2-49de-73b3-67f5140d8f8e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 347.6532ms
+        duration: 303.02054ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4cd6d90d-f3ed-e1f6-ceb2-db1eda04bf61
+                - 0c5614a6-d418-f352-f8f8-6abc6c453e7c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:45 GMT
+                - Tue, 26 Sep 2023 10:49:23 GMT
             Expires:
                 - "0"
             Location:
@@ -131,12 +131,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 1dfccfe1-b416-4441-503a-3d4b9ed38a61
+                - 5edd7bb8-d6c6-41c6-54a7-0a8cf698699a
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 123.0207ms
+        duration: 211.362882ms
     - id: 2
       request:
         proto: ""
@@ -159,7 +159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4cd6d90d-f3ed-e1f6-ceb2-db1eda04bf61
+                - 0c5614a6-d418-f352-f8f8-6abc6c453e7c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -187,7 +187,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:45 GMT
+                - Tue, 26 Sep 2023 10:49:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -209,18 +209,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ffc7252c-cabf-4381-4b4f-2aaff2093c71
+                - 1d28e21e-f1d3-4137-5a00-ee83cd765ee8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 112.2937ms
+        duration: 104.486123ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -235,7 +235,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - f72631da-35ec-2668-f597-d196811e0bc1
+                - ee868730-6520-ce83-e61f-73631fb48ead
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -246,18 +246,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:46 GMT
+                - Tue, 26 Sep 2023 10:49:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -273,12 +273,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dc6bc8dd-8473-44b7-7ffe-a913a3d0defa
+                - 05746e42-6630-4c37-49b6-ae012508ecc8
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 976.8003ms
+        duration: 381.441503ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -299,7 +299,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 8a4173a2-900a-eb3d-8b7d-c5a7f29766f9
+                - 441f8309-f153-2125-4749-47718299bc1d
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -325,7 +325,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:46 GMT
+                - Tue, 26 Sep 2023 10:49:24 GMT
             Expires:
                 - "0"
             Location:
@@ -345,12 +345,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 28fcab9c-119b-493a-505e-7519fae0501b
+                - f22d2429-c9b4-411e-7743-672e682b097e
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 98.1498ms
+        duration: 104.308918ms
     - id: 5
       request:
         proto: ""
@@ -373,7 +373,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 8a4173a2-900a-eb3d-8b7d-c5a7f29766f9
+                - 441f8309-f153-2125-4749-47718299bc1d
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -401,7 +401,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:47 GMT
+                - Tue, 26 Sep 2023 10:49:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -423,18 +423,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fedba578-ff15-4796-6ea7-0e0534ade1e0
+                - 8297680c-ad79-4fc4-6db9-f22ad99aa628
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 96.1994ms
+        duration: 303.941277ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -449,7 +449,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7f1d924f-3b44-e36b-3de6-dcfbcbf7839e
+                - c873a1e8-9196-9655-4e8e-8ce88cec9e8d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -460,18 +460,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:47 GMT
+                - Tue, 26 Sep 2023 10:49:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3cfc0dc8-98d6-4212-49be-f92df85aabb5
+                - f9d55725-6a5a-4f1d-7723-b85964622052
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 316.3007ms
+        duration: 398.360179ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 70a488a8-1b08-765b-faac-68d0ff086eba
+                - f47d323e-76a4-a6b4-4800-751d51974868
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -539,7 +539,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:47 GMT
+                - Tue, 26 Sep 2023 10:49:25 GMT
             Expires:
                 - "0"
             Location:
@@ -559,12 +559,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 72b188e7-1a94-409a-4a07-303f79a43cd0
+                - e97b9362-f362-417d-55f6-c91cee2e428d
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 115.9772ms
+        duration: 122.66321ms
     - id: 8
       request:
         proto: ""
@@ -587,7 +587,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 70a488a8-1b08-765b-faac-68d0ff086eba
+                - f47d323e-76a4-a6b4-4800-751d51974868
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -615,7 +615,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:47 GMT
+                - Tue, 26 Sep 2023 10:49:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -637,18 +637,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b6727a24-3570-4381-67d4-d5e86514112a
+                - 1db348bb-2ede-4e88-5b25-ce4a01c901a1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 109.5523ms
+        duration: 196.118789ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -663,7 +663,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1c67af93-8cea-62d4-495d-79e957ac4fec
+                - 6de515fe-9bce-12f1-141c-b0701859a438
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -674,18 +674,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:48 GMT
+                - Tue, 26 Sep 2023 10:49:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,12 +701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 517bd094-91b2-4580-7971-9c4fd5713fca
+                - 2267ccb8-81a9-4e1b-4673-7c8a009699bc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 880.3542ms
+        duration: 213.368891ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -727,7 +727,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3ac914d3-48bf-8ea9-eb71-37731e554aa8
+                - 95278e5a-b51c-9d1e-2907-3b82d4e6d6be
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -753,7 +753,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:48 GMT
+                - Tue, 26 Sep 2023 10:49:25 GMT
             Expires:
                 - "0"
             Location:
@@ -773,12 +773,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c44cfe84-a049-4076-4794-7341c94d29bb
+                - 2428f2cf-c439-4a02-581d-7a725dfa1ebf
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 92.3107ms
+        duration: 123.831404ms
     - id: 11
       request:
         proto: ""
@@ -801,7 +801,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3ac914d3-48bf-8ea9-eb71-37731e554aa8
+                - 95278e5a-b51c-9d1e-2907-3b82d4e6d6be
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -829,7 +829,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:48 GMT
+                - Tue, 26 Sep 2023 10:49:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -851,18 +851,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ccb591bf-60d4-4f9e-4d6e-114a30542428
+                - 97f878cf-840f-49b9-495e-a3ce30ecbca7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 123.9243ms
+        duration: 139.701427ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -877,7 +877,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b7cb8130-2606-318a-8ba3-a6e5289a3c2b
+                - e00f53c9-60ae-f0ab-26f8-b958d1595ccc
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -888,18 +888,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:49 GMT
+                - Tue, 26 Sep 2023 10:49:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -915,12 +915,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4d09394d-6adc-43e0-54a9-bb8e2f21d026
+                - 196a1c94-b3c1-406e-5c78-5bbefd1f7412
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 354.6698ms
+        duration: 390.021507ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -941,7 +941,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 2841f259-f4b5-a52d-baf6-eb701f957fa9
+                - 2dacca9c-5bca-e2d2-92f6-3fba64bdc3ed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -967,7 +967,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:49 GMT
+                - Tue, 26 Sep 2023 10:49:26 GMT
             Expires:
                 - "0"
             Location:
@@ -987,12 +987,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5f60e734-84a7-4a7d-5e00-8735af260be9
+                - d9f34f23-324d-469c-6d79-c87f028a8994
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 127.6227ms
+        duration: 202.575941ms
     - id: 14
       request:
         proto: ""
@@ -1015,7 +1015,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 2841f259-f4b5-a52d-baf6-eb701f957fa9
+                - 2dacca9c-5bca-e2d2-92f6-3fba64bdc3ed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1043,7 +1043,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:49 GMT
+                - Tue, 26 Sep 2023 10:49:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1065,18 +1065,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1939ccbc-e82a-4b52-43ff-85f072048e42
+                - d31ff5a7-496f-48c0-6df7-379d8082ad98
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 89.6804ms
+        duration: 205.112669ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1091,7 +1091,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 2f2c955b-ff6a-0d07-9fa4-3eb3d0c56ce2
+                - 09f942c3-43ab-8c52-43b8-461f4c6e54ef
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1102,18 +1102,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:50 GMT
+                - Tue, 26 Sep 2023 10:49:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1129,9 +1129,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3316c06d-cc7b-4a80-460c-b6e48c66577c
+                - d2de8244-684e-4a13-4ff5-d14d380ecfcb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 742.2297ms
+        duration: 263.562219ms

--- a/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_not_existing.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_not_existing.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a2bc88c2-c152-8769-2722-9f34f808a6ac
+                - 3c26886d-4d97-508d-398b-de770e57ff73
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:50 GMT
+                - Tue, 26 Sep 2023 10:49:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 41362c4d-9666-4753-7012-45298a6ee35e
+                - 143b0f33-90bb-4039-681e-6fbca4bb92fc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 402.344ms
+        duration: 317.202368ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 5683658c-38a0-e57e-cd47-13cf3a00ace2
+                - 7328c511-1206-6ae2-8780-7abded22a35c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:51 GMT
+                - Tue, 26 Sep 2023 10:49:28 GMT
             Expires:
                 - "0"
             Location:
@@ -131,12 +131,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 6e1a9f19-d9b8-4e8e-5bf4-31b2c7d32c26
+                - 83fbbaad-ec5d-455e-67e8-caa5caf78dc0
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 104.2597ms
+        duration: 97.956889ms
     - id: 2
       request:
         proto: ""
@@ -159,7 +159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 5683658c-38a0-e57e-cd47-13cf3a00ace2
+                - 7328c511-1206-6ae2-8780-7abded22a35c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -187,7 +187,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:51 GMT
+                - Tue, 26 Sep 2023 10:49:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -207,9 +207,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c2ebcde6-f7e9-4fc4-7ac9-97efce7d3986
+                - 8e0b0582-afd5-44e9-67e1-0e567fdcf571
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 149.5198ms
+        duration: 182.520755ms

--- a/internal/provider/fixtures/datasource_subaccount_trust_configuration.default.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configuration.default.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b4f5078f-67aa-b30d-b153-c4d977127b71
+                - 61a44b8b-b91d-b401-4def-40dddf795f93
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:40 GMT
+                - Tue, 26 Sep 2023 10:49:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ba6941e8-665c-4c58-65ed-0c528a634b02
+                - 4826574b-b629-4856-4bde-55de6435e479
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 482.6757ms
+        duration: 307.577608ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 8c46020e-533d-9859-5971-b01a0907f098
+                - d6a5e125-61c9-5007-8b3b-d5dfeffadc63
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:40 GMT
+                - Tue, 26 Sep 2023 10:49:18 GMT
             Expires:
                 - "0"
             Location:
@@ -131,12 +131,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e1d184fc-4529-443e-4bee-ad9dbeadb60b
+                - ef203687-add4-499f-4ab9-fc85d3de86ea
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 163.8402ms
+        duration: 205.430708ms
     - id: 2
       request:
         proto: ""
@@ -159,7 +159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 8c46020e-533d-9859-5971-b01a0907f098
+                - d6a5e125-61c9-5007-8b3b-d5dfeffadc63
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -187,7 +187,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:40 GMT
+                - Tue, 26 Sep 2023 10:49:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -209,18 +209,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ecfea916-4c3e-489c-4948-2921dd667077
+                - 07520d77-7822-4b80-49f6-158e7004b84d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 265.9301ms
+        duration: 448.172469ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -235,7 +235,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - cf4706cb-b97e-d826-1278-1f4eb3af7ac9
+                - c21af611-31b4-8c81-a6a2-cacb7f26cb77
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -246,18 +246,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:41 GMT
+                - Tue, 26 Sep 2023 10:49:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -273,12 +273,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 02f6c3d4-119c-44e9-4813-f59aaf843559
+                - c37f573b-8833-48c8-4988-b4047944f36f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 745.7744ms
+        duration: 315.697905ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -299,7 +299,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d49f733e-ef87-704d-8fb7-8fd36f5ea3b1
+                - e8d2add1-d8ec-f795-5992-e7a5ddc4693b
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -325,7 +325,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:41 GMT
+                - Tue, 26 Sep 2023 10:49:19 GMT
             Expires:
                 - "0"
             Location:
@@ -345,12 +345,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 62bc3884-4587-4fbd-4ce8-c476d61a7468
+                - a7ef1dbf-012e-4808-6478-19ec49fe2818
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 114.1479ms
+        duration: 183.905813ms
     - id: 5
       request:
         proto: ""
@@ -373,7 +373,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d49f733e-ef87-704d-8fb7-8fd36f5ea3b1
+                - e8d2add1-d8ec-f795-5992-e7a5ddc4693b
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -401,7 +401,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:41 GMT
+                - Tue, 26 Sep 2023 10:49:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -423,18 +423,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8de1cc53-ba1a-41a6-704b-2443c9f74386
+                - 7c040be9-f427-4e52-4433-53934c9da854
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 134.8444ms
+        duration: 97.315799ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -449,7 +449,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - e927366d-0bce-f22f-6966-424fe39f8c24
+                - 2c1a5a5c-8fd0-31bd-5f00-c89ed47d8dad
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -460,18 +460,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:42 GMT
+                - Tue, 26 Sep 2023 10:49:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 420035fd-9b67-46fb-5a1b-e0fac20dca86
+                - 199bb2d3-9aab-41f1-53b7-1add09d61698
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 388.5208ms
+        duration: 328.055611ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 843dfa86-bec9-8c19-8242-8309b04dffda
+                - 5c384977-e5cf-349f-4918-07f038fda0d2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -539,7 +539,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:42 GMT
+                - Tue, 26 Sep 2023 10:49:19 GMT
             Expires:
                 - "0"
             Location:
@@ -559,12 +559,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7e5b4602-ec2e-4aaf-48b6-356bf79811a8
+                - ed4f805c-b466-4c00-4feb-7ab6340ed1c4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 112.2422ms
+        duration: 106.065915ms
     - id: 8
       request:
         proto: ""
@@ -587,7 +587,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 843dfa86-bec9-8c19-8242-8309b04dffda
+                - 5c384977-e5cf-349f-4918-07f038fda0d2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -615,7 +615,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:42 GMT
+                - Tue, 26 Sep 2023 10:49:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -637,18 +637,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bc0a3752-05c0-4445-5834-1fffad2b9900
+                - 6bf10a2a-17be-4d97-78e4-aefa5f9fa2d0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 157.2133ms
+        duration: 196.990954ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -663,7 +663,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 48c10370-5b0a-6778-d34e-693392b210b0
+                - f588ebc5-cc61-4eb8-e010-85cd8396fbe6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -674,18 +674,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:43 GMT
+                - Tue, 26 Sep 2023 10:49:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,12 +701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c47d8c3b-4134-4d44-4c35-1c6348e8123b
+                - 0c27b050-c330-414d-6af7-5a8712b7a33b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 797.6204ms
+        duration: 452.768083ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -727,7 +727,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b7af3eab-c3fa-ee78-2153-b8cb29092648
+                - 63d4a5ed-342f-4027-0f3f-10b816f652d5
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -753,7 +753,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:43 GMT
+                - Tue, 26 Sep 2023 10:49:20 GMT
             Expires:
                 - "0"
             Location:
@@ -773,12 +773,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - b806ee5e-b251-46c1-6a6a-ac3c3498c139
+                - 06908e54-8133-460c-68ba-fca52a71e6bc
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 116.943ms
+        duration: 142.099983ms
     - id: 11
       request:
         proto: ""
@@ -801,7 +801,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b7af3eab-c3fa-ee78-2153-b8cb29092648
+                - 63d4a5ed-342f-4027-0f3f-10b816f652d5
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -829,7 +829,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:43 GMT
+                - Tue, 26 Sep 2023 10:49:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -851,18 +851,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f32f4902-4323-4b2f-65e0-b7d5daf3688d
+                - 21a6fa22-1a58-4e0d-5583-3372fd9af689
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 111.0433ms
+        duration: 196.761929ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -877,7 +877,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 54312a8f-624d-3d2c-f4f7-9124e14b8050
+                - fc72cf69-4783-d5ac-9b10-5e132dec8eb0
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -888,18 +888,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:43 GMT
+                - Tue, 26 Sep 2023 10:49:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -915,12 +915,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ff1133ce-cb1d-4842-5b03-46fded27610c
+                - 4e3f40c2-04d6-40b1-6a7c-048085e41607
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 360.1586ms
+        duration: 266.784649ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -941,7 +941,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 20418769-c928-19f4-8e7e-df64078224b8
+                - c0ef7568-a779-498e-9a28-073e92d70907
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -967,7 +967,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 06:49:44 GMT
+                - Tue, 26 Sep 2023 10:49:21 GMT
             Expires:
                 - "0"
             Location:
@@ -987,12 +987,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2a1d5764-e0b0-4395-4ac3-61b4ae82ff71
+                - e1a31a8b-b60b-4a71-55c7-4fa32a3fa1c4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 143.4338ms
+        duration: 305.791771ms
     - id: 14
       request:
         proto: ""
@@ -1015,7 +1015,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 20418769-c928-19f4-8e7e-df64078224b8
+                - c0ef7568-a779-498e-9a28-073e92d70907
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1043,7 +1043,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:44 GMT
+                - Tue, 26 Sep 2023 10:49:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1065,18 +1065,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1f08541e-425a-4a6d-782f-c0c4b847931a
+                - 54e2c624-b179-465a-67a9-2798ec245fd9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 87.8426ms
+        duration: 272.556954ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1091,7 +1091,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 267273d3-fc04-da3f-cc5c-6b335f3c1020
+                - be9fc63e-348d-1d12-4969-be6cf5cf36f1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1102,18 +1102,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 06:49:45 GMT
+                - Tue, 26 Sep 2023 10:49:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1129,9 +1129,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c21958eb-1640-469d-4181-2ae18ce9e106
+                - 8fecac01-22f8-4b8d-4c5c-b563dfb07b72
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 756.1915ms
+        duration: 216.202798ms

--- a/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_exists.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_exists.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3335338c-0395-f2c0-b6c5-de61371d5b42
+                - 6cb0b167-cc50-1436-0daf-50ab7194f3c9
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:24 GMT
+                - Tue, 26 Sep 2023 10:48:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 989ecbce-41e0-48ec-60a9-d13ffe654708
+                - cda06280-1fae-4a72-70f7-f844b37116f0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.2021986s
+        duration: 986.097925ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - feac2672-6042-ccd5-1c38-3813023db5e1
+                - 13b32790-b36f-ec7b-4f3b-b86bc6db0e8e
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:24 GMT
+                - Tue, 26 Sep 2023 10:48:18 GMT
             Expires:
                 - "0"
             Location:
@@ -131,12 +131,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - a9d5ade9-e848-446d-4927-40da9be48f92
+                - 8c617d43-4462-4ac3-4bc9-dffb0cfc2d83
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 107.3903ms
+        duration: 253.866744ms
     - id: 2
       request:
         proto: ""
@@ -159,7 +159,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - feac2672-6042-ccd5-1c38-3813023db5e1
+                - 13b32790-b36f-ec7b-4f3b-b86bc6db0e8e
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -180,14 +180,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"name":"terraform.accounts400.ondemand.com (platform users)","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Identity Authentication tenant terraform.accounts400.ondemand.com used for platform users","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
+        body: '[{"name":"terraform-platform","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:25 GMT
+                - Tue, 26 Sep 2023 10:48:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -209,18 +209,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d287c27e-f2dc-4520-4a87-fa55a40443da
+                - d259f0d1-4786-42cd-61c9-71cd14c96726
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 618.371ms
+        duration: 297.925214ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -235,7 +235,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 2446bd2b-8c3f-6582-9e81-c25bd08f37d6
+                - a760f098-a981-e872-a8ef-d764ffae396d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -246,18 +246,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:26 GMT
+                - Tue, 26 Sep 2023 10:48:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -273,12 +273,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 64d0343e-3deb-4f76-7f5e-421ef5827fa2
+                - 1e8b711c-6231-40ec-690d-d4aecdc75b0b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.0977495s
+        duration: 571.640596ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -299,7 +299,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 8a36485e-1cc2-dcdb-14e9-6a3206200652
+                - 05fcbc79-5a4b-5a52-4fde-0754aa377ac7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -325,7 +325,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:26 GMT
+                - Tue, 26 Sep 2023 10:48:20 GMT
             Expires:
                 - "0"
             Location:
@@ -345,12 +345,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - be333ee9-67ce-4eff-7d5f-dac12537f248
+                - 11c526f7-a2fc-4981-575d-e85d9933f951
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 120.9524ms
+        duration: 182.864985ms
     - id: 5
       request:
         proto: ""
@@ -373,7 +373,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 8a36485e-1cc2-dcdb-14e9-6a3206200652
+                - 05fcbc79-5a4b-5a52-4fde-0754aa377ac7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -394,14 +394,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"name":"terraform.accounts400.ondemand.com (platform users)","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Identity Authentication tenant terraform.accounts400.ondemand.com used for platform users","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
+        body: '[{"name":"terraform-platform","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:26 GMT
+                - Tue, 26 Sep 2023 10:48:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -423,18 +423,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7b2b19f8-c50f-4437-64fc-43e155f6a132
+                - e91bde76-74f9-4808-72aa-6f535d9c0652
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 168.6263ms
+        duration: 241.767715ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -449,7 +449,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1f02e458-eaed-a8d0-77bf-73d5101b30f2
+                - 87ba3632-8c46-7470-5784-cd7986886aed
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -460,18 +460,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:27 GMT
+                - Tue, 26 Sep 2023 10:48:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 21132b25-52c3-4aac-5666-9e92e6d39542
+                - 30278f15-428b-4715-43e2-a17e72aab82d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 391.9554ms
+        duration: 404.104136ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3d00db0d-74df-e51e-4c1d-0c8972be9888
+                - 57ae5408-866b-32c6-aee6-ab292af81522
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -539,7 +539,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:27 GMT
+                - Tue, 26 Sep 2023 10:48:21 GMT
             Expires:
                 - "0"
             Location:
@@ -559,12 +559,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - fb4af10a-d5bd-4bc6-74ac-e9f934af63e3
+                - 50b48408-d7b5-4dec-4a1f-e32f6f88782c
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 111.6013ms
+        duration: 102.46325ms
     - id: 8
       request:
         proto: ""
@@ -587,7 +587,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3d00db0d-74df-e51e-4c1d-0c8972be9888
+                - 57ae5408-866b-32c6-aee6-ab292af81522
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -608,14 +608,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"name":"terraform.accounts400.ondemand.com (platform users)","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Identity Authentication tenant terraform.accounts400.ondemand.com used for platform users","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
+        body: '[{"name":"terraform-platform","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:27 GMT
+                - Tue, 26 Sep 2023 10:48:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -637,18 +637,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b8e49541-8d8e-41f0-7bee-e5fa7973e446
+                - 89807800-b425-4ae5-69f0-a545684ed7bf
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 145.1038ms
+        duration: 249.986653ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -663,7 +663,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 61691343-28e8-7689-2ffa-3065b16ed2c5
+                - eb316b05-6df3-5c27-4342-4827a4b572d8
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -674,18 +674,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:28 GMT
+                - Tue, 26 Sep 2023 10:48:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -701,12 +701,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9da7ac97-892d-486d-6655-f13bc5c76b0a
+                - fc718f82-1f24-4426-7217-82bbebf18e27
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 618.226ms
+        duration: 320.33378ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -727,7 +727,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 6fd494ba-6aea-0c67-80c2-d783198173c5
+                - 8bbcdf25-07ca-a728-baf7-7f71e4178d6c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -753,7 +753,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:28 GMT
+                - Tue, 26 Sep 2023 10:48:22 GMT
             Expires:
                 - "0"
             Location:
@@ -773,12 +773,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 9daa814c-0ace-4333-63cc-4b9e53a93cfc
+                - f1a15de2-105c-4497-5b27-7c19420ef039
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 164.8076ms
+        duration: 202.225268ms
     - id: 11
       request:
         proto: ""
@@ -801,7 +801,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 6fd494ba-6aea-0c67-80c2-d783198173c5
+                - 8bbcdf25-07ca-a728-baf7-7f71e4178d6c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -822,14 +822,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"name":"terraform.accounts400.ondemand.com (platform users)","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Identity Authentication tenant terraform.accounts400.ondemand.com used for platform users","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
+        body: '[{"name":"terraform-platform","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:28 GMT
+                - Tue, 26 Sep 2023 10:48:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -851,18 +851,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8b6b1d42-71cb-4c5f-71e3-31fb8c7d0d67
+                - 471c73be-5cb6-4f0b-67d5-4fc394fba8ac
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 154.6995ms
+        duration: 308.548604ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -877,7 +877,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b0ab48fd-eacf-dedd-99d8-a5c83986a3e0
+                - a4c89a28-159a-bc79-1246-918db1a2f77c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -888,18 +888,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:29 GMT
+                - Tue, 26 Sep 2023 10:48:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -915,12 +915,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5f20c83a-52fe-4f90-418a-d892d9d3ae61
+                - 3458234f-d18b-4f49-7280-f07f13e68577
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 359.4428ms
+        duration: 407.410538ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -941,7 +941,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1931874b-902a-92dc-24d1-2c673b61aea8
+                - b6b1ffd9-9bdc-7cdb-ccc5-e16962c35942
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -967,7 +967,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:29 GMT
+                - Tue, 26 Sep 2023 10:48:23 GMT
             Expires:
                 - "0"
             Location:
@@ -987,12 +987,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e866dfe8-7c73-4aa5-789b-3c22ea45e07f
+                - e926c1d5-3179-4cc6-7201-86d49ccee512
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 125.122ms
+        duration: 181.095097ms
     - id: 14
       request:
         proto: ""
@@ -1015,7 +1015,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1931874b-902a-92dc-24d1-2c673b61aea8
+                - b6b1ffd9-9bdc-7cdb-ccc5-e16962c35942
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1036,14 +1036,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"name":"terraform.accounts400.ondemand.com (platform users)","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Identity Authentication tenant terraform.accounts400.ondemand.com used for platform users","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
+        body: '[{"name":"terraform-platform","originKey":"terraform-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraform.accounts400.ondemand.com","domain":"terraform.accounts400.ondemand.com","linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraform","protocol":"OpenID Connect","readOnly":true},{"name":"terraformint-platform","originKey":"terraformint-platform","typeOfTrust":"Platform","status":"active","description":"Custom Platform Identity Provider","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":null,"availableForUserLogon":null,"createShadowUsersDuringLogon":null,"sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":true},{"name":"sap.default","originKey":"sap.default","typeOfTrust":"Application","status":"active","description":null,"identityProvider":null,"domain":null,"linkTextForUserLogon":"Default Identity Provider","availableForUserLogon":"true","createShadowUsersDuringLogon":"false","sapBtpCli":null,"protocol":"OpenID Connect","readOnly":false}]'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:29 GMT
+                - Tue, 26 Sep 2023 10:48:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1065,18 +1065,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 82dc9433-18f8-4450-564a-869a86b57b16
+                - 157579cf-d481-41ad-4f35-25b78e7a0558
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 146.9429ms
+        duration: 192.147501ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -1091,7 +1091,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a342ecf4-13ca-1a20-2983-423d19b54a77
+                - 9ba1d33c-a4e1-5ddb-d81c-f6dcdaeab7eb
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1102,18 +1102,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:30 GMT
+                - Tue, 26 Sep 2023 10:48:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1129,9 +1129,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dfab0bb1-8df5-416b-4fae-127f1c24152c
+                - 96d1315a-1655-4712-777d-de949b331ccf
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 709.0767ms
+        duration: 351.432649ms

--- a/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_not_existing.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_not_existing.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ec630645-4b1e-b0d4-3cf5-7548d09c7820
+                - 9e46c336-4aa6-cff0-4e97-d99cea0ec386
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 08:49:30 GMT
+                - Tue, 26 Sep 2023 10:48:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7a31b6d8-3b9b-4c8f-4b15-a04d75818051
+                - ac573abf-425c-4060-6e7c-f9e4cea5e721
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 424.8586ms
+        duration: 476.303272ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4cf4bb25-8c09-363d-f142-bff017c97f90
+                - f49742b9-b940-5163-5ec6-e0424d2cc5b7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -111,7 +111,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 08:49:30 GMT
+                - Tue, 26 Sep 2023 10:48:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -127,9 +127,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 225d0354-d0f9-41c0-7eb5-1d193c1d892e
+                - 065afe92-6b58-46cc-4f0d-8dbed84d92b6
             X-Xss-Protection:
                 - "0"
         status: 403 Forbidden
         code: 403
-        duration: 149.9736ms
+        duration: 303.863861ms

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1a03bf7d-5fa9-cfcd-93a0-5e73b7aada47
+                - cb24fdd6-9a8a-6a1a-ba89-77d61054882c
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:33 GMT
+                - Tue, 26 Sep 2023 10:50:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b7aa3855-1b6c-411e-6cda-a354dd8ee67a
+                - 95b764e6-6bd5-4e33-56f6-8102322d15f0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 789.076827ms
+        duration: 539.436047ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 2e52c922-b3cf-578f-8bcf-7477e0f8bf71
+                - 7fa8d03d-0404-7ec0-bfbd-c95bebad147f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -107,7 +107,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:34 GMT
+                - Tue, 26 Sep 2023 10:50:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,12 +123,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a6d5b180-0445-4f5e-5efc-453ba37eabaa
+                - d857a9af-f090-47be-4a38-8253f99dc54f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 618.456149ms
+        duration: 462.423904ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -149,7 +149,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - f1f8a49a-f321-4754-ef59-da51303bb65a
+                - b97aced6-f0dc-338c-5685-c050d653f8c2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -171,7 +171,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:35 GMT
+                - Tue, 26 Sep 2023 10:50:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,12 +187,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 97147449-51f0-453e-4757-35c2dc26ce45
+                - 5f6ae27b-67e9-46d4-4208-863891e880ef
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 612.021203ms
+        duration: 491.472473ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -213,7 +213,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4d278207-5084-7f69-174d-a0b6e2754847
+                - a646146d-ab70-1d0b-29cb-cb5187b21093
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:34:35 GMT
+                - Tue, 26 Sep 2023 10:50:21 GMT
             Expires:
                 - "0"
             Location:
@@ -259,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f907eaab-35d7-484b-6e2d-ea1880ccbd65
+                - 4d91622f-2eac-4a4c-59cf-4e30a4d29da7
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 242.956234ms
+        duration: 127.870258ms
     - id: 4
       request:
         proto: ""
@@ -287,7 +287,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4d278207-5084-7f69-174d-a0b6e2754847
+                - a646146d-ab70-1d0b-29cb-cb5187b21093
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformint.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"4d95dd32-7e12-498e-a1be-0221af763a88","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6511e0ccecf2c21f375cb1b5/trust"},"neoAuthnWithOidc":false},"id":"189b3556-270b-49c1-b229-1ead0de66f56","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1695670477160,"last_modified":1695670477160,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformint.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"1edde1ff-f861-4ca2-903c-2ba388d934f9","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6512b76e8a2c1a0894e4db43/trust"},"neoAuthnWithOidc":false},"id":"bcd22fca-4d13-4079-a63a-6d185b8c6df0","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1695725422892,"last_modified":1695725422892,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:37 GMT
+                - Tue, 26 Sep 2023 10:50:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -337,12 +337,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 35412bcf-df2c-4a6b-438f-49168db4bee2
+                - 1e6923cf-ce98-4980-4ed0-67365a31e4d3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.499105664s
+        duration: 1.301946138s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -363,7 +363,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4d8cb55e-609a-8f22-efd3-c6da0818f986
+                - a1aa33a0-5dcf-0df3-c58e-cc33eb2cb165
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -389,7 +389,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:34:37 GMT
+                - Tue, 26 Sep 2023 10:50:23 GMT
             Expires:
                 - "0"
             Location:
@@ -409,12 +409,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c05c219c-a908-4a98-61ff-c9bc0cd465c1
+                - aaca61b9-f34b-46a6-653e-3daff81bf617
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 207.967056ms
+        duration: 137.009548ms
     - id: 6
       request:
         proto: ""
@@ -437,7 +437,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4d8cb55e-609a-8f22-efd3-c6da0818f986
+                - a1aa33a0-5dcf-0df3-c58e-cc33eb2cb165
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -465,7 +465,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:38 GMT
+                - Tue, 26 Sep 2023 10:50:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1f871424-e769-4932-4173-71101e1c8acb
+                - 8bc3d4aa-e212-452a-67ad-06644e58b075
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 640.425129ms
+        duration: 484.889029ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 62fb655c-e748-5681-e8bc-e146d1b595ec
+                - bae3f931-2ee2-b3e9-fe09-f85af47eeacf
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -535,7 +535,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:38 GMT
+                - Tue, 26 Sep 2023 10:50:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -551,12 +551,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 57d3e509-5c7a-4aab-6f8c-e40b9eda9423
+                - 59809790-759c-47bf-63c4-d646658779de
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 520.107911ms
+        duration: 332.128042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -577,7 +577,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4a29da57-3de3-2c90-32ff-0025435df8c4
+                - 24530813-ed05-100f-3984-adfded71faf6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -599,7 +599,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:39 GMT
+                - Tue, 26 Sep 2023 10:50:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -615,12 +615,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 74203026-7cfc-48d0-5115-e45f7129223b
+                - 1441a3ad-cad9-4c3a-6743-a21ce1c2f8c4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 315.512298ms
+        duration: 334.176323ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -641,7 +641,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - dcb09654-d99a-effc-5e4d-c1d0147a1639
+                - fe58085b-c232-a43b-4892-7e71ea1922f9
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -667,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:34:39 GMT
+                - Tue, 26 Sep 2023 10:50:24 GMT
             Expires:
                 - "0"
             Location:
@@ -687,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4c719467-e6c9-493a-5eda-294385309460
+                - 0e231493-8ba6-4ac4-5d14-2a50c61f1322
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 263.956518ms
+        duration: 126.892738ms
     - id: 10
       request:
         proto: ""
@@ -715,7 +715,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - dcb09654-d99a-effc-5e4d-c1d0147a1639
+                - fe58085b-c232-a43b-4892-7e71ea1922f9
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -743,7 +743,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:39 GMT
+                - Tue, 26 Sep 2023 10:50:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -765,12 +765,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 43e1987b-897b-43f7-7e40-3781af2d45a0
+                - eb7985a5-a980-4161-7279-53edd01c96e6
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 242.849916ms
+        duration: 265.171145ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -791,7 +791,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - e43382af-5cbb-664b-b016-b449cecc838e
+                - 9c17a56d-2939-8e98-7e5f-e253bb509699
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -813,7 +813,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:40 GMT
+                - Tue, 26 Sep 2023 10:50:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -829,12 +829,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2cb53423-6089-4f24-77d7-9ba8235d7bf4
+                - 9dd779ad-4e60-4e7c-764d-797959a04879
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 471.786332ms
+        duration: 282.101534ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -855,7 +855,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b8731f9e-e840-1d28-0607-e4c8126ef770
+                - afefd108-edcb-ce83-c3a3-1445d7cff3bb
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -877,7 +877,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:40 GMT
+                - Tue, 26 Sep 2023 10:50:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -893,12 +893,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 44254bfa-51aa-4418-5f1c-b0dce23dfcbc
+                - 958cae65-bae5-4895-7bf7-8a65bd3bbcca
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 472.650385ms
+        duration: 377.395373ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -919,7 +919,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d582efa6-866a-8b83-9955-eb11177a37fc
+                - f7f6ab95-7ce2-07fa-b7c1-90a421f19934
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -945,7 +945,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:34:41 GMT
+                - Tue, 26 Sep 2023 10:50:26 GMT
             Expires:
                 - "0"
             Location:
@@ -965,12 +965,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - fcd59994-1356-45f4-54d3-d813883d0545
+                - d7653dd9-1991-48a4-794b-b98e3ffdb7bf
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 305.235913ms
+        duration: 111.587115ms
     - id: 14
       request:
         proto: ""
@@ -993,7 +993,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - d582efa6-866a-8b83-9955-eb11177a37fc
+                - f7f6ab95-7ce2-07fa-b7c1-90a421f19934
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1021,7 +1021,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:41 GMT
+                - Tue, 26 Sep 2023 10:50:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1043,12 +1043,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3370a824-86d2-47b9-5de9-e9dc3d0836e3
+                - ca106a69-c192-4e9f-4fee-33076287b517
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 409.059158ms
+        duration: 199.143058ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1069,7 +1069,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 0fdbee91-eb6d-e5ab-5e00-8cfa7f8beec6
+                - 4f2dfe72-7987-9b51-da9e-66a4aebed79d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1091,7 +1091,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:42 GMT
+                - Tue, 26 Sep 2023 10:50:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1107,12 +1107,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ad934030-9fe5-45b8-5c42-a12508642691
+                - 23aa3d52-64f2-41dc-48f5-303abdfb77fd
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 514.259801ms
+        duration: 299.82708ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1133,7 +1133,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 2ae5a8ae-fba2-d0be-bc32-9cde274a4d0f
+                - 00f1eb5a-b593-372b-75f9-26ef0105baf1
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1155,7 +1155,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:42 GMT
+                - Tue, 26 Sep 2023 10:50:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1171,12 +1171,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dd823401-d2f0-4685-5257-475126267d0c
+                - 743441c5-8461-4953-4619-5c1006ce6683
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 218.176512ms
+        duration: 293.014994ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1197,7 +1197,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - e1ad2579-9b6c-882a-4b28-aa803cd6c0b8
+                - 90745610-8a90-9c19-ff9f-9f15387d58a5
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1223,7 +1223,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:34:42 GMT
+                - Tue, 26 Sep 2023 10:50:27 GMT
             Expires:
                 - "0"
             Location:
@@ -1243,12 +1243,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - b71e9f4e-d459-4b6a-7ef1-7e8db96f2362
+                - ed5caa16-9520-412e-687a-15c66ac091c6
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 302.367812ms
+        duration: 134.990953ms
     - id: 18
       request:
         proto: ""
@@ -1271,7 +1271,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - e1ad2579-9b6c-882a-4b28-aa803cd6c0b8
+                - 90745610-8a90-9c19-ff9f-9f15387d58a5
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1299,7 +1299,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:43 GMT
+                - Tue, 26 Sep 2023 10:50:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1321,12 +1321,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0b7de02d-1cc6-410a-453c-38dd68412907
+                - 7fcbd6d3-7efb-4ee8-7c5d-93314e836892
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 614.375289ms
+        duration: 483.762968ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1347,7 +1347,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - eb9edcd4-8699-c326-5b0f-c1733df972ab
+                - e3fba56b-46c3-aff4-8158-67ad030564fd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1369,7 +1369,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:44 GMT
+                - Tue, 26 Sep 2023 10:50:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1385,12 +1385,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a2c98b8c-0517-485c-444f-9c8314274b32
+                - c0279c30-0307-4cc8-7bc6-ac281910671c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 387.064961ms
+        duration: 245.772584ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1411,7 +1411,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 0df96bca-d699-8a1e-4e5c-a6d2006e12f7
+                - 4c71941d-7b18-f665-8b41-e4a2b5b36c41
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1433,7 +1433,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:44 GMT
+                - Tue, 26 Sep 2023 10:50:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1449,13 +1449,355 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0278305a-1bf5-41cc-5c3d-5e20f1a6617c
+                - dd319371-ef3f-48fa-75da-8c4a04ccec43
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 230.271366ms
+        duration: 333.021902ms
     - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 0deef3c7-ad8e-507f-7b45-da019363b643
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "0"
+            Date:
+                - Tue, 26 Sep 2023 10:50:28 GMT
+            Expires:
+                - "0"
+            Location:
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Frame-Options:
+                - DENY
+            X-Id-Token:
+                - redacted
+            X-Vcap-Request-Id:
+                - 3c81549b-0ba7-4f2a-5073-bc7b4f4fc34e
+            X-Xss-Protection:
+                - "0"
+        status: 307 Temporary Redirect
+        code: 307
+        duration: 114.539092ms
+    - id: 22
+      request:
+        proto: ""
+        proto_major: 0
+        proto_minor: 0
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            Referer:
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 0deef3c7-ad8e-507f-7b45-da019363b643
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Id-Token:
+                - redacted
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 26 Sep 2023 10:50:29 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 2e378206-9b30-44cc-609d-2fd8c8b62862
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 249.58685ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - b7a1babc-8e8f-2a19-30b4-273e00ab5e3d
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 26 Sep 2023 10:50:29 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - fb205789-d726-4232-52e4-12e9f5848ea5
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 342.889119ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 8cf3d042-a704-7169-000e-b267199cf5f1
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 26 Sep 2023 10:50:30 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - ea4a90b5-5e1f-46d2-5059-b9cdb2c5cc18
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 261.42744ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 797fe748-d6ba-c21b-afe7-a53644db7888
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 26 Sep 2023 10:50:30 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 1cf97105-efa9-41f7-6bd1-d99f67337886
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 502.182142ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1475,7 +1817,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b798c45a-99ae-115f-9044-b8490777b2a1
+                - a8365131-7eef-309f-3825-cec41b2d88fd
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1501,7 +1843,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:34:44 GMT
+                - Tue, 26 Sep 2023 10:50:30 GMT
             Expires:
                 - "0"
             Location:
@@ -1521,13 +1863,13 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7905e64f-5c5a-4ec1-76c0-2f7297025fa8
+                - 5a6f230e-2b7b-4aed-41d3-210673db1766
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 218.740881ms
-    - id: 22
+        duration: 117.149306ms
+    - id: 27
       request:
         proto: ""
         proto_major: 0
@@ -1549,7 +1891,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b798c45a-99ae-115f-9044-b8490777b2a1
+                - a8365131-7eef-309f-3825-cec41b2d88fd
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1570,14 +1912,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"4d95dd32-7e12-498e-a1be-0221af763a88","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6511e0ccecf2c21f375cb1b5/trust"},"neoAuthnWithOidc":false},"id":"189b3556-270b-49c1-b229-1ead0de66f56","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1695670477160,"last_modified":1695670483478,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"1edde1ff-f861-4ca2-903c-2ba388d934f9","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6512b76e8a2c1a0894e4db43/trust"},"neoAuthnWithOidc":false},"id":"bcd22fca-4d13-4079-a63a-6d185b8c6df0","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1695725422892,"last_modified":1695725427719,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:34:45 GMT
+                - Tue, 26 Sep 2023 10:50:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1599,9 +1941,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7de74637-7949-4df2-54b2-9df483b87c6b
+                - fa8cafc8-b859-4665-61b0-72d96040bf19
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.171527765s
+        duration: 1.109444286s

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - c3652e36-5e1a-e007-65af-944154509125
+                - 1a03bf7d-5fa9-cfcd-93a0-5e73b7aada47
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:21 GMT
+                - Mon, 25 Sep 2023 19:34:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,18 +59,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ed828937-3a72-4f3b-7262-1edb5a40cde4
+                - b7aa3855-1b6c-411e-6cda-a354dd8ee67a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 544.6812ms
+        duration: 789.076827ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 17752fae-db06-de41-4ad4-36049ef6ecaf
+                - 2e52c922-b3cf-578f-8bcf-7477e0f8bf71
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:22 GMT
+                - Mon, 25 Sep 2023 19:34:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,18 +123,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 227d6b9a-37bf-4f0b-548d-8bf77942c9b5
+                - a6d5b180-0445-4f5e-5efc-453ba37eabaa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 695.2901ms
+        duration: 618.456149ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -149,7 +149,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a61d6f42-ac5a-ec13-9293-156650d93259
+                - f1f8a49a-f321-4754-ef59-da51303bb65a
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -160,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:22 GMT
+                - Mon, 25 Sep 2023 19:34:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,25 +187,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 98729535-cfd9-4be3-52ac-642f45669a29
+                - 97147449-51f0-453e-4757-35c2dc26ce45
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 360.1016ms
+        duration: 612.021203ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 243
+        content_length: 280
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"description":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","iasTenantUrl":"terraformint.accounts400.ondemand.com","name":"Custom IAS tenant for apps","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","name":"Custom IAS tenant for apps","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
         form: {}
         headers:
             Content-Type:
@@ -213,7 +213,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 05f12b45-f95e-0217-bda0-5670ee69759a
+                - 4d278207-5084-7f69-174d-a0b6e2754847
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:22 GMT
+                - Mon, 25 Sep 2023 19:34:35 GMT
             Expires:
                 - "0"
             Location:
@@ -259,25 +259,25 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 332be3b8-2dd7-4545-6c4d-abb5d5678c32
+                - f907eaab-35d7-484b-6e2d-ea1880ccbd65
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 142.0417ms
+        duration: 242.956234ms
     - id: 4
       request:
         proto: ""
         proto_major: 0
         proto_minor: 0
-        content_length: 243
+        content_length: 280
         transfer_encoding: []
         trailer: {}
         host: ""
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"description":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","iasTenantUrl":"terraformint.accounts400.ondemand.com","name":"Custom IAS tenant for apps","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","name":"Custom IAS tenant for apps","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
         form: {}
         headers:
             Content-Type:
@@ -287,7 +287,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 05f12b45-f95e-0217-bda0-5670ee69759a
+                - 4d278207-5084-7f69-174d-a0b6e2754847
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"0991aafa-1820-443d-b27c-6e41fd251c4c","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/64f6d6031c76710776fa2929/trust"},"neoAuthnWithOidc":false},"id":"e498e380-201f-44e9-83b0-639e74045e2b","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1693898243880,"last_modified":1693898243880,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformint.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"4d95dd32-7e12-498e-a1be-0221af763a88","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6511e0ccecf2c21f375cb1b5/trust"},"neoAuthnWithOidc":false},"id":"189b3556-270b-49c1-b229-1ead0de66f56","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1695670477160,"last_modified":1695670477160,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:23 GMT
+                - Mon, 25 Sep 2023 19:34:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -337,25 +337,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a236b7c9-f73e-48d4-615e-55b9ff9dbfb0
+                - 35412bcf-df2c-4a6b-438f-49168db4bee2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.0998994s
+        duration: 1.499105664s
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 92
+        content_length: 313
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+            {"paramValues":{"domain":"terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"false","status":"inactive","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"false"}}
         form: {}
         headers:
             Content-Type:
@@ -363,7 +363,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 9ad5b07a-4680-2090-39ce-4bd11d4f0bd1
+                - 4d8cb55e-609a-8f22-efd3-c6da0818f986
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -372,7 +372,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -389,11 +389,11 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:24 GMT
+                - Mon, 25 Sep 2023 19:34:37 GMT
             Expires:
                 - "0"
             Location:
-                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
             Pragma:
                 - no-cache
             Referrer-Policy:
@@ -409,35 +409,35 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 802d75fd-a136-46ea-620c-5489b2f32e85
+                - c05c219c-a908-4a98-61ff-c9bc0cd465c1
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 169.6082ms
+        duration: 207.967056ms
     - id: 6
       request:
         proto: ""
         proto_major: 0
         proto_minor: 0
-        content_length: 92
+        content_length: 313
         transfer_encoding: []
         trailer: {}
         host: ""
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+            {"paramValues":{"domain":"terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"false","status":"inactive","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"false"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 9ad5b07a-4680-2090-39ce-4bd11d4f0bd1
+                - 4d8cb55e-609a-8f22-efd3-c6da0818f986
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -448,7 +448,7 @@ interactions:
                 - integration-test-acc-static-b8xxozer
             X-Id-Token:
                 - redacted
-        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -458,14 +458,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"terraformint.accounts400.ondemand.com","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"inactive","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"false","createShadowUsersDuringLogon":"false","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:24 GMT
+                - Mon, 25 Sep 2023 19:34:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,18 +487,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0cb2fecd-f491-4920-60c5-de874cd3294c
+                - 1f871424-e769-4932-4173-71101e1c8acb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 269.3101ms
+        duration: 640.425129ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ca08cd5b-259c-572b-ea88-17dd41b9c28b
+                - 62fb655c-e748-5681-e8bc-e146d1b595ec
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -524,18 +524,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:24 GMT
+                - Mon, 25 Sep 2023 19:34:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -551,18 +551,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dd66c638-e194-4540-6df2-68a03e5a3e19
+                - 57d3e509-5c7a-4aab-6f8c-e40b9eda9423
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 333.883ms
+        duration: 520.107911ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -577,7 +577,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 932b10d7-f612-4afa-6b8c-fc4b53fe013c
+                - 4a29da57-3de3-2c90-32ff-0025435df8c4
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -588,18 +588,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:25 GMT
+                - Mon, 25 Sep 2023 19:34:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -615,12 +615,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c3eb0682-b08a-44ce-56ab-e5324a8b9554
+                - 74203026-7cfc-48d0-5115-e45f7129223b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 890.6601ms
+        duration: 315.512298ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -641,7 +641,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1e46c050-e3c9-bcaa-a16c-09467cd524c7
+                - dcb09654-d99a-effc-5e4d-c1d0147a1639
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -667,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:25 GMT
+                - Mon, 25 Sep 2023 19:34:39 GMT
             Expires:
                 - "0"
             Location:
@@ -687,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8f35e35b-f40c-4524-5c9d-e4375bfce5ba
+                - 4c719467-e6c9-493a-5eda-294385309460
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 101.2362ms
+        duration: 263.956518ms
     - id: 10
       request:
         proto: ""
@@ -715,7 +715,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1e46c050-e3c9-bcaa-a16c-09467cd524c7
+                - dcb09654-d99a-effc-5e4d-c1d0147a1639
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -736,14 +736,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"terraformint.accounts400.ondemand.com","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"inactive","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"false","createShadowUsersDuringLogon":"false","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:26 GMT
+                - Mon, 25 Sep 2023 19:34:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -765,18 +765,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5243edd2-fa41-4988-6734-fde09ad3819c
+                - 43e1987b-897b-43f7-7e40-3781af2d45a0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 238.5105ms
+        duration: 242.849916ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -791,7 +791,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 5be77b2c-ac1e-22b5-7c68-33d64f04b374
+                - e43382af-5cbb-664b-b016-b449cecc838e
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -802,18 +802,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:26 GMT
+                - Mon, 25 Sep 2023 19:34:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -829,18 +829,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 355f209f-116f-4e06-581d-f51e57d88619
+                - 2cb53423-6089-4f24-77d7-9ba8235d7bf4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 351.2705ms
+        duration: 471.786332ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -855,7 +855,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 9aec4ff7-9548-f2e2-336f-89c94a1663ce
+                - b8731f9e-e840-1d28-0607-e4c8126ef770
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -866,18 +866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:27 GMT
+                - Mon, 25 Sep 2023 19:34:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -893,18 +893,168 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0de1cbec-ced2-49c2-5382-da506054d224
+                - 44254bfa-51aa-4418-5f1c-b0dce23dfcbc
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 918.379ms
+        duration: 472.650385ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - d582efa6-866a-8b83-9955-eb11177a37fc
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 25 Sep 2023 19:34:41 GMT
+            Expires:
+                - "0"
+            Location:
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Frame-Options:
+                - DENY
+            X-Id-Token:
+                - redacted
+            X-Vcap-Request-Id:
+                - fcd59994-1356-45f4-54d3-d813883d0545
+            X-Xss-Protection:
+                - "0"
+        status: 307 Temporary Redirect
+        code: 307
+        duration: 305.235913ms
+    - id: 14
+      request:
+        proto: ""
+        proto_major: 0
+        proto_minor: 0
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            Referer:
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - d582efa6-866a-8b83-9955-eb11177a37fc
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Id-Token:
+                - redacted
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"inactive","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"false","createShadowUsersDuringLogon":"false","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:34:41 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 3370a824-86d2-47b9-5de9-e9dc3d0836e3
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 409.059158ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -919,7 +1069,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - f48c1fb2-af8d-ee58-e22e-5d95916b0976
+                - 0fdbee91-eb6d-e5ab-5e00-8cfa7f8beec6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -930,18 +1080,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:27 GMT
+                - Mon, 25 Sep 2023 19:34:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -957,13 +1107,355 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 551eb049-94df-40e9-6782-9b91677a227b
+                - ad934030-9fe5-45b8-5c42-a12508642691
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 364.9598ms
-    - id: 14
+        duration: 514.259801ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 2ae5a8ae-fba2-d0be-bc32-9cde274a4d0f
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:34:42 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - dd823401-d2f0-4685-5257-475126267d0c
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 218.176512ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 330
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - e1ad2579-9b6c-882a-4b28-aa803cd6c0b8
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 25 Sep 2023 19:34:42 GMT
+            Expires:
+                - "0"
+            Location:
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Frame-Options:
+                - DENY
+            X-Id-Token:
+                - redacted
+            X-Vcap-Request-Id:
+                - b71e9f4e-d459-4b6a-7ef1-7e8db96f2362
+            X-Xss-Protection:
+                - "0"
+        status: 307 Temporary Redirect
+        code: 307
+        duration: 302.367812ms
+    - id: 18
+      request:
+        proto: ""
+        proto_major: 0
+        proto_minor: 0
+        content_length: 330
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            Referer:
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - e1ad2579-9b6c-882a-4b28-aa803cd6c0b8
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Id-Token:
+                - redacted
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:34:43 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 0b7de02d-1cc6-410a-453c-38dd68412907
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 614.375289ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - eb9edcd4-8699-c326-5b0f-c1733df972ab
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:34:44 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - a2c98b8c-0517-485c-444f-9c8314274b32
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 387.064961ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 0df96bca-d699-8a1e-4e5c-a6d2006e12f7
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:34:44 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 0278305a-1bf5-41cc-5c3d-5e20f1a6617c
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 230.271366ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -983,7 +1475,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 6c931442-7a1c-b3fb-6aa7-31f56e731e4e
+                - b798c45a-99ae-115f-9044-b8490777b2a1
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1009,7 +1501,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:28 GMT
+                - Mon, 25 Sep 2023 19:34:44 GMT
             Expires:
                 - "0"
             Location:
@@ -1029,13 +1521,13 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 48e0dc40-e246-4b73-747c-fd1f4ad4880f
+                - 7905e64f-5c5a-4ec1-76c0-2f7297025fa8
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 141.9115ms
-    - id: 15
+        duration: 218.740881ms
+    - id: 22
       request:
         proto: ""
         proto_major: 0
@@ -1057,7 +1549,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 6c931442-7a1c-b3fb-6aa7-31f56e731e4e
+                - b798c45a-99ae-115f-9044-b8490777b2a1
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1078,14 +1570,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"0991aafa-1820-443d-b27c-6e41fd251c4c","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"neoAuthnWithOidc":false},"id":"e498e380-201f-44e9-83b0-639e74045e2b","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1693898243880,"last_modified":1693898243880,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"4d95dd32-7e12-498e-a1be-0221af763a88","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6511e0ccecf2c21f375cb1b5/trust"},"neoAuthnWithOidc":false},"id":"189b3556-270b-49c1-b229-1ead0de66f56","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1695670477160,"last_modified":1695670483478,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:29 GMT
+                - Mon, 25 Sep 2023 19:34:45 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1107,9 +1599,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3ab5cddd-b1e6-4f99-7767-44c483f5687d
+                - 7de74637-7949-4df2-54b2-9df483b87c6b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.0244832s
+        duration: 1.171527765s

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1a989d48-6c0d-6d67-81b8-9189a8d3ef06
+                - c564e6be-b0ef-fa79-a6fd-abda7853085d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:29 GMT
+                - Mon, 25 Sep 2023 19:47:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,18 +59,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7bc138ae-7478-454a-5bd5-5338c7daf13e
+                - 579c63bc-4384-46ec-7aec-c577efe323ee
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 309.0557ms
+        duration: 621.189076ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 616fd399-75bf-cd7a-4d4b-12cda852b761
+                - da4553eb-5eee-2d44-91d0-511b5b8b233d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:29 GMT
+                - Mon, 25 Sep 2023 19:47:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,18 +123,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 660f1349-d463-4c60-6ccb-aebc919cfef4
+                - 24c34255-abf9-44fb-576d-85b22fc42072
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 384.5673ms
+        duration: 463.268907ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -149,7 +149,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - e0b3335e-b088-546d-5abc-cb3b16fc6853
+                - b477ccdb-1fca-154d-c538-622e9a92f9f0
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -160,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:31 GMT
+                - Mon, 25 Sep 2023 19:47:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,12 +187,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b0be898f-ae6f-43e3-4fee-a3b3830d3cd8
+                - 3780b08b-0156-41ba-7a60-6b2f97d2f47a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.0526881s
+        duration: 319.05003ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -213,7 +213,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 34ba9928-6c01-56a0-7502-a37ffd2e2450
+                - 87765677-20f0-6e62-3953-2024f08dc57a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:31 GMT
+                - Mon, 25 Sep 2023 19:47:20 GMT
             Expires:
                 - "0"
             Location:
@@ -259,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 834b2573-2e5b-4e0a-7f60-89fd348e99f4
+                - f1dd4c0e-2356-43f4-6b09-9f468265cb4c
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 139.034ms
+        duration: 221.571313ms
     - id: 4
       request:
         proto: ""
@@ -287,7 +287,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 34ba9928-6c01-56a0-7502-a37ffd2e2450
+                - 87765677-20f0-6e62-3953-2024f08dc57a
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"a5476296-a9e8-4180-a8eb-06d75301e0cd","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/64f6d60b1c76710776fa2933/trust"},"neoAuthnWithOidc":false},"id":"3b3a0a00-605a-41c0-a505-f03930fbdf74","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1693898252187,"last_modified":1693898252187,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"07553680-de45-4e2b-bd0a-f21fde5147bc","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6511e3c941f426421d4ffa28/trust"},"neoAuthnWithOidc":false},"id":"a8f1d3d6-8011-4bde-84bd-4a55f6805606","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1695671241693,"last_modified":1695671241693,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:32 GMT
+                - Mon, 25 Sep 2023 19:47:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -337,25 +337,25 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c3003f6d-26bb-4a45-7780-a8bbb6d26014
+                - 66678790-7955-4238-6591-54af8392205c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 884.7543ms
+        duration: 1.211462402s
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 92
+        content_length: 230
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+            {"paramValues":{"iasTenantUrl":"terraformint.accounts400.ondemand.com","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
         form: {}
         headers:
             Content-Type:
@@ -363,7 +363,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a4bcdfe3-2a3b-280d-728d-5ecb024b652d
+                - ae38754b-516f-31da-baff-facba5a6c6d6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -372,7 +372,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -389,11 +389,11 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:32 GMT
+                - Mon, 25 Sep 2023 19:47:21 GMT
             Expires:
                 - "0"
             Location:
-                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
             Pragma:
                 - no-cache
             Referrer-Policy:
@@ -409,35 +409,35 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - e84a79ed-b0b4-4067-466b-562c2f6b8772
+                - d2063a75-f8f3-4736-4ae9-82eff7220054
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 139.6931ms
+        duration: 197.976939ms
     - id: 6
       request:
         proto: ""
         proto_major: 0
         proto_minor: 0
-        content_length: 92
+        content_length: 230
         transfer_encoding: []
         trailer: {}
         host: ""
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+            {"paramValues":{"iasTenantUrl":"terraformint.accounts400.ondemand.com","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a4bcdfe3-2a3b-280d-728d-5ecb024b652d
+                - ae38754b-516f-31da-baff-facba5a6c6d6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -448,7 +448,7 @@ interactions:
                 - integration-test-acc-static-b8xxozer
             X-Id-Token:
                 - redacted
-        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -465,7 +465,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:32 GMT
+                - Mon, 25 Sep 2023 19:47:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,18 +487,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 25ff039e-866e-4858-69f8-a702fcda29c4
+                - 0341eb1c-c06c-475e-4a27-16959676f20c
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 233.0972ms
+        duration: 607.903794ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 5d736b80-2bd8-85e4-c8fe-b8f5fb268a57
+                - cae10ebc-bd50-5c3e-0a59-b01d9e5c3789
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -524,18 +524,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:33 GMT
+                - Mon, 25 Sep 2023 19:47:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -551,18 +551,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7fc81b25-f80c-4c24-509a-f68da7dbeab9
+                - e088d062-eb9a-492f-4979-6218002c458e
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 326.2242ms
+        duration: 414.799684ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -577,7 +577,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - e1481b5f-d154-acf6-56f4-0c42765beca9
+                - b1b90724-40fa-0e3a-fa1b-1626a654cf02
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -588,18 +588,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:33 GMT
+                - Mon, 25 Sep 2023 19:47:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -615,12 +615,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 314fdfb7-8c91-40c5-79b0-beee8a1ae8cc
+                - 0b7a42f6-cb63-459b-4dc8-5be1e77804d9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 364.893ms
+        duration: 511.627359ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -641,7 +641,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 0e7bbf38-a784-4f98-cfc9-4f453c0de3d2
+                - c2a2af79-188b-1696-868d-32ac2a550981
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -667,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:33 GMT
+                - Mon, 25 Sep 2023 19:47:23 GMT
             Expires:
                 - "0"
             Location:
@@ -687,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 14e81690-8bc3-4f4a-6c20-50ec473f7123
+                - 175fca71-2729-437c-6bf0-00eca2210d6b
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 142.9509ms
+        duration: 198.433511ms
     - id: 10
       request:
         proto: ""
@@ -715,7 +715,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 0e7bbf38-a784-4f98-cfc9-4f453c0de3d2
+                - c2a2af79-188b-1696-868d-32ac2a550981
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -743,7 +743,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:33 GMT
+                - Mon, 25 Sep 2023 19:47:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -765,18 +765,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a783107f-8e63-461d-53a6-3d53b205557c
+                - 32b3f770-d1dd-4f32-7f0d-8cdf83560778
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 157.7308ms
+        duration: 177.412439ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -791,7 +791,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 03a799f0-af7f-ff97-5fef-b7bc695a7aff
+                - 573d8f68-c6f1-7897-8b36-15d0a09144d0
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -802,18 +802,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:34 GMT
+                - Mon, 25 Sep 2023 19:47:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -829,18 +829,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 56ddfa67-84e6-487e-71a3-43f75dc041e9
+                - 56f50d04-b555-48b3-42df-7de66ee04056
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 396.233ms
+        duration: 339.716318ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -855,7 +855,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7fd73367-a92d-643b-d904-e8674b77a60c
+                - c5191cbe-5341-5711-9ab2-81029ffc7ecd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -866,18 +866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:34 GMT
+                - Mon, 25 Sep 2023 19:47:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -893,18 +893,168 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d4505c18-78b4-45b4-502a-1b4290e296f8
+                - 298c2821-d075-47d4-6d23-c326d010d016
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 385.9639ms
+        duration: 395.509404ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 1a78c70e-55e3-6a36-7cba-0895528dbbf6
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 25 Sep 2023 19:47:25 GMT
+            Expires:
+                - "0"
+            Location:
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Frame-Options:
+                - DENY
+            X-Id-Token:
+                - redacted
+            X-Vcap-Request-Id:
+                - 4861d60e-f6fa-459f-630c-e3a627271626
+            X-Xss-Protection:
+                - "0"
+        status: 307 Temporary Redirect
+        code: 307
+        duration: 182.46319ms
+    - id: 14
+      request:
+        proto: ""
+        proto_major: 0
+        proto_minor: 0
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            Referer:
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 1a78c70e-55e3-6a36-7cba-0895528dbbf6
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Id-Token:
+                - redacted
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Custom IAS tenant","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"terraformint.accounts400.ondemand.com","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:25 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - bf3ec285-e71d-4fb6-528f-5a5cdf1e2917
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 300.888124ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: cpcli.cf.sap.hana.ondemand.com
@@ -919,7 +1069,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 709e75ca-5329-5f48-9231-905f503018c6
+                - 303490a5-f627-d5d1-3718-5107f706c83f
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -930,18 +1080,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:35 GMT
+                - Mon, 25 Sep 2023 19:47:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -957,13 +1107,697 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b893049a-0dc6-4e68-554a-bebab90e80b4
+                - 3c81886b-e9d5-48cd-4d8d-41443ba03e0f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.033589s
-    - id: 14
+        duration: 483.828467ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 412e43fc-2a81-c39a-296a-dd623c81a838
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:26 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 3567fc22-8410-404a-7433-b5db47d91ebb
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 341.201962ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 421
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","domain":"terraformtest.accounts400.ondemand.com","iasTenantUrl":"terraformtest.accounts400.ondemand.com","linkText":"custom link text","name":"Custom IAS tenant for apps","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"false","status":"inactive","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"false"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 3bdca989-9493-0734-84ec-52be09ceb630
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 25 Sep 2023 19:47:26 GMT
+            Expires:
+                - "0"
+            Location:
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Frame-Options:
+                - DENY
+            X-Id-Token:
+                - redacted
+            X-Vcap-Request-Id:
+                - 24db24e1-0238-422f-69d9-2016cf0e784c
+            X-Xss-Protection:
+                - "0"
+        status: 307 Temporary Redirect
+        code: 307
+        duration: 138.579129ms
+    - id: 18
+      request:
+        proto: ""
+        proto_major: 0
+        proto_minor: 0
+        content_length: 421
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","domain":"terraformtest.accounts400.ondemand.com","iasTenantUrl":"terraformtest.accounts400.ondemand.com","linkText":"custom link text","name":"Custom IAS tenant for apps","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"false","status":"inactive","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"false"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            Referer:
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 3bdca989-9493-0734-84ec-52be09ceb630
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Id-Token:
+                - redacted
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?update
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"inactive","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformtest.accounts400.ondemand.com","domain":"terraformtest.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"false","createShadowUsersDuringLogon":"false","sapBtpCli":"terraformtest","protocol":"OpenID Connect","readOnly":false}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:28 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 19d57f8f-9770-4281-6ce6-55d7f827eead
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.548424316s
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - ef52d7a7-07b5-1ddf-5e3c-eae6d74e5116
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:28 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 17e1581a-9ee1-48ab-6fa8-f9db17400422
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 286.551141ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 262e1c15-7b86-2666-acf3-97ae5f06b5f9
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:29 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 937aeccb-9fb5-44a9-593c-e6451d7a5160
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 266.982792ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 319b0784-af8d-5fba-b17d-9f9f8166cb46
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - terraformintcanary
+        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 25 Sep 2023 19:47:29 GMT
+            Expires:
+                - "0"
+            Location:
+                - https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Frame-Options:
+                - DENY
+            X-Id-Token:
+                - redacted
+            X-Vcap-Request-Id:
+                - 671ef255-4edc-4a4c-6282-c0c99ef09038
+            X-Xss-Protection:
+                - "0"
+        status: 307 Temporary Redirect
+        code: 307
+        duration: 181.369308ms
+    - id: 22
+      request:
+        proto: ""
+        proto_major: 0
+        proto_minor: 0
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"paramValues":{"origin":"sap.custom","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            Referer:
+                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 319b0784-af8d-5fba-b17d-9f9f8166cb46
+            X-Cpcli-Customidp:
+                - identityProvider
+            X-Cpcli-Format:
+                - json
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Subdomain:
+                - integration-test-acc-static-b8xxozer
+            X-Id-Token:
+                - redacted
+        url: https://cpcli.cf.eu12.hana.ondemand.com/command/v2.49.0/security/trust?get
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"inactive","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformtest.accounts400.ondemand.com","domain":"terraformtest.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"false","createShadowUsersDuringLogon":"false","sapBtpCli":"terraformtest","protocol":"OpenID Connect","readOnly":false}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:29 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Backend-Mediatype:
+                - application/json
+            X-Cpcli-Backend-Status:
+                - "200"
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Cpcli-Replacementrefreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 770afe8f-773a-401d-6db0-5bc48b94c68b
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 327.709231ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 448ddd1d-e615-135d-7301-f1deb958bc6b
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:30 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 6aba7070-ef65-4222-4427-c50ed644bd1d
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 314.611596ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 7bd892e7-fb45-6613-be4c-9c77c73a2230
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:30 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 2b79c055-2ed1-4989-5f8b-30c02fffee63
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 378.663407ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 124
+        transfer_encoding: []
+        trailer: {}
+        host: cpcli.cf.sap.hana.ondemand.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"customIdp":"identityProvider","subdomain":"terraformintcanary","userName":"john.doe@int.test","password":"testUserPassword"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Terraform/1.5.6 terraform-provider-btp/dev
+            X-Correlationid:
+                - 6d4e331b-91cf-757e-dc14-157616fbf0f0
+            X-Cpcli-Format:
+                - json
+        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
+        headers:
+            Cache-Control:
+                - no-cache, no-store, max-age=0, must-revalidate
+            Content-Length:
+                - "163"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 25 Sep 2023 19:47:31 GMT
+            Expires:
+                - "0"
+            Pragma:
+                - no-cache
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload;
+            X-Content-Type-Options:
+                - nosniff
+            X-Cpcli-Refreshtoken:
+                - redacted
+            X-Frame-Options:
+                - DENY
+            X-Vcap-Request-Id:
+                - 7b7f385f-93ca-47f0-580a-9b2c679fd5b4
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 321.711525ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -983,7 +1817,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a72a4c32-1a28-c09c-ac1b-b72cac5dfd08
+                - 4671e522-48c3-90e3-d289-b30401f14699
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1009,7 +1843,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 05 Sep 2023 07:17:35 GMT
+                - Mon, 25 Sep 2023 19:47:31 GMT
             Expires:
                 - "0"
             Location:
@@ -1029,13 +1863,13 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4bb8f8ea-1024-492d-5cc9-30c910ed1053
+                - c89c11e6-aada-49bd-7306-ff95d33695c7
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 122.7585ms
-    - id: 15
+        duration: 125.33788ms
+    - id: 27
       request:
         proto: ""
         proto_major: 0
@@ -1057,7 +1891,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - a72a4c32-1a28-c09c-ac1b-b72cac5dfd08
+                - 4671e522-48c3-90e3-d289-b30401f14699
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1078,14 +1912,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"a5476296-a9e8-4180-a8eb-06d75301e0cd","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"neoAuthnWithOidc":false},"id":"3b3a0a00-605a-41c0-a505-f03930fbdf74","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1693898252187,"last_modified":1693898252187,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformtest.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":false,"storeCustomAttributes":true,"authUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":false,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"daefc512-5533-49ba-8999-c7572b0d6ea0","scopes":["openid","email"],"issuer":"https://terraformtest.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformtest.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":false,"neoAuthnWithOidc":false},"id":"a8f1d3d6-8011-4bde-84bd-4a55f6805606","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1695671241693,"last_modified":1695671248407,"active":false,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Tue, 05 Sep 2023 07:17:36 GMT
+                - Mon, 25 Sep 2023 19:47:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1107,9 +1941,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2660ea13-3844-4831-63d8-95c2fea57341
+                - e20f6ec6-7b5a-410c-5136-0f7694d88331
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 882.1406ms
+        duration: 1.258802583s

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
@@ -21,7 +21,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - c564e6be-b0ef-fa79-a6fd-abda7853085d
+                - f197c96d-2b1f-a152-aaf0-3224f74050ba
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -43,7 +43,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:19 GMT
+                - Tue, 26 Sep 2023 10:50:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,12 +59,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 579c63bc-4384-46ec-7aec-c577efe323ee
+                - c90c0684-8a28-4527-6735-d66b4eb00626
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 621.189076ms
+        duration: 430.231191ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -85,7 +85,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - da4553eb-5eee-2d44-91d0-511b5b8b233d
+                - 74c5dae8-a6ce-dbf3-c159-42474b3c1224
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -107,7 +107,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:19 GMT
+                - Tue, 26 Sep 2023 10:50:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,12 +123,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 24c34255-abf9-44fb-576d-85b22fc42072
+                - 5eae3557-8a81-4d5b-5b35-70c3e7ba187d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 463.268907ms
+        duration: 392.72382ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -149,7 +149,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b477ccdb-1fca-154d-c538-622e9a92f9f0
+                - e22110fb-0bb3-ebc4-4c80-38f39ecd3908
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -171,7 +171,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:20 GMT
+                - Tue, 26 Sep 2023 10:50:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,12 +187,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3780b08b-0156-41ba-7a60-6b2f97d2f47a
+                - 06fd08c4-74d3-4b07-5e80-a4a4a1812dc4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 319.05003ms
+        duration: 273.304763ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -213,7 +213,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 87765677-20f0-6e62-3953-2024f08dc57a
+                - 2964a814-5e2b-1eae-4d07-27235c648863
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:20 GMT
+                - Tue, 26 Sep 2023 10:50:33 GMT
             Expires:
                 - "0"
             Location:
@@ -259,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - f1dd4c0e-2356-43f4-6b09-9f468265cb4c
+                - bcf54374-58e6-4eaf-5109-f56d41062873
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 221.571313ms
+        duration: 109.290303ms
     - id: 4
       request:
         proto: ""
@@ -287,7 +287,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 87765677-20f0-6e62-3953-2024f08dc57a
+                - 2964a814-5e2b-1eae-4d07-27235c648863
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"07553680-de45-4e2b-bd0a-f21fde5147bc","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6511e3c941f426421d4ffa28/trust"},"neoAuthnWithOidc":false},"id":"a8f1d3d6-8011-4bde-84bd-4a55f6805606","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1695671241693,"last_modified":1695671241693,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"c5f5c7a5-c81f-4839-9d9c-400494108754","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/6512b77ade44b87496a4429d/trust"},"neoAuthnWithOidc":false},"id":"0241c899-fb08-44cb-ae50-9b5acd8857a1","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1695725434984,"last_modified":1695725434984,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:21 GMT
+                - Tue, 26 Sep 2023 10:50:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -337,12 +337,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 66678790-7955-4238-6591-54af8392205c
+                - 7ab90bb4-a145-4136-6080-4f0d9725fe53
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.211462402s
+        duration: 1.421884612s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -363,7 +363,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ae38754b-516f-31da-baff-facba5a6c6d6
+                - 854c2973-e0d9-b7d7-9520-b7ebab28f9e4
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -389,7 +389,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:21 GMT
+                - Tue, 26 Sep 2023 10:50:35 GMT
             Expires:
                 - "0"
             Location:
@@ -409,12 +409,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - d2063a75-f8f3-4736-4ae9-82eff7220054
+                - a9f2e948-6ec9-49ec-67b1-4fe8ee9e1ccd
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 197.976939ms
+        duration: 125.162306ms
     - id: 6
       request:
         proto: ""
@@ -437,7 +437,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ae38754b-516f-31da-baff-facba5a6c6d6
+                - 854c2973-e0d9-b7d7-9520-b7ebab28f9e4
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -465,7 +465,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:22 GMT
+                - Tue, 26 Sep 2023 10:50:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -487,12 +487,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0341eb1c-c06c-475e-4a27-16959676f20c
+                - 3daea2f9-e4e3-4aca-7c02-130776e3bc89
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 607.903794ms
+        duration: 693.330211ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - cae10ebc-bd50-5c3e-0a59-b01d9e5c3789
+                - 10145e42-236c-81a5-25af-329de0ed08a2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -535,7 +535,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:23 GMT
+                - Tue, 26 Sep 2023 10:50:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -551,12 +551,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e088d062-eb9a-492f-4979-6218002c458e
+                - c746d01a-78e6-4eb8-51bd-b538f858270a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 414.799684ms
+        duration: 313.998799ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -577,7 +577,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - b1b90724-40fa-0e3a-fa1b-1626a654cf02
+                - 582c3039-3cc7-3d3b-5b7c-5bf236f4841d
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -599,7 +599,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:23 GMT
+                - Tue, 26 Sep 2023 10:50:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -615,12 +615,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0b7a42f6-cb63-459b-4dc8-5be1e77804d9
+                - 49211891-f329-4a6b-7794-6a888932b531
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 511.627359ms
+        duration: 313.377063ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -641,7 +641,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - c2a2af79-188b-1696-868d-32ac2a550981
+                - 04d8370d-d4af-57ea-34bc-c51d872dbbe6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -667,7 +667,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:23 GMT
+                - Tue, 26 Sep 2023 10:50:37 GMT
             Expires:
                 - "0"
             Location:
@@ -687,12 +687,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 175fca71-2729-437c-6bf0-00eca2210d6b
+                - a0f54963-79b6-4734-7fdc-021e78289f6b
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 198.433511ms
+        duration: 184.202683ms
     - id: 10
       request:
         proto: ""
@@ -715,7 +715,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - c2a2af79-188b-1696-868d-32ac2a550981
+                - 04d8370d-d4af-57ea-34bc-c51d872dbbe6
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -743,7 +743,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:24 GMT
+                - Tue, 26 Sep 2023 10:50:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -765,12 +765,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 32b3f770-d1dd-4f32-7f0d-8cdf83560778
+                - a5a9678b-c355-4b2a-6769-50483a69ee49
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 177.412439ms
+        duration: 190.023758ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -791,7 +791,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 573d8f68-c6f1-7897-8b36-15d0a09144d0
+                - 9baa41b6-ce41-5fef-b951-e00a3029d6e2
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -813,7 +813,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:24 GMT
+                - Tue, 26 Sep 2023 10:50:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -829,12 +829,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 56f50d04-b555-48b3-42df-7de66ee04056
+                - 64db27ab-9908-4573-728c-a5dc9781b34b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 339.716318ms
+        duration: 299.423177ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -855,7 +855,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - c5191cbe-5341-5711-9ab2-81029ffc7ecd
+                - 665a5bbf-16a6-8850-56db-ebcecef0bf32
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -877,7 +877,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:25 GMT
+                - Tue, 26 Sep 2023 10:50:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -893,12 +893,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 298c2821-d075-47d4-6d23-c326d010d016
+                - 3e2602f5-56e4-4e4a-5716-610d40797381
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 395.509404ms
+        duration: 259.979058ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -919,7 +919,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1a78c70e-55e3-6a36-7cba-0895528dbbf6
+                - b4fbf33a-69c8-585c-6f1d-b8387c42ee82
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -945,7 +945,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:25 GMT
+                - Tue, 26 Sep 2023 10:50:38 GMT
             Expires:
                 - "0"
             Location:
@@ -965,12 +965,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4861d60e-f6fa-459f-630c-e3a627271626
+                - 05870eee-4e4a-417b-70d7-8a05471ffd9b
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 182.46319ms
+        duration: 125.656154ms
     - id: 14
       request:
         proto: ""
@@ -993,7 +993,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 1a78c70e-55e3-6a36-7cba-0895528dbbf6
+                - b4fbf33a-69c8-585c-6f1d-b8387c42ee82
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1021,7 +1021,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:25 GMT
+                - Tue, 26 Sep 2023 10:50:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1043,12 +1043,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bf3ec285-e71d-4fb6-528f-5a5cdf1e2917
+                - 965bd9a1-4782-4494-60de-769bbbd5e5cb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 300.888124ms
+        duration: 219.085676ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1069,7 +1069,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 303490a5-f627-d5d1-3718-5107f706c83f
+                - 910a2054-4c2b-214d-3efb-71c8c84036dd
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1091,7 +1091,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:26 GMT
+                - Tue, 26 Sep 2023 10:50:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1107,12 +1107,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3c81886b-e9d5-48cd-4d8d-41443ba03e0f
+                - 5cd7b0a2-1393-4903-63ab-a990d51d3ac4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 483.828467ms
+        duration: 262.592877ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1133,7 +1133,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 412e43fc-2a81-c39a-296a-dd623c81a838
+                - c46d9418-066b-e338-a2ab-b107d3d5db18
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1155,7 +1155,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:26 GMT
+                - Tue, 26 Sep 2023 10:50:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1171,12 +1171,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3567fc22-8410-404a-7433-b5db47d91ebb
+                - 12d21e7b-0090-484e-5254-4860f3bc9c78
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 341.201962ms
+        duration: 399.360085ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1197,7 +1197,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3bdca989-9493-0734-84ec-52be09ceb630
+                - b0fb49a7-5b27-bccd-5999-ef45daea237f
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1223,7 +1223,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:26 GMT
+                - Tue, 26 Sep 2023 10:50:39 GMT
             Expires:
                 - "0"
             Location:
@@ -1243,12 +1243,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 24db24e1-0238-422f-69d9-2016cf0e784c
+                - 49868bb8-5ffb-46b2-4cb5-18f13ab4bbe3
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 138.579129ms
+        duration: 135.244796ms
     - id: 18
       request:
         proto: ""
@@ -1271,7 +1271,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 3bdca989-9493-0734-84ec-52be09ceb630
+                - b0fb49a7-5b27-bccd-5999-ef45daea237f
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1299,7 +1299,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:28 GMT
+                - Tue, 26 Sep 2023 10:50:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1321,12 +1321,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 19d57f8f-9770-4281-6ce6-55d7f827eead
+                - ffafd389-5879-4154-78b7-1c9725f9cf1f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.548424316s
+        duration: 1.69938369s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1347,7 +1347,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - ef52d7a7-07b5-1ddf-5e3c-eae6d74e5116
+                - 995e9db7-9ce0-2db9-7857-b4e3cc3bbfd6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1369,7 +1369,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:28 GMT
+                - Tue, 26 Sep 2023 10:50:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1385,12 +1385,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 17e1581a-9ee1-48ab-6fa8-f9db17400422
+                - 64677db3-c758-43f5-7905-ff37c4b56cd7
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 286.551141ms
+        duration: 309.787954ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1411,7 +1411,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 262e1c15-7b86-2666-acf3-97ae5f06b5f9
+                - 0a9ac48d-759c-5328-4d3c-6da4b24191b6
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1433,7 +1433,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:29 GMT
+                - Tue, 26 Sep 2023 10:50:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1449,12 +1449,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 937aeccb-9fb5-44a9-593c-e6451d7a5160
+                - 24793627-406b-43e5-525a-4e36e3b00ba2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 266.982792ms
+        duration: 220.850965ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1475,7 +1475,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 319b0784-af8d-5fba-b17d-9f9f8166cb46
+                - 0201f24f-149f-2206-fdc6-f256c934e0fe
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1501,7 +1501,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:29 GMT
+                - Tue, 26 Sep 2023 10:50:42 GMT
             Expires:
                 - "0"
             Location:
@@ -1521,12 +1521,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 671ef255-4edc-4a4c-6282-c0c99ef09038
+                - c4074a60-42f1-472f-767f-58a4aa94e572
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 181.369308ms
+        duration: 113.072211ms
     - id: 22
       request:
         proto: ""
@@ -1549,7 +1549,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 319b0784-af8d-5fba-b17d-9f9f8166cb46
+                - 0201f24f-149f-2206-fdc6-f256c934e0fe
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1577,7 +1577,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:29 GMT
+                - Tue, 26 Sep 2023 10:50:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1599,12 +1599,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 770afe8f-773a-401d-6db0-5bc48b94c68b
+                - bb47e16f-f162-4926-553e-422c7ae400e0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 327.709231ms
+        duration: 196.519021ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1625,7 +1625,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 448ddd1d-e615-135d-7301-f1deb958bc6b
+                - 451f9fb8-020a-196e-145f-a14c824c5f80
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1647,7 +1647,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:30 GMT
+                - Tue, 26 Sep 2023 10:50:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1663,12 +1663,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6aba7070-ef65-4222-4427-c50ed644bd1d
+                - cf7bd866-cc28-43db-4553-becaa3fbf2d3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 314.611596ms
+        duration: 213.094062ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1689,7 +1689,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 7bd892e7-fb45-6613-be4c-9c77c73a2230
+                - b66f6bb1-d0a4-64bd-8501-3b9d406d4418
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1711,7 +1711,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:30 GMT
+                - Tue, 26 Sep 2023 10:50:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1727,12 +1727,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2b79c055-2ed1-4989-5f8b-30c02fffee63
+                - 14ebc08a-8f7b-4283-4d77-2f54ff60f6f5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 378.663407ms
+        duration: 345.730873ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1753,7 +1753,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 6d4e331b-91cf-757e-dc14-157616fbf0f0
+                - 68a5e707-7a0a-7225-75fe-0ecf2ad166d3
             X-Cpcli-Format:
                 - json
         url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
@@ -1775,7 +1775,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:31 GMT
+                - Tue, 26 Sep 2023 10:50:43 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1791,12 +1791,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7b7f385f-93ca-47f0-580a-9b2c679fd5b4
+                - ca2fbb59-253c-434b-601b-b30c304be1bb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 321.711525ms
+        duration: 396.956501ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1817,7 +1817,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4671e522-48c3-90e3-d289-b30401f14699
+                - bf04a97a-6e20-ad7b-8333-f2deb72e2b0d
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1843,7 +1843,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 25 Sep 2023 19:47:31 GMT
+                - Tue, 26 Sep 2023 10:50:44 GMT
             Expires:
                 - "0"
             Location:
@@ -1863,12 +1863,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - c89c11e6-aada-49bd-7306-ff95d33695c7
+                - 55eb27b9-1107-4783-72d2-1de463da27f7
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 125.33788ms
+        duration: 198.042855ms
     - id: 27
       request:
         proto: ""
@@ -1891,7 +1891,7 @@ interactions:
             User-Agent:
                 - Terraform/1.5.6 terraform-provider-btp/dev
             X-Correlationid:
-                - 4671e522-48c3-90e3-d289-b30401f14699
+                - bf04a97a-6e20-ad7b-8333-f2deb72e2b0d
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1912,14 +1912,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformtest.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":false,"storeCustomAttributes":true,"authUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":false,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"daefc512-5533-49ba-8999-c7572b0d6ea0","scopes":["openid","email"],"issuer":"https://terraformtest.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformtest.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":false,"neoAuthnWithOidc":false},"id":"a8f1d3d6-8011-4bde-84bd-4a55f6805606","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1695671241693,"last_modified":1695671248407,"active":false,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformtest.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":false,"storeCustomAttributes":true,"authUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":false,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"5d8212e7-0dd6-4922-b5f5-61fc65b8f502","scopes":["openid","email"],"issuer":"https://terraformtest.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformtest.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":false,"neoAuthnWithOidc":false},"id":"0241c899-fb08-44cb-ae50-9b5acd8857a1","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1695725434984,"last_modified":1695725441246,"active":false,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Mon, 25 Sep 2023 19:47:32 GMT
+                - Tue, 26 Sep 2023 10:50:45 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1941,9 +1941,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e20f6ec6-7b5a-410c-5136-0f7694d88331
+                - 6f15ad01-51c9-4c44-4979-4eab111cadf2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.258802583s
+        duration: 1.329251125s

--- a/internal/provider/resource_globalaccount_trust_configuration.go
+++ b/internal/provider/resource_globalaccount_trust_configuration.go
@@ -132,7 +132,7 @@ func (rs *globalaccountTrustConfigurationResource) Create(ctx context.Context, r
 		return
 	}
 
-	cliReq := btpcli.TrustConfigurationInput{
+	cliReq := btpcli.TrustConfigurationCreateInput{
 		IdentityProvider: plan.IdentityProvider.ValueString(),
 	}
 

--- a/internal/provider/resource_subaccount_trust_configuration_test.go
+++ b/internal/provider/resource_subaccount_trust_configuration_test.go
@@ -19,14 +19,41 @@ func TestResourceSubaccountTrustConfiguration(t *testing.T) {
 			ProtoV6ProviderFactories: getProviders(rec.GetDefaultClient()),
 			Steps: []resource.TestStep{
 				{
-					Config: hclProviderFor(user) + hclResourceSubaccountTrustConfigurationComplete("uut", "ef23ace8-6ade-4d78-9c1f-8df729548bbf", "terraformint.accounts400.ondemand.com", "Custom IAS tenant for apps", "IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)"),
+					Config: hclProviderFor(user) + hclResourceSubaccountTrustConfigurationComplete("uut", "ef23ace8-6ade-4d78-9c1f-8df729548bbf", "terraformint.accounts400.ondemand.com", "terraformint.accounts400.ondemand.com", "Custom IAS tenant for apps", "Description for terraformint.accounts400.ondemand.com", "custom link text", false, false, "inactive"),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestMatchResourceAttr("btp_subaccount_trust_configuration.uut", "subaccount_id", regexpValidUUID),
-						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "id", "sap.custom"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "identity_provider", "terraformint.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "domain", "terraformint.accounts400.ondemand.com"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "name", "Custom IAS tenant for apps"),
-						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "description", "IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "description", "Description for terraformint.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "link_text", "custom link text"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "available_for_user_logon", "false"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "auto_create_shadow_users", "false"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "origin", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "id", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "type", "Application"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "protocol", "OpenID Connect"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "status", "inactive"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "read_only", "false"),
+					),
+				},
+				{
+					Config: hclProviderFor(user) + hclResourceSubaccountTrustConfigurationMinimum("uut", "ef23ace8-6ade-4d78-9c1f-8df729548bbf", "terraformint.accounts400.ondemand.com"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestMatchResourceAttr("btp_subaccount_trust_configuration.uut", "subaccount_id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "identity_provider", "terraformint.accounts400.ondemand.com"),
+						resource.TestCheckNoResourceAttr("btp_subaccount_trust_configuration.uut", "domain"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "name", "Custom IAS tenant for apps"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "description", "Description for terraformint.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "link_text", "custom link text"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "available_for_user_logon", "true"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "auto_create_shadow_users", "true"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "origin", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "id", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "type", "Application"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "protocol", "OpenID Connect"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "status", "active"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "read_only", "false"),
 					),
 				},
 			},
@@ -45,11 +72,38 @@ func TestResourceSubaccountTrustConfiguration(t *testing.T) {
 					Config: hclProviderFor(user) + hclResourceSubaccountTrustConfigurationMinimum("uut", "ef23ace8-6ade-4d78-9c1f-8df729548bbf", "terraformint.accounts400.ondemand.com"),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestMatchResourceAttr("btp_subaccount_trust_configuration.uut", "subaccount_id", regexpValidUUID),
-						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "id", "sap.custom"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "identity_provider", "terraformint.accounts400.ondemand.com"),
+						resource.TestCheckNoResourceAttr("btp_subaccount_trust_configuration.uut", "domain"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "name", "Custom IAS tenant"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "description", "IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "link_text", "terraformint.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "available_for_user_logon", "true"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "auto_create_shadow_users", "true"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "origin", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "id", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "type", "Application"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "protocol", "OpenID Connect"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "status", "active"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "read_only", "false"),
+					),
+				},
+				{
+					Config: hclProviderFor(user) + hclResourceSubaccountTrustConfigurationComplete("uut", "ef23ace8-6ade-4d78-9c1f-8df729548bbf", "terraformtest.accounts400.ondemand.com", "terraformtest.accounts400.ondemand.com", "Custom IAS tenant for apps", "Description for terraformint.accounts400.ondemand.com", "custom link text", false, false, "inactive"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestMatchResourceAttr("btp_subaccount_trust_configuration.uut", "subaccount_id", regexpValidUUID),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "identity_provider", "terraformtest.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "domain", "terraformtest.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "name", "Custom IAS tenant for apps"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "description", "Description for terraformint.accounts400.ondemand.com"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "link_text", "custom link text"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "available_for_user_logon", "false"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "auto_create_shadow_users", "false"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "origin", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "id", "sap.custom"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "type", "Application"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "protocol", "OpenID Connect"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "status", "inactive"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "read_only", "false"),
 					),
 				},
 			},
@@ -58,16 +112,21 @@ func TestResourceSubaccountTrustConfiguration(t *testing.T) {
 
 }
 
-func hclResourceSubaccountTrustConfigurationComplete(resourceName string, subaccountId string, identityProvider string, name string, description string) string {
+func hclResourceSubaccountTrustConfigurationComplete(resourceName string, subaccountId string, identityProvider string, domain string, name string, description string, linkText string, availableForUserLogin bool, autoCreateShadowUsers bool, status string) string {
 	template := `
 resource "btp_subaccount_trust_configuration" "%s" {
-    subaccount_id 		= "%s"
-    identity_provider  	= "%s"
-    name     			= "%s"
-    description     	= "%s"
+    subaccount_id            = "%s"
+    identity_provider        = "%s"
+    domain                   = "%s"
+    name                     = "%s"
+    description              = "%s"
+    link_text                = "%s"
+    available_for_user_logon = %t
+    auto_create_shadow_users = %t
+    status                   = "%s"
 }`
 
-	return fmt.Sprintf(template, resourceName, subaccountId, identityProvider, name, description)
+	return fmt.Sprintf(template, resourceName, subaccountId, identityProvider, domain, name, description, linkText, availableForUserLogin, autoCreateShadowUsers, status)
 }
 
 func hclResourceSubaccountTrustConfigurationMinimum(resourceName string, subaccountId string, identityProvider string) string {

--- a/internal/provider/type_subaccount_trust_configuration.go
+++ b/internal/provider/type_subaccount_trust_configuration.go
@@ -5,32 +5,47 @@ import (
 	"github.com/SAP/terraform-provider-btp/internal/btpcli/types/xsuaa_trust"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strconv"
 )
 
 type subaccountTrustConfigurationType struct {
-	SubaccountId     types.String `tfsdk:"subaccount_id"`
-	Origin           types.String `tfsdk:"origin"`
-	Id               types.String `tfsdk:"id"`
-	Name             types.String `tfsdk:"name"`
-	Description      types.String `tfsdk:"description"`
-	Type             types.String `tfsdk:"type"`
-	IdentityProvider types.String `tfsdk:"identity_provider"`
-	Protocol         types.String `tfsdk:"protocol"`
-	Status           types.String `tfsdk:"status"`
-	ReadOnly         types.Bool   `tfsdk:"read_only"`
+	SubaccountId          types.String `tfsdk:"subaccount_id"`
+	IdentityProvider      types.String `tfsdk:"identity_provider"`
+	Domain                types.String `tfsdk:"domain"`
+	Name                  types.String `tfsdk:"name"`
+	Description           types.String `tfsdk:"description"`
+	LinkText              types.String `tfsdk:"link_text"`
+	AvailableForUserLogon types.Bool   `tfsdk:"available_for_user_logon"`
+	AutoCreateShadowUsers types.Bool   `tfsdk:"auto_create_shadow_users"`
+	Origin                types.String `tfsdk:"origin"`
+	Id                    types.String `tfsdk:"id"`
+	Type                  types.String `tfsdk:"type"`
+	Protocol              types.String `tfsdk:"protocol"`
+	Status                types.String `tfsdk:"status"`
+	ReadOnly              types.Bool   `tfsdk:"read_only"`
 }
 
 func subaccountTrustConfigurationFromValue(ctx context.Context, value xsuaa_trust.TrustConfigurationResponseObject) (subaccountTrustConfigurationType, diag.Diagnostics) {
+	availableForUserLogon, _ := strconv.ParseBool(value.AvailableForUserLogon)
+	autoCreateShadowUsers, _ := strconv.ParseBool(value.CreateShadowUsersDuringLogon)
+	domain := types.StringNull()
+	if len(value.Domain) > 0 {
+		domain = types.StringValue(value.Domain)
+	}
 	return subaccountTrustConfigurationType{
-		SubaccountId:     types.StringNull(),
-		Origin:           types.StringValue(value.OriginKey),
-		Id:               types.StringValue(value.OriginKey),
-		Name:             types.StringValue(value.Name),
-		Description:      types.StringValue(value.Description),
-		Type:             types.StringValue(value.TypeOfTrust),
-		IdentityProvider: types.StringValue(value.IdentityProvider),
-		Protocol:         types.StringValue(value.Protocol),
-		Status:           types.StringValue(value.Status),
-		ReadOnly:         types.BoolValue(value.ReadOnly),
+		SubaccountId:          types.StringNull(),
+		IdentityProvider:      types.StringValue(value.IdentityProvider),
+		Domain:                domain,
+		Name:                  types.StringValue(value.Name),
+		Description:           types.StringValue(value.Description),
+		LinkText:              types.StringValue(value.LinkTextForUserLogon),
+		AvailableForUserLogon: types.BoolValue(availableForUserLogon),
+		AutoCreateShadowUsers: types.BoolValue(autoCreateShadowUsers),
+		Origin:                types.StringValue(value.OriginKey),
+		Id:                    types.StringValue(value.OriginKey),
+		Type:                  types.StringValue(value.TypeOfTrust),
+		Protocol:              types.StringValue(value.Protocol),
+		Status:                types.StringValue(value.Status),
+		ReadOnly:              types.BoolValue(value.ReadOnly),
 	}, diag.Diagnostics{}
 }

--- a/internal/provider/type_subaccount_trust_configuration.go
+++ b/internal/provider/type_subaccount_trust_configuration.go
@@ -8,6 +8,46 @@ import (
 	"strconv"
 )
 
+type subaccountTrustConfigurationListEntryType struct {
+	IdentityProvider      types.String `tfsdk:"identity_provider"`
+	Domain                types.String `tfsdk:"domain"`
+	Name                  types.String `tfsdk:"name"`
+	Description           types.String `tfsdk:"description"`
+	LinkText              types.String `tfsdk:"link_text"`
+	AvailableForUserLogon types.Bool   `tfsdk:"available_for_user_logon"`
+	AutoCreateShadowUsers types.Bool   `tfsdk:"auto_create_shadow_users"`
+	Origin                types.String `tfsdk:"origin"`
+	Id                    types.String `tfsdk:"id"`
+	Type                  types.String `tfsdk:"type"`
+	Protocol              types.String `tfsdk:"protocol"`
+	Status                types.String `tfsdk:"status"`
+	ReadOnly              types.Bool   `tfsdk:"read_only"`
+}
+
+func subaccountTrustConfigurationFromListEntry(ctx context.Context, value xsuaa_trust.TrustConfigurationResponseObject) (subaccountTrustConfigurationListEntryType, diag.Diagnostics) {
+	availableForUserLogon, _ := strconv.ParseBool(value.AvailableForUserLogon)
+	autoCreateShadowUsers, _ := strconv.ParseBool(value.CreateShadowUsersDuringLogon)
+	domain := types.StringNull()
+	if len(value.Domain) > 0 {
+		domain = types.StringValue(value.Domain)
+	}
+	return subaccountTrustConfigurationListEntryType{
+		IdentityProvider:      types.StringValue(value.IdentityProvider),
+		Domain:                domain,
+		Name:                  types.StringValue(value.Name),
+		Description:           types.StringValue(value.Description),
+		LinkText:              types.StringValue(value.LinkTextForUserLogon),
+		AvailableForUserLogon: types.BoolValue(availableForUserLogon),
+		AutoCreateShadowUsers: types.BoolValue(autoCreateShadowUsers),
+		Origin:                types.StringValue(value.OriginKey),
+		Id:                    types.StringValue(value.OriginKey),
+		Type:                  types.StringValue(value.TypeOfTrust),
+		Protocol:              types.StringValue(value.Protocol),
+		Status:                types.StringValue(value.Status),
+		ReadOnly:              types.BoolValue(value.ReadOnly),
+	}, diag.Diagnostics{}
+}
+
 type subaccountTrustConfigurationType struct {
 	SubaccountId          types.String `tfsdk:"subaccount_id"`
 	IdentityProvider      types.String `tfsdk:"identity_provider"`
@@ -33,7 +73,7 @@ func subaccountTrustConfigurationFromValue(ctx context.Context, value xsuaa_trus
 		domain = types.StringValue(value.Domain)
 	}
 	return subaccountTrustConfigurationType{
-		SubaccountId:          types.StringNull(),
+		SubaccountId:          types.StringUnknown(),
 		IdentityProvider:      types.StringValue(value.IdentityProvider),
 		Domain:                domain,
 		Name:                  types.StringValue(value.Name),

--- a/internal/tfutils/tfutils.go
+++ b/internal/tfutils/tfutils.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"reflect"
 	"strings"
-  "time"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -49,6 +49,8 @@ func ToBTPCLIParamsMap(a any) (map[string]string, error) {
 			setBool(field, tagValue, out)
 		case "basetypes.BoolValue":
 			setBoolValue(field, tagValue, out)
+		case "*bool":
+			setBoolPointer(field, tagValue, out)
 		case "map[string][]string": // TODO would be nice to have `encodethisasjson` tag, instead of an explicit type mapping
 			if !field.IsNil() {
 				valueArr, err := json.Marshal(field.Interface())
@@ -128,6 +130,13 @@ func setBool(field reflect.Value, tagValue string, out map[string]string) {
 	out[tagValue] = fmt.Sprintf("%v", fieldVal)
 }
 
+func setBoolPointer(field reflect.Value, tagValue string, out map[string]string) {
+	if !field.IsNil() {
+		fieldVal := field.Elem().Interface().(bool)
+		out[tagValue] = fmt.Sprintf("%v", fieldVal)
+
+	}
+}
 func setStringSlice(field reflect.Value, tagValue string, out map[string]string) {
 	if !field.IsNil() {
 		valueString := fmt.Sprintf("%v", strings.Join(field.Interface().([]string), ","))


### PR DESCRIPTION
## Purpose
- add update operation to btp_subaccount_trust_configuration (covers the subaccount part of issue #372)
- add defaults to optional computed attributes which need to be updated when removed from the resource configuration
- make 'origin' computable (and no longer optional) since it cannot be set for subaccounts, resolves #392

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [ ] Possible follow-up items are created and linked.
