### PR TITLE
fix: sonar cloud code smell - error message header

### DIFF
--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -202,6 +202,8 @@ func (rs *directoryResource) Read(ctx context.Context, req resource.ReadRequest,
 }
 
 func (rs *directoryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	const createErrorHeader = "API Error Creating Resource Directory"
+
 	var plan directoryType
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -242,7 +244,7 @@ func (rs *directoryResource) Create(ctx context.Context, req resource.CreateRequ
 
 	cliRes, _, err := rs.cli.Accounts.Directory.Create(ctx, &args)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Creating Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(createErrorHeader, fmt.Sprintf("%s", err))
 		return
 	}
 
@@ -268,7 +270,7 @@ func (rs *directoryResource) Create(ctx context.Context, req resource.CreateRequ
 
 	updatedRes, err := createStateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Creating Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(createErrorHeader, fmt.Sprintf("%s", err))
 	}
 
 	plan, diags = directoryValueFrom(ctx, updatedRes.(cis.DirectoryResponseObject))
@@ -279,6 +281,8 @@ func (rs *directoryResource) Create(ctx context.Context, req resource.CreateRequ
 }
 
 func (rs *directoryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	const updateErrorHeader = "API Error Updating Resource Directory"
+
 	var plan directoryType
 	var state directoryType
 
@@ -322,13 +326,13 @@ func (rs *directoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	state.Features.ElementsAs(ctx, &stateFeatures, false)
 
 	if strings.Join(planFeatures, ",") != strings.Join(stateFeatures, ",") {
-		resp.Diagnostics.AddError("API Error Updating Resource Directory", "Update of Directory Features is not supported")
+		resp.Diagnostics.AddError(updateErrorHeader, "Update of Directory Features is not supported")
 		return
 	}
 
 	cliRes, _, err := rs.cli.Accounts.Directory.Update(ctx, &args)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Updating Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(updateErrorHeader, fmt.Sprintf("%s", err))
 		return
 	}
 
@@ -354,7 +358,7 @@ func (rs *directoryResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	updatedRes, err := updateStateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Updating Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(updateErrorHeader, fmt.Sprintf("%s", err))
 	}
 
 	plan, diags = directoryValueFrom(ctx, updatedRes.(cis.DirectoryResponseObject))
@@ -365,6 +369,8 @@ func (rs *directoryResource) Update(ctx context.Context, req resource.UpdateRequ
 }
 
 func (rs *directoryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	const deleteErrorHeader = "API Error Deleting Resource Directory"
+
 	var state directoryType
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -374,7 +380,7 @@ func (rs *directoryResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	cliRes, _, err := rs.cli.Accounts.Directory.Delete(ctx, state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Deleting Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(deleteErrorHeader, fmt.Sprintf("%s", err))
 		return
 	}
 
@@ -407,7 +413,7 @@ func (rs *directoryResource) Delete(ctx context.Context, req resource.DeleteRequ
 	_, err = deleteStateConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Deleting Resource Directory", fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(deleteErrorHeader, fmt.Sprintf("%s", err))
 		return
 	}
 }


### PR DESCRIPTION
## Purpose

* This PR fixes a Sonar Cloud code smell concerning duplication of identical strings used in error messages.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Sonar Cloud Code Smell
```

## How to Test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
