### PR TITLE
fix: remove "computed" as attribute for labels on subaccount and directory

### DIFF
--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -128,7 +128,6 @@ __Further documentation:__
 				},
 				MarkdownDescription: "Contains information about the labels assigned to a specified global account. Labels are represented in a JSON array of key-value pairs; each key has up to 10 corresponding values.",
 				Optional:            true,
-				Computed:            true,
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"

--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -128,9 +128,6 @@ __Further documentation:__
 				},
 				MarkdownDescription: "Contains information about the labels assigned to a specified global account. Labels are represented in a JSON array of key-value pairs; each key has up to 10 corresponding values.",
 				Optional:            true,
-				PlanModifiers: []planmodifier.Map{
-					mapplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the directory.",

--- a/internal/provider/resource_directory_test.go
+++ b/internal/provider/resource_directory_test.go
@@ -114,7 +114,7 @@ func TestResourceDirectory(t *testing.T) {
 				},
 				{
 					// Update name wo change of usage but omit optional parameters
-					Config: hclProviderFor(user) + hclResourceDirectory("uut", "my-new-directory", "This is a updated directory"),
+					Config: hclProviderFor(user) + hclResourceDirectoryAll("uut", "my-new-directory", "This is a updated directory"),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestMatchResourceAttr("btp_directory.uut", "id", regexpValidUUID),
 						resource.TestMatchResourceAttr("btp_directory.uut", "created_date", regexpValidRFC3999Format),

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -95,6 +95,7 @@ __Further documentation:__
 			},
 			"parent_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.",
+				Computed:            true,
 				Optional:            true,
 				Validators: []validator.String{
 					uuidvalidator.ValidUUID(),
@@ -109,7 +110,6 @@ __Further documentation:__
 					ElemType: types.StringType,
 				},
 				MarkdownDescription: "The set of words or phrases assigned to the subaccount.",
-				Computed:            true,
 				Optional:            true,
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.UseStateForUnknown(),

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -111,9 +111,6 @@ __Further documentation:__
 				},
 				MarkdownDescription: "The set of words or phrases assigned to the subaccount.",
 				Optional:            true,
-				PlanModifiers: []planmodifier.Map{
-					mapplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"beta_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Shows whether the subaccount can use beta services and applications.",

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -96,7 +96,6 @@ __Further documentation:__
 			"parent_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.",
 				Optional:            true,
-				Computed:            true,
 				Validators: []validator.String{
 					uuidvalidator.ValidUUID(),
 				},

--- a/internal/provider/resource_subaccount_test.go
+++ b/internal/provider/resource_subaccount_test.go
@@ -183,7 +183,7 @@ func TestResourceSubaccount(t *testing.T) {
 				},
 				{
 					// Update name wo change of usage but omit optional parameters
-					Config: hclProviderFor(user) + hclResourceSubaccount("uut", "Integration Test Acc Dyn", "eu12", "integration-test-acc-dyn"),
+					Config: hclProviderFor(user) + hclResourceSubaccountAll("uut", "Integration Test Acc Dyn", "eu12", "integration-test-acc-dyn", "My subaccount description", "NOT_USED_FOR_PRODUCTION", true),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestMatchResourceAttr("btp_subaccount.uut", "id", regexpValidUUID),
 						resource.TestCheckResourceAttr("btp_subaccount.uut", "name", "Integration Test Acc Dyn"),


### PR DESCRIPTION
## Purpose

* This PR removes the `computed`attribute from the labels of the resources `directory` and `subaccount`
* Due to this change the planmodifier can be removed as it has no impact which corresponds to the [documentation](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v1.4.1/resource/schema/mapplanmodifier#UseStateForUnknown). Consequently, two tests needed adjustements 
* Closes #467

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
