### PR TITLE
chore: remove version pinning of TF CLI in devcontainer

### DIFF
--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -3,9 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/go:1.21-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/terraform:1": {
-			"version": "1.5.7"
-		},
+		"ghcr.io/devcontainers/features/terraform:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {

--- a/.devcontainer/withenvfile/devcontainer.json
+++ b/.devcontainer/withenvfile/devcontainer.json
@@ -3,9 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/go:1.21-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/terraform:1": {
-			"version": "1.5.7"
-		},
+		"ghcr.io/devcontainers/features/terraform:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {


### PR DESCRIPTION
## Purpose

* Set TF CLI version in devcontainer back to latest
* closes #479

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: dev setup
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
