### PR TITLE
fix: remove unused code for logout

### DIFF
--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -280,21 +280,6 @@ func (v2 *v2Client) PasscodeLogin(ctx context.Context, loginReq *PasscodeLoginRe
 	})
 }
 
-// Logout invalidates the current user session
-func (v2 *v2Client) Logout(ctx context.Context, logoutReq *LogoutRequest) (*LogoutResponse, error) {
-	ctx = v2.initTrace(ctx)
-
-	res, err := v2.doPostRequest(ctx, path.Join("logout", cliTargetProtocolVersion), logoutReq)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &LogoutResponse{}, v2.parseResponse(ctx, res, nil, http.StatusOK, map[int]string{
-		http.StatusGatewayTimeout: "Logout timed out. Please try again later.",
-	})
-}
-
 // Execute executes a command
 func (v2 *v2Client) Execute(ctx context.Context, cmdReq *CommandRequest, options ...CommandOptions) (cmdRes CommandResponse, err error) {
 	ctx = v2.initTrace(ctx)

--- a/internal/btpcli/client_test.go
+++ b/internal/btpcli/client_test.go
@@ -355,54 +355,6 @@ func TestV2Client_PasscodeLogin(t *testing.T) {
 	})
 }
 
-func TestV2Client_Logout(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		description string
-
-		logoutRequest *LogoutRequest
-		simulation    v2SimulationConfig
-	}{
-		{
-			description:   "happy path",
-			logoutRequest: NewLogoutRequest("subdomain"),
-			simulation: v2SimulationConfig{
-				srvExpectBody:   `{"customIdp":"","subdomain":"subdomain","refreshToken":""}`,
-				srvReturnStatus: http.StatusOK,
-				expectResponse:  &LogoutResponse{},
-			},
-		},
-		{
-			description:   "error path - login request times out [504]]",
-			logoutRequest: NewLogoutRequest("subdomain"),
-			simulation: v2SimulationConfig{
-				srvReturnStatus: http.StatusGatewayTimeout,
-				expectErrorMsg:  "Logout timed out. Please try again later. [Status: 504; Correlation ID: fake-correlation-id]",
-			},
-		},
-		{
-			description:   "error path - unexpected error",
-			logoutRequest: NewLogoutRequest("subdomain"),
-			simulation: v2SimulationConfig{
-				srvReturnStatus: http.StatusTeapot,
-				expectErrorMsg:  "received response with unexpected status [Status: 418; Correlation ID: fake-correlation-id]",
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			test.simulation.srvExpectPath = path.Join("/logout", cliTargetProtocolVersion)
-			test.simulation.callFunctionUnderTest = func(ctx context.Context, uut *v2Client) (any, error) {
-				return uut.Logout(ctx, test.logoutRequest)
-			}
-
-			simulateV2Call(t, test.simulation)
-		})
-	}
-}
-
 func TestV2Client_Execute(t *testing.T) {
 	t.Run("every request must have a unique correlation ID", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/btpcli/clienttypes.go
+++ b/internal/btpcli/clienttypes.go
@@ -55,28 +55,6 @@ type LoginResponse struct {
 	Issuer   string `json:"issuer"`
 }
 
-/* Logout */
-
-func NewLogoutRequest(globalaccountSubdomain string) *LogoutRequest {
-	return NewLogoutRequestWithCustomIDP("", globalaccountSubdomain)
-}
-
-func NewLogoutRequestWithCustomIDP(idp string, globalaccountSubdomain string) *LogoutRequest {
-	return &LogoutRequest{
-		IdentityProvider:       idp,
-		GlobalAccountSubdomain: globalaccountSubdomain,
-	}
-}
-
-type LogoutRequest struct {
-	IdentityProvider       string `json:"customIdp"`
-	GlobalAccountSubdomain string `json:"subdomain"`
-	RefreshToken           string `json:"refreshToken"`
-}
-
-type LogoutResponse struct {
-}
-
 /* Command */
 func NewCommandRequest(action Action, command string, args any) *CommandRequest {
 	return &CommandRequest{

--- a/internal/btpcli/clienttypes_test.go
+++ b/internal/btpcli/clienttypes_test.go
@@ -36,32 +36,3 @@ func TestLoginRequest(t *testing.T) {
 		}
 	})
 }
-
-func TestLogoutRequest(t *testing.T) {
-	t.Run("NewLogoutRequest(...) doesn't set default idp", func(t *testing.T) {
-		uut := NewLogoutRequest("")
-		assert.Empty(t, uut.IdentityProvider)
-		assert.Empty(t, uut.GlobalAccountSubdomain)
-		assert.Empty(t, uut.RefreshToken)
-	})
-	t.Run("NewLogoutRequest(...) uses all given values", func(t *testing.T) {
-		uut := NewLogoutRequest("my-subdomain")
-		assert.Empty(t, uut.IdentityProvider)
-		assert.Equal(t, "my-subdomain", uut.GlobalAccountSubdomain)
-		assert.Empty(t, uut.RefreshToken)
-	})
-	t.Run("NewLogoutRequestWithCustomIDP(...) respects custom idp", func(t *testing.T) {
-		uut := NewLogoutRequestWithCustomIDP("my-idp", "")
-		assert.Equal(t, "my-idp", uut.IdentityProvider)
-	})
-	t.Run("LogoutRequest can be marshalled", func(t *testing.T) {
-		uut := NewLogoutRequestWithCustomIDP("my-idp", "my-subdomain")
-		uut.RefreshToken = "a-refresh-token"
-
-		b, err := json.Marshal(uut)
-
-		if assert.NoError(t, err) {
-			assert.Equal(t, `{"customIdp":"my-idp","subdomain":"my-subdomain","refreshToken":"a-refresh-token"}`, string(b))
-		}
-	})
-}


### PR DESCRIPTION
## Purpose

* Remove unused code for client logout
* closes #490 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```
## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
