### PR TITLE
feat: switch to new cli server urls

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ provider "btp" {
 
 ### Optional
 
-- `cli_server_url` (String) The URL of the BTP CLI server (e.g. `https://cpcli.cf.eu10.hana.ondemand.com`).
+- `cli_server_url` (String) The URL of the BTP CLI server (e.g. `https://cli.btp.cloud.sap`).
 - `idp` (String) The identity provider to be used for authentication (default: SAP ID service with origin `sap.default`).
 - `idp_url` (String) The URL of the identity provider to be used for authentication (only required for x509 auth).
 - `idtoken` (String, Sensitive) A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable. (SAP-internal usage only)

--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -15,7 +15,7 @@ import (
 	uuid "github.com/hashicorp/go-uuid"
 )
 
-const DefaultServerURL string = "https://cpcli.cf.eu10.hana.ondemand.com"
+const DefaultServerURL string = "https://cli.btp.cloud.sap"
 
 func NewV2Client(serverURL *url.URL) *v2Client {
 	return NewV2ClientWithHttpClient(http.DefaultClient, serverURL)

--- a/internal/provider/fixtures/datasource_directory.yaml
+++ b/internal/provider/fixtures/datasource_directory.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 1bd80dcc-ae7b-a603-f3d3-add4eb5d1c7d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - e1282ae6-c5a7-3a80-2a10-de2e10f8f8a6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 48f8ce1c-d90c-f27c-c2c8-241f80ba4474
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 877c9976-5a95-fd19-494c-620117ca03b9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - f40f32cd-0810-60a0-a03b-5a4e1844caa4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 016a04e4-32ba-bbc9-9803-24c98cc7d35b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -764,7 +764,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -813,7 +813,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - 8d53a5f6-d3ab-c56c-8b32-39139acb5031
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -898,7 +898,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -947,7 +947,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -962,7 +962,7 @@ interactions:
                 - cb8a093e-2105-e14c-7542-2c67ac596412
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1011,7 +1011,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1032,7 +1032,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1081,7 +1081,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - b424938f-9bb5-a993-968a-1fbde678317c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1166,7 +1166,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1215,7 +1215,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1230,7 +1230,7 @@ interactions:
                 - 3de4f314-bb36-7add-be23-4ac267165b63
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1279,7 +1279,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1300,7 +1300,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1349,7 +1349,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1364,7 +1364,7 @@ interactions:
                 - f6298b11-8c93-0834-251a-19c59ec8bacd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_entitlements.yaml
+++ b/internal/provider/fixtures/datasource_directory_entitlements.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 56d00848-47ab-574d-d7cf-fe1eac04edec
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 5c710f38-6cfc-d59b-f6c6-93b1e67451bc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 17b38642-cfc6-6fe9-d4ee-03bed54fc244
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 492e729c-0493-88dc-b4b4-6269c01fd52b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 0e91acad-d5e0-ed52-4742-1d194e77c998
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 0effd624-a2e2-3e42-7892-2ea95b916fa0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_labels.yaml
+++ b/internal/provider/fixtures/datasource_directory_labels.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 9ec271e7-13a2-1cc6-87d1-59f27eac5884
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 0877507c-3ba8-19cb-6411-e5a9a782abef
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 864858b0-ff19-0077-cc64-7987df9d0aa6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 76d4f50d-5208-0139-c403-03902f469487
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 9e5d3364-1955-2a16-8b92-32aa4b1b46ac
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 05f07b56-4a76-0299-44a1-89d6becb9a65
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_role.not_security_enabled.yaml
+++ b/internal/provider/fixtures/datasource_directory_role.not_security_enabled.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c619418c-29b7-1e04-98b1-f5c4f959ea1a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_role.yaml
+++ b/internal/provider/fixtures/datasource_directory_role.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d08d6bc2-34b9-790d-3661-7a625ab4a341
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 844142f1-6939-6db9-7eb5-46a15d620089
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 6a66ad8a-ff52-7f8b-491c-3c0bab6efea7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 51c0766a-3f75-8a89-b0f3-1ff47777c435
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - e54df741-028a-766d-7136-019beceac495
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - d1be4a03-8c59-8031-703d-91cb5a354459
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_role_collection.not_security_enabled.yaml
+++ b/internal/provider/fixtures/datasource_directory_role_collection.not_security_enabled.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 89d6d2b7-cb07-74b3-736b-ee870c2f8e94
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_role_collection.yaml
+++ b/internal/provider/fixtures/datasource_directory_role_collection.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 4fa9ebc5-410b-246b-8937-fbdf1add5fc0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - efd7b00b-7761-aedd-5e00-df4f73ab0c56
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - ee2e2a50-b836-8334-8ee0-87f361ea2568
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - c7638b33-3534-b908-a473-d9c8e84337a1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 41f90b0d-abf4-8a70-4e89-e980fe58844d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - f72fac7d-c0b1-fe0f-8e72-1f6bccb45b5e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_role_collections.not_security_enabled.yaml
+++ b/internal/provider/fixtures/datasource_directory_role_collections.not_security_enabled.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ac540772-2f74-5d5c-8e4c-dc0e9f70f814
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_role_collections.yaml
+++ b/internal/provider/fixtures/datasource_directory_role_collections.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 963702e3-e552-a4cb-928f-e0e996ff3c92
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - f8f03d1b-8258-fadd-1040-62f36a290e5f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 80a28fc1-3d06-c95d-e697-c550eaa8b557
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 3448af74-f1cf-31df-af13-4786edd0ab45
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 9506d4c2-206c-0e46-62cc-f5080479fcb4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 01878c3c-1380-2509-7295-1b74d967a650
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_roles.not_security_enabled.yaml
+++ b/internal/provider/fixtures/datasource_directory_roles.not_security_enabled.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 38bdb723-19dd-2da2-a5df-7f8b6f37f59b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_roles.yaml
+++ b/internal/provider/fixtures/datasource_directory_roles.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 640a05de-25c8-b690-0c7a-581a08949842
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 9198bf49-be71-146f-81e6-d4d35dc93277
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 1181fbe7-d420-0522-7547-a0144c001b3f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - b4340d10-c1b4-8ec8-0bfc-0367f350bf71
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 822de078-48a5-27ec-50ac-b9da4fdca65c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - a57405d5-c5d6-b589-a52c-8841838a82aa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_user.custom_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_user.custom_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b74812d4-7a0d-f86a-3a1a-b5fad1799d24
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 134
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 085ba2ff-81cf-da35-9732-03f00c08e1a1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 134
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 17a60cfb-3b2f-577c-7094-207353fe2843
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 134
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 9272079e-ec7a-5401-0b53-09ac2216188c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 134
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - d49d52d3-669a-14cc-9151-4054d53ecb09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 134
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - dfdfe5d7-a735-77a9-e95e-1e892fa15579
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_user.default_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_user.default_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 7b56ff08-cc16-cea3-fd66-1c326e2a6606
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - ee73ab99-9b78-c6ac-b0fb-b01ac1dfd6a3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - e6da1b98-0f28-7b32-81a8-5c667457be96
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 55e2f804-f903-87e3-199b-643797e52f43
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 8b87aa8e-4ad5-b44c-4955-d0a9e887ac8a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - e1a8acc7-8ed2-360f-506c-6dcd7747f955
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_users.custom_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_users.custom_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 842d317b-dbdd-6493-5d00-f5a321b43f2b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 102
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 733d794f-9add-855f-b71f-3b5630270224
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 102
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - cda76349-a1ac-b757-c6f8-448ed839db2f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 102
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - df0e5c54-4fcf-44d7-646e-005742a595c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 102
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - ff6f7403-295d-1792-d9db-f7753ffb834e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 102
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - fa4316bc-49e8-101e-a908-1d52842a4245
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_users.default_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_users.default_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - beea47c7-bcc9-b0fa-92ba-9c48a43ffc5d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 7957c5fb-7531-149f-fdaa-3565ab317935
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 7d3c9d4c-284a-5796-9374-7217c044bcba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - bf47139c-b8c2-c61e-0b98-59bc1a288283
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 096a3d19-04f5-89c6-fb0f-6d8e510a06ac
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 528bc9fc-ebe4-e4aa-34ae-ea70e4cc54d4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_directory_users.non_existing_idp.yaml
+++ b/internal/provider/fixtures/datasource_directory_users.non_existing_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c279e44f-051f-e640-3b08-39ed1cf1cb1f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 98
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c9d53110-e8b1-b34b-e504-4644747ff0cf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/global-account?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/global-account?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 51332b04-66dc-fc21-e7f9-8a69f4f782fc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/global-account?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/global-account?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - f705e8fe-7343-d5c1-0659-cd1febfc7a16
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/global-account?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/global-account?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - a8e4128a-6d08-9a5b-871c-c6ad335a85a6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/global-account?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/global-account?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 7391278d-5fed-ef9a-8027-225d45a8e093
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/global-account?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/global-account?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - f242d472-2962-167c-1d18-b068fa3849c0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_entitlements.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_entitlements.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 99331c83-63f7-95b9-e819-3900fd5c177e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - bfe1c488-b9ec-4b3a-746b-2af51b62edfd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 3965ed09-7fc3-e082-e459-bcfda2b41d2d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 4cecce5e-292f-edff-c0f4-149dcaf24e5f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 9a8da107-9d4a-3122-d734-e6492686fa17
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 091fac78-1fa1-86a8-e585-cd7c909ae74a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_resource_provider.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_resource_provider.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b9c393a6-7b9a-36e2-6066-8111e77641e7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - f873ce8a-8935-d762-4581-a0ca6cfd212a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - c845c46b-332d-0b6c-13ac-9828eb76f5a5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 3224697c-7a2d-ffef-8ead-a95564064a44
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 3de54e96-f3ed-61c7-c7e2-84b65b1770c8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - fc20c88f-d4fe-9289-9ce5-8ff7d0eb8ed9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_resource_providers.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_resource_providers.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ec53898a-6b6e-68c5-430a-1561759528b9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 5d353859-a670-3772-7816-cf7a6fbfc31e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 03ab8c13-8b28-503e-e058-9ddbe064d6f1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - f410ace9-b8de-e308-5fcb-bbd9c3a93570
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - c462507c-c4a3-84bb-6f57-fdaf9a70dca3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 0bb90e0a-3d05-7dab-dc66-908ec6c91652
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_role.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_role.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 57f30ccb-8419-99e4-5a26-34af33ac3d60
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 158
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 8a3136a2-cdb1-5a5c-e856-897b4bc7fb36
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 158
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 6b71397d-9762-cc3c-6bd6-1c4836e595d5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 158
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 1e164b36-1517-f630-988d-7f55cf5973f1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 158
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - f9568169-5b92-7f03-c08e-5160f8be2320
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 158
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - ecd6f620-711f-8a55-dcb0-acfd7028d415
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_role_collection.role_collection_exists.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_role_collection.role_collection_exists.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - df62c62f-bfdf-b428-a31f-e76a3ecc995f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 107
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 1e8438ac-86d6-07c6-f8fe-7af18656c95e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 107
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 3cbe30c5-08b1-2847-2e2b-8cf7c80786df
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 107
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - df21a893-dd67-d610-f342-04447c4ddbed
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 107
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - ca51f060-b778-b5e6-45d5-1bdd22658237
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 107
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 89493a91-ced9-0952-670a-ba4aa158f39b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_role_collection.role_collection_not_available.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_role_collection.role_collection_not_available.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c3dd115d-59a6-5864-3a12-3182db0f28d5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 82
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_role_collections.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_role_collections.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - f6a4186e-f917-1714-ef63-1908f0b6a20e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - f216ef98-316a-d442-cb52-c18ba8005eb3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 8d21adc0-f6ef-c042-a176-bef5a5c7134b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 77e60fe2-0614-e043-a89b-c46608b9b67d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 196381d4-643b-e6ae-7e24-832fd88dee65
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 39d1fc33-c28e-cdec-b132-2e5a57e88f11
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_roles.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_roles.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 65610950-aa23-190f-cc98-4001c1076ca8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 6788fb32-e4cc-1d95-7f12-cec795b6ca4b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - d92060a6-0f1b-f652-8cc4-8a7aa26e0951
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 2fb17574-c21a-1260-9324-7cb6b5e201b3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - d8d43181-6474-9aac-09ba-42db72e09911
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 53305093-cdd7-0b52-3002-5adf614494fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_trust_configuration.custom_idp_exists.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_trust_configuration.custom_idp_exists.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d05986a7-df9b-813a-6f8a-0f9e68d7fabd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 701db19c-7760-fd65-4e8b-a9a45adb628d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - a2200b5b-1b6b-bef1-969e-baaa3f19133b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 4e11b394-4a4e-e0c6-f27b-9a4401f7c4af
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - d07ffb4b-6de6-8abb-4d9b-e72148854dcc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - b2247bcb-93e2-33ce-e73f-16828e461546
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_trust_configuration.custom_idp_not_existing.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_trust_configuration.custom_idp_not_existing.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e8961cd2-3952-552c-3229-5eed2ebbbde2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_trust_configuration.default.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_trust_configuration.default.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b62ccc53-9da0-e4d9-a73d-206fd25b7380
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 78
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - bc50b36d-4a39-0eb3-ce2d-3341405daafd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 78
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - d9082d7f-e3a8-34a3-8eeb-af1e61444166
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 78
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 56c002ef-49aa-0466-d9f3-a056d767ffa5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 78
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 3fc681d5-719e-cf1f-e71b-541c9f1d7215
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 78
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 98f83568-32a3-4213-4c15-5870d14238a6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_trust_configurations.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_trust_configurations.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d737a846-acbb-f99c-a03b-83f13a811549
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - b55d0fec-cc6d-1bb8-29dc-feb020c24f84
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - f91a20e9-3861-0232-25a7-d9b2460142cf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - a60dc628-30e3-2935-7e7a-ab408e4b85f4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 860de3af-0b5b-8ae6-6f34-2a855cb18a13
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 849e8460-55bd-e826-e2e9-e0224773ee80
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_user.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_user.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e7c0faae-1bac-ce75-1982-39ebcdba29c8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 110
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 3fbe92ed-4065-af42-95ad-1ef583b630a0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 110
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 0714af40-e99c-972f-229f-d9846c4a66e5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 110
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 744a5437-a4e3-c2e6-a9ce-c3c0f34301fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 110
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 50127c7b-c229-252e-1bd3-591edd91d91e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 110
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 7bb4efc8-f8bf-aab3-bdde-671c5b334a74
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_users.custom_idp.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_users.custom_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 373f36de-9d53-46ca-dda8-a923fa662ee7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 4f971e4e-aefe-96bc-f566-fffd4a08ffe5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 68d830cc-6782-8b1d-ab48-e27d4ca71b70
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - f193c9e5-c10d-ca8e-1354-d332527bab97
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - a5ade3ce-479e-92a5-f4b1-4ee4ba7d9fc9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 88
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 6685fc26-4007-d026-c086-e6f7bd5d2e10
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_globalaccount_users.default_idp.yaml
+++ b/internal/provider/fixtures/datasource_globalaccount_users.default_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 5772f9c2-9e5d-2891-df2e-4bd32df13dbd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 71
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 549562f3-bd90-8dac-8d94-196a2438974a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 71
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 67c536f4-5be6-3343-b2ef-85607c818841
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 71
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 6cdc1e18-f9e7-2a5a-8a7b-423b01d9d518
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 71
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - e0e89d87-fa3b-757d-83dc-df31998cc73a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 71
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 3cebe00c-7ad0-7329-5e8e-ae12903ad039
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_regions.yaml
+++ b/internal/provider/fixtures/datasource_regions.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 01815745-fbe9-48ab-6a31-4db42d2327a4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-region?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-region?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - df27787a-cc92-872c-f921-c8dcdc497be6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-region?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-region?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 6291fdf4-a054-f23a-f30c-c06d3df88b2e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-region?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-region?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 7bb1e68b-ddca-9f42-7585-9156d3220936
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-region?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-region?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 238fb72a-5c0c-955f-4b19-ddf1660923f2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-region?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-region?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - eaf17c99-04e1-84c3-81dc-64a19a86e20e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount.err_subaccount_doesnt_exist.yaml
+++ b/internal/provider/fixtures/datasource_subaccount.err_subaccount_doesnt_exist.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b71750c7-497b-de20-889e-3dc747ffa618
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount.yaml
+++ b/internal/provider/fixtures/datasource_subaccount.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 6605445e-5314-62ae-0fa8-3facf2692942
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - 56eb564b-3cce-3962-ae37-13a9760c9afb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - 98339f93-1db8-4af7-9546-7827f4e8a2e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 0415bd86-4845-4577-a437-7f0320dc1ef9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 8729b375-f572-b65e-3012-71b7a09cc733
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 69fd0760-0ef8-feed-4f01-92e91ae2f648
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_app.by_id.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_app.by_id.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 16986ec9-db50-3e9f-2941-cbc7263830fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - c236c68c-117f-cd49-4272-3563df0c099e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - df8fb11d-b11a-e1ba-dee4-22201051fcdd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 45390b9c-d5de-3832-14c4-59aeccc1d92f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - a05f2545-0cac-db06-a7be-19d2211d2648
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - ed97bea3-7428-0645-e675-2d2dd889192b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_apps.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_apps.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d938b6da-31a4-ed47-7e2d-887710c1d149
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 7270b3b7-195c-b4aa-43de-9a8a24fd571d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 225a6362-53a3-e451-e747-beea5cd86b81
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 83bfa156-3b59-acd1-a8eb-34ca610d49e8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - d4510d11-d3ee-1f86-9201-72725f8f5385
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/app?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/app?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 93e1b717-4820-fc45-fb68-11b012fb1b24
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_entitlements.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_entitlements.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - f29b906b-0150-74ec-d693-0b9af99f3bef
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -164,7 +164,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -213,7 +213,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -234,7 +234,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -298,7 +298,7 @@ interactions:
                 - ed7521cb-6535-b904-0234-fde1d45fab29
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -347,7 +347,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -368,7 +368,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -417,7 +417,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -438,7 +438,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -487,7 +487,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -508,7 +508,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -557,7 +557,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -572,7 +572,7 @@ interactions:
                 - 22e9fccb-55b2-c4d6-fd66-d098cc0a19e2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -621,7 +621,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -642,7 +642,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -691,7 +691,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -712,7 +712,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -761,7 +761,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -782,7 +782,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -831,7 +831,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -846,7 +846,7 @@ interactions:
                 - e63b58b3-2fe7-5df9-af7f-f05537ca4263
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -895,7 +895,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -986,7 +986,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1035,7 +1035,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1056,7 +1056,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1105,7 +1105,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1120,7 +1120,7 @@ interactions:
                 - 93e161e8-719a-d460-176d-f00ce9862f17
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1169,7 +1169,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1190,7 +1190,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1239,7 +1239,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1260,7 +1260,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1309,7 +1309,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1330,7 +1330,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1379,7 +1379,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1394,7 +1394,7 @@ interactions:
                 - b690611b-95d3-769a-d5f5-1454af88c84c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_environment_instances.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_environment_instances.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c743adac-e54f-47a8-8d22-1c4a0de2180b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 46f5e11b-5c97-594a-7401-ab084a1821f9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 2f4e3ccc-58b6-db03-88c9-3b0a45fe5752
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - fc74fb26-5b58-e2c7-9359-1c39a287bc59
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - c5121739-d65a-df8c-4234-b6ad426a52d7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - ebd4b24d-fe5e-28dc-f55d-7b72903e51ff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_environments.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_environments.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 2a84ae85-40ad-c9da-f8fb-78b8a21efe68
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 80560b92-1d1b-adcd-710d-5a62bd0daffb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 45c7d0ca-11ee-12a7-0256-db6434f71fc0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 1df9769e-503b-9880-06c3-afd0eb915990
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - eb7779d1-8ed2-86f1-4843-196d25cc29aa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/available-environment?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/available-environment?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 89b64634-f654-a66b-b3fe-3d5a13bff750
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_labels.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_labels.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 3ca1fd91-631b-47dd-9a83-e4bdf378e6d4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - dcbd8ee0-22b9-ce10-1511-4705047af76b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - caa7037a-4b98-d6fa-e8e1-ea53128c89ac
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 1b97d5b5-9cb8-7dab-e531-a3b83a28eb98
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - cfe0b255-1e21-b7f3-3d5d-b09981ff15f5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/label?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/label?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 1ff42618-9170-0571-7185-a53871278a76
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_role.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_role.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d3294707-9f62-1b73-d9f2-51d4b6765253
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 63b8620f-a9bb-fe99-b9f4-dddb058074a2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 362a8a88-5193-6436-3239-2f966cb53fd3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - f3fe2a82-71e0-df82-d492-7ff313377290
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - e1b3afc3-1e8f-5b2d-9633-f683cfbe03cf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 163
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - ea0e312e-3154-1a53-da54-f7f2f4b55e22
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_role_collection.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_role_collection.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 2b20f089-9715-a623-7b55-1f7465feb012
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 9c3eeb9b-0566-99ab-31a1-91ce4a776df8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - d71b47e2-ca72-edc6-ef53-977718b0f5f6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - ff3a3cd7-595d-beee-d58f-2cba307ecf23
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 3fb60fd1-71ec-d5b1-d227-502209bbcad7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 5e1094a6-4bd7-1873-947b-76b5a344efb1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_role_collections.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_role_collections.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 5723a195-699f-ed97-37c8-cf070a6025ee
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 5c50cf9d-8dbe-1af1-dd7f-ee318525a013
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 14a77f4b-bc78-8022-c374-7e84baa0fb9c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 6fbc9777-6ff0-abc6-e5dd-7ea47b14fdf9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 977d38e0-c068-c68e-768d-64e61f4544e9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 5852ce6f-f3d3-f245-0e97-b00b9ff5f28b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_roles.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_roles.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 7a76c1f4-b9b2-563d-3d6c-e8029aeddcd7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 4d15ce8a-4433-0589-93dc-1a30e1ccc6e7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 0aa59655-011d-f44c-0807-67bbe32daac7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 25645c80-b64b-99cb-e245-8ae26c5a2c4c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 46248bb6-6717-f7ed-791e-22d335d321e6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 55168b1a-b32d-6221-43fe-93d36a1d9840
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_binding.by_id.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_binding.by_id.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 0f5b8703-e3af-c98e-2560-af8811ae63cc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - bbebc4e3-a7dc-3e71-7d02-0f0125dc4f93
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 3da9d914-45fe-d179-c1f0-b5b11bac066e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 3f0739d8-59d1-9dc7-e9c0-0cdbd6ac26a8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 2f10b3a7-d732-5905-20f2-6a402e57b699
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 35524e49-e375-2ff5-8c34-d34511e89018
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_binding.by_name.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_binding.by_name.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - a919ef23-1aac-edaf-4424-82f65bf29e55
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 1ef96bac-3837-2080-aa82-23c185cc27f7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 7f19bc07-0751-fe7e-4b42-622253b17171
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 83e952b5-df9e-034b-6d4c-09f0e3e201b2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 6455ef7b-9648-caec-cb21-2cf3108a2e42
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 836f867f-d445-f0e0-58e6-c9a4f4386a53
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_bindings.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_bindings.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e8986b24-0556-ee5b-714b-8ce3750e1dcc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 44ecd420-d60b-feea-fdcc-eb5932034425
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 95d9ffa8-03c6-5112-9db1-cca85bec5688
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 63bc5b69-fdb4-1135-370d-849746a3c69c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 759f339d-e55f-93eb-cb57-731eaa1c76f5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 451e959c-13c9-cbc0-a205-8e6a48236f54
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_instance.by_id.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_instance.by_id.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 139e8fea-051b-445d-28da-07bc5ac5ab61
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 0275ce83-3369-ac6e-e197-dcf00c8f1af2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 6397bf23-f43f-07e4-73b1-60eca3da9238
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - df762093-f617-ad02-d8ad-47de0ebe7162
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - cda6c24b-bd1b-cb77-9a98-8f796a14e71d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - b9d9adf6-0782-2022-a55d-a90559db3b8a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_instance.by_name.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_instance.by_name.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 08ccae59-43b8-3c13-c6fd-481e238bd1cc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - be569a98-c2ec-29eb-1318-94baf07c2417
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 36cf9263-376d-c5ff-7754-b2eb2cf9e080
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 6180cdd3-b955-3a9c-5e60-b678808dc7ca
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 730f8281-be27-8977-d8d8-0e1b0cba098f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 6bd71eea-3efc-930a-232c-8e5a8e7d2f7d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_instances.all.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_instances.all.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 0bb9edec-f4f4-6d5b-b154-a397e1e8067d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 480223a2-cff8-c15a-3a39-7afc5b9dba21
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - d72da7da-8f83-d23e-19ea-71dccdf759f5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - a1833131-6d4a-8e00-1d36-858f5f5dce36
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - ab3c8fff-c309-edc4-9292-44625fd66a63
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 6ee033db-d00b-b54b-ba93-f30377cb269b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_instances.labelsfilter.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_instances.labelsfilter.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 9f83d2b5-fe4c-7142-ba33-033a04ea682c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - f0b78c0b-98b9-59e5-af30-a2d28cd34200
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 48607a8f-d412-85db-a348-4a8141916240
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 6c0e4659-bd75-0021-92bd-f74fc030e0cd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - dc6c88fa-7110-43c2-ad9e-15af24d651ef
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 7f66d664-fb05-c212-741e-b5fed6229a9e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_instances.namefilter.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_instances.namefilter.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ff78877a-1b34-19d1-75ef-b3b77a849c10
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - ba0dbf0d-a6ad-baa5-e0f3-f0eb0bafd31d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 9a200ffa-b7ab-dd78-6f93-26463534b1c5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 4cf0bd6b-ce11-0165-2257-130312570cf1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - db65823d-fd74-5868-894c-4b5362bebd8e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 105
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 4685b013-5066-da30-7018-e9774bec2da4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_instances.namefilter_variant.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_instances.namefilter_variant.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c8d2d969-4c99-1eb2-b266-bcc6fd73116e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 104
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 4537c0ca-9f95-5007-0421-3cb9635d3a07
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 104
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - d98e88a2-8cd5-419e-11c9-b87d1936ae57
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 104
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - cbfca9ba-9059-78b9-0d3f-afec2012d967
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 104
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - eff506fe-f9d6-0b0c-f1c0-458950ee1402
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 104
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 6f033542-186e-86c5-a192-e86990cdcf90
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_offering.by_id.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_offering.by_id.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 4d8606ed-45a2-3700-5899-eba636598545
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - c5867067-dbcc-5c07-e636-66cb1f66a125
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 89efe175-691b-5e2b-32ef-98ce92e43b9d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 6713da3f-3dee-cb58-3220-7fe8faa36f58
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - c19afb34-0224-ada9-b6d7-4f7b4906272b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 8a09f663-18c2-d250-8223-deef96e90359
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_offering.by_name.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_offering.by_name.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 33d21eef-43ba-6ce3-02d9-f34c3ce4de5f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 14da9974-9107-00c8-37fa-92b068d7c466
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 3cccef8b-1069-21ef-cf70-de1013b3d3e3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 1611014a-3c88-8b1d-c1a3-aacb6eb5cc28
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - cc9c3f02-ec47-a789-d3d9-535b67c6bcea
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 8b26601b-5e5e-74ed-097c-e9e94d7da6f5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_offerings.all.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_offerings.all.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 2ded15a4-8a96-04e5-5cfe-3cb38bbcaa1a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - d376a8df-8e8b-7be1-e747-526b7e0b9409
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - f5da97a3-1da9-7eff-8105-315a2aa6e405
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - aaa585b8-6eef-5282-f407-21b9efe29d90
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 61a1e2ef-8aa6-d1a7-6333-f5819091517f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 0ae14a0b-4c07-9c7b-71cc-68a52729e8d7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_offerings.by_environment.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_offerings.by_environment.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 3dde8088-2a17-3c22-58a8-58327c6b1543
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - e2b496a0-cbb9-aae5-8ee4-84e99e52bf27
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 51663911-e25c-6edb-43ab-d268cdef8726
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 8b65eb27-0360-5be3-d7f8-3515488efb32
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 0e79e9a6-c84a-34d9-e91b-87fdfd162f6a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - fd60fa35-e0a0-98e6-60c6-a0ee28d30c53
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_offerings.namefilter.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_offerings.namefilter.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 73f36405-05df-1336-57ac-999a7852e514
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 6d5ff3cd-05ea-51a0-891d-893f92e30280
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 6dc15296-37d2-5db8-89fc-736157c15d48
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 2a50398c-8758-d078-50e6-255e09c23c09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 42c3e2a3-d167-4ace-81ee-f77548fdf5bc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/offering?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/offering?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 9db81b40-26f0-28d2-78ee-347a06b54ff7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_plan.by_id.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_plan.by_id.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 2b761228-852f-e7c4-b53e-0d6d7d7ecb09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - f9a799bf-65f7-740a-895c-94b9e67ec1e2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 5e5f37f7-e0e9-e64f-fc0f-b37552871e30
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - eda262e3-384e-57e7-15c9-9706d012b003
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 18d75784-dd21-030a-a6b2-5a5a4d4c1f9c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - d608662b-4a9e-9aa1-d47e-e16f109ec5e3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_plan.by_name.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_plan.by_name.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 2b23782b-08c8-ceb0-6a90-7fc1bbdb56da
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 8b92561a-f404-a837-02b4-b317673f56a6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - b6fc0991-4517-91bd-42f3-e34c91cf8bab
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 3e59f9b8-10fc-7613-2a36-051124f7bad4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 3f737134-2a76-964a-e052-8b710ed7c1a2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 113
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - eb68c5c3-3b9e-3b0e-6d86-75f5fee05925
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_plans.all.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_plans.all.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d53155b4-572c-9473-510a-3b38f412645e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - c2dbeaf1-3e50-5bd6-1563-827b9339d9c2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 6b81628e-afae-f3ec-2a05-3f3239154984
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 691b8169-23ab-1117-65d8-e24b7f6b7bd1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - a0d7c76a-018d-1897-3bde-b7376672f158
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 09d62a5b-5f7d-e857-0b06-6ce63708264b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_plans.cloudfoundry.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_plans.cloudfoundry.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 94e4bbc9-6154-a6d8-4fd3-bb6e64c965c8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 827ebd2f-cda7-11d6-d56d-3d4c224f19ce
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - c7f26933-862e-6fd0-62d0-febed74a7e09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 03d625b6-cb5a-f6bc-02b8-587e17834e20
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 0233d2cd-d3c4-8617-6e9a-2da021f3fa7a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 99
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 06ea063a-2815-e270-df93-29589c728257
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_service_plans.namefilter.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_service_plans.namefilter.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 971476aa-e7e8-8265-3c45-63cea0fd1f50
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 4aeaafa9-1d71-ed8d-1fe6-7f3f6e9cf59e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 33f68344-c960-0be9-9eb1-f3dd5a39520c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - d0ae0c7e-a63b-6b2b-0789-c86f33eb6712
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - accc9366-233a-a0bd-35f2-7a7cfae75261
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 106
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/plan?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/plan?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - ffc33c31-a586-0a21-fa2a-6c62e767e617
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_subscription.by_id_and_plan.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_subscription.by_id_and_plan.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 1a18df50-d4a0-b359-7bc6-369d5c2f4bdd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - cb398ae0-9966-fa33-aced-8ee1d1a49539
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 331be041-62dd-722d-c358-e8ffb23a68c2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - c4cbeebf-721d-c2b8-a35a-e1d1285b8afc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 6c1a02c6-e6c5-9612-047a-af95e9ed043a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 117
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 06d019e4-c4e3-e4a4-1aa0-91369cdcc20d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_subscriptions.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_subscriptions.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 5b03d18f-af4b-a6a0-bf16-a80283d3c627
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 10059a82-5399-53a7-98f6-cc71c774fd97
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 34f5083e-b314-0470-37e2-8ed1b16f982b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - a4e34040-27ea-a49d-0f05-5a99c105aac3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 1ac673a7-ba3a-61ff-9da1-e003faa9640c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - d2946d6b-66df-7fce-eb07-046410b72a2b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_exists.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_exists.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 0c70a544-9e20-36a6-1692-7c4e9f5a88b2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - e6abb91d-86b0-fc4f-c50b-ec51ad357ecb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 4353dc1f-59e0-06ec-92e6-7c4ee8e15fa8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - d1c5773d-4cd7-1427-dd91-2ca4fa80ec46
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 653e5fdc-1f76-eed3-1842-c90e9905e319
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 8f5b4b89-5294-db15-3640-73405a7a2947
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_not_existing.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configuration.custom_idp_not_existing.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ecbb9515-e508-2f20-071a-bc1c446a15d6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 85
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/datasource_subaccount_trust_configuration.default.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configuration.default.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 17b7ffa0-1464-43b0-8670-0ed672bc298f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 93
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 5274aebc-d40c-b355-09b3-264845ae9fec
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 93
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 9647fc0d-cf7f-ec59-d538-395502dd389c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 93
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 312351ae-b12b-d587-0b33-25da31de901d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 93
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 74123c29-6f8e-f12e-9f62-4a33b31c3570
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 93
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 4872f445-2df2-c076-6818-305e4e7a4739
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_exists.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_exists.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - a3c7e67a-3018-6308-81bd-135658b0e84e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 1672fc03-8dc1-aaab-79db-1629832aff86
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 521d3398-4ace-9fa0-bbe7-67bba00db019
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - 18a6232a-4a01-f198-e10f-c8b904736300
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 160a1d96-4185-c1ad-efd5-95ea475f01b5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 9d27fad5-605c-6269-4166-2e47ecdf9f2c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_not_existing.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_trust_configurations.subaccount_not_existing.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - f29bbcc4-a3f9-cc15-a27b-cf5f478dca0d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_user.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_user.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 638a3718-1ba3-e47f-6e4f-209ea16aee22
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 5c198c4a-3bba-6de1-4728-a7c179fef32c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - b4e05944-c79a-697e-b628-ee2c8a9ab9ad
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - a7bfeaca-47a1-8d4c-5a4d-769931f4e288
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - 928f8f5f-e20e-d2ec-6b2b-551ae70b4077
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 97623409-cb37-e329-461e-7b1f588c07df
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_users.custom_idp.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_users.custom_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 8e42593c-55ac-98e2-5c1f-afaa304e7251
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - 2948d35b-5768-04e4-2cd7-3383c9472048
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 889d0d04-2dc3-c7d1-8100-f984eeb57a04
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - a290be2f-2a5a-e12a-14fd-083b6618d8b9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - d05127d4-d541-cbac-6482-655d274e565d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 103
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - da63bbc5-7c81-5c52-f8ed-d813791ad17c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccount_users.default_idp.yaml
+++ b/internal/provider/fixtures/datasource_subaccount_users.default_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c4234cfc-9433-1551-7c25-9f49c2b2039f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 86
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -155,7 +155,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -221,7 +221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -236,7 +236,7 @@ interactions:
                 - ab7bcf2c-0fb2-5434-9e6b-725050283d73
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -285,7 +285,7 @@ interactions:
         content_length: 86
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -306,7 +306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -367,7 +367,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -433,7 +433,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -448,7 +448,7 @@ interactions:
                 - 73c44baf-f79e-9c3e-54c0-a34a7849551b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -497,7 +497,7 @@ interactions:
         content_length: 86
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -518,7 +518,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -579,7 +579,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -645,7 +645,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -660,7 +660,7 @@ interactions:
                 - e513da39-eb97-6c03-5468-7e1c9257a6e6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -709,7 +709,7 @@ interactions:
         content_length: 86
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -730,7 +730,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -791,7 +791,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -857,7 +857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -872,7 +872,7 @@ interactions:
                 - aa73c1a7-24ea-3a9e-a3fa-99cd44af3cb2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -921,7 +921,7 @@ interactions:
         content_length: 86
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -942,7 +942,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1003,7 +1003,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/user?list
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/user?list
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 953ab2cc-9f16-36e5-96a5-e67cbd00c362
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_subaccounts.all.yaml
+++ b/internal/provider/fixtures/datasource_subaccounts.all.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 7f2c827b-8443-578c-5470-e6636aac33bd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -94,7 +94,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -143,7 +143,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -158,7 +158,7 @@ interactions:
                 - a29ed43a-185e-bbcc-eb05-8f933da2fee9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -207,7 +207,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -228,7 +228,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -277,7 +277,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - eeccc52e-0579-9a0b-d069-a1000a83c9f5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 53e7e420-32f0-5f0b-b5b6-398883c14fed
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - abb5cc55-c470-c3b5-d7bb-32733821ab8c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 55
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 11c848c6-620c-0e51-a0e3-ae7407f9318c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/datasource_whoami.yaml
+++ b/internal/provider/fixtures/datasource_whoami.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - f8247323-21df-3314-bbe4-3adf38957cda
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - dae3c2a1-86a2-f663-9108-1814ac569e33
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 4bbcd411-125d-0095-2ad9-dfd26cc3aad8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -216,7 +216,7 @@ interactions:
                 - 2d2ac898-fee8-ad0e-f575-8437e1ca4880
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -265,7 +265,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -280,7 +280,7 @@ interactions:
                 - ab5b74ff-1fb1-957e-11f9-5112e55df21c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -329,7 +329,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -344,7 +344,7 @@ interactions:
                 - e22bb99c-ccde-77eb-a815-c58eb18ebbaa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory.error_change_features.yaml
+++ b/internal/provider/fixtures/resource_directory.error_change_features.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ed79d604-fd23-a3e0-1128-56a0a9fc0a7d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 63682a77-a969-169e-aafa-9f684a4ae754
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 0a211a9e-5f14-92b6-7ce4-344b23533036
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - aa2e36cd-46b6-5199-34ec-023033f8275f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - c0cc97a7-0f46-b3d0-6354-3e781430ef48
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 38d494f7-8b16-f728-9c8d-0312ca351bb5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 88183f4f-29c9-496f-1f2a-84912fa37c3e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - 0aa42df9-69b8-ff07-8d0e-051741c27d4e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - f8d65fbd-ba8e-d7ff-a917-8fae62278de3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -880,7 +880,7 @@ interactions:
                 - 4b751771-7f9f-121d-7c34-1f61ae9a2439
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -929,7 +929,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -944,7 +944,7 @@ interactions:
                 - 06c34fe1-0741-6a72-8df6-5383b1d31bbc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -993,7 +993,7 @@ interactions:
         content_length: 146
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1014,7 +1014,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1063,7 +1063,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory.full_config.yaml
+++ b/internal/provider/fixtures/resource_directory.full_config.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 001687c0-b3fe-fa28-be62-1babb6b6b41c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 4d2963b8-43b1-eef6-9564-9c0faa5dc0ae
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - b234019b-f74c-da87-90ce-7a58e501d39e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 217
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - 45c903ef-7d8d-8dab-93d7-8d2f13cae3a4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 28250f24-2260-6efe-f616-eedcaa32d225
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - a420bb68-7f2f-0d80-9634-dd05ee35ebbc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -758,7 +758,7 @@ interactions:
                 - ac57786f-1087-e731-1a91-a0df4cdaf678
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -807,7 +807,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -892,7 +892,7 @@ interactions:
                 - 25f0d7fd-f4fe-8428-bae3-180296a2c428
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - de1f0de9-9c1c-e1b4-f8f8-f042e9d293ef
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 199
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1026,7 +1026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1160,7 +1160,7 @@ interactions:
                 - 5d33eb3b-f1f1-79f5-5be2-44dfaa449caf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1209,7 +1209,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1224,7 +1224,7 @@ interactions:
                 - 81bf98a8-cc70-b3fb-1a3b-7c4db3ea23c5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1273,7 +1273,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1294,7 +1294,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1343,7 +1343,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1358,7 +1358,7 @@ interactions:
                 - df0bc0e0-2122-eab2-4643-5675119e5407
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1422,7 +1422,7 @@ interactions:
                 - 8328526e-77e1-a4bb-5cec-e9e814bcf7e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1492,7 +1492,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1541,7 +1541,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1556,7 +1556,7 @@ interactions:
                 - baa47aab-7a53-1e49-913d-97151b8648de
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1605,7 +1605,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - 6dd5fa38-e0f2-7f15-11a7-9867f37779e8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1669,7 +1669,7 @@ interactions:
         content_length: 146
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1690,7 +1690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1739,7 +1739,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1760,7 +1760,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1809,7 +1809,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1830,7 +1830,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1879,7 +1879,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1900,7 +1900,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1949,7 +1949,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1970,7 +1970,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory.with_features.yaml
+++ b/internal/provider/fixtures/resource_directory.with_features.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b31fc979-57ce-4903-f6b6-5a6f9cf34f8f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 6b2a08ae-dba6-4277-564b-739491f61c99
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - d27b996c-6997-2ef1-6de4-8728a6cd0c31
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 219
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - 64e281df-2c1d-f290-c78a-666ff8210e91
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 62b25649-9d00-44e3-59c7-9cccb252c101
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 663bf05a-cec4-5bab-c706-3b70b8f2788d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -758,7 +758,7 @@ interactions:
                 - 3e513933-af24-3577-eb6e-602863de934a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -807,7 +807,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -892,7 +892,7 @@ interactions:
                 - 35d6a3ba-d564-9b3b-7e8e-9a456313693a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - 36b43149-8c5a-c047-24d9-8e43ca9db532
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 222
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1026,7 +1026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1160,7 +1160,7 @@ interactions:
                 - 66580e7c-7c31-cf8e-9d11-701c8c46b7ba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1209,7 +1209,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1224,7 +1224,7 @@ interactions:
                 - 57137e44-1272-90f9-5e60-4993feb5f236
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1273,7 +1273,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1294,7 +1294,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1343,7 +1343,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1358,7 +1358,7 @@ interactions:
                 - 43ad5b01-c768-b5d4-ad0a-d22d4628e09e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1422,7 +1422,7 @@ interactions:
                 - b75ce552-7284-365a-a7ac-4e8e019a69d0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1492,7 +1492,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1541,7 +1541,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1556,7 +1556,7 @@ interactions:
                 - e7736a1d-b7b1-7d72-4677-99b2e94eb027
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1605,7 +1605,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - 5c86a27d-5ed8-aa39-7015-19705d7dc214
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1669,7 +1669,7 @@ interactions:
         content_length: 146
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1690,7 +1690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1739,7 +1739,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1760,7 +1760,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1809,7 +1809,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1830,7 +1830,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1879,7 +1879,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1900,7 +1900,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory.yaml
+++ b/internal/provider/fixtures/resource_directory.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 20282b93-ab1e-b9dd-4a8a-e15d25b57a76
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 61795237-2ac9-ea0e-6b67-9b1416123d57
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 50115f5b-9111-0cf7-8847-de733c44d90c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - 9f41ea49-57a2-ce34-dab0-1095c696dc7a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - 74877477-e5dd-8f9d-72e9-c7f9a73334a4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - ebb0b145-4d18-0b11-74ad-5c5a89907615
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 6f84012f-84f0-7a45-398e-a4292b23869a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - d2f85e93-7eee-32a5-a02a-a793f4af5746
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - 0fb0f5a2-893e-181c-78e3-aa602078cfcb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 203
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - e603ac88-5f2b-65a3-601f-92f421b27234
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 02564539-5cdd-f256-9c90-4b6730435ac1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1133,7 +1133,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1154,7 +1154,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1203,7 +1203,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1218,7 +1218,7 @@ interactions:
                 - 9c194fab-b856-c43c-b219-48dad3a07063
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1267,7 +1267,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1282,7 +1282,7 @@ interactions:
                 - 150cf2ec-3bf5-3276-375e-64db038e001a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1331,7 +1331,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1352,7 +1352,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1401,7 +1401,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1416,7 +1416,7 @@ interactions:
                 - d9282658-edca-787b-0af5-7591d4c92429
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1465,7 +1465,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1480,7 +1480,7 @@ interactions:
                 - e6a7716d-722e-df76-331e-7f846be262bc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1529,7 +1529,7 @@ interactions:
         content_length: 146
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1550,7 +1550,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1599,7 +1599,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_entitlement.amount_set.yaml
+++ b/internal/provider/fixtures/resource_directory_entitlement.amount_set.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 8b1af421-d842-0f0e-f2ca-360d601fea2d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 0ad9433a-c446-77da-d5bf-eb5a58c61a0c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - c658e606-49d5-07a9-bab1-dab860b40b6f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - 878332a7-5c8e-1922-dd98-7ae8c3b320c8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - e632e387-7bc4-ea93-5bfe-cf603821eb86
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - c0bb4dd4-ece0-5ec9-e72a-e57ec9891bc8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - c5429227-7298-1af2-f074-14790ba65901
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - 07d7bc0d-7a06-ac16-d4d6-48ac3e06a1d2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - 6bce40c5-fc5f-0566-2cfb-96a0f147723c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_entitlement.no_amount.yaml
+++ b/internal/provider/fixtures/resource_directory_entitlement.no_amount.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 68e24441-5d77-8625-8e4a-474c3355fbe6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - c32f02d5-afe5-f27c-204a-c586f61eaee5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 5dab41e0-7fb8-86fa-e01a-7b55350ad853
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 179
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - 988ed62c-7caa-5b3e-d5e2-26f9b61f626b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - 4f5f1efc-c3e5-d401-2e07-2af322e9ba98
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 5c7e50f9-4056-7b9c-d192-e6f823447eae
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 2c9dc407-e4cb-18d1-1a78-78b7bcc3abf0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - 05e8b089-0fd2-699d-35e5-6acff6f73cb9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - 30e40b9e-5639-37ac-6105-937f55276924
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 180
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_entitlement.no_amount_with_flags.yaml
+++ b/internal/provider/fixtures/resource_directory_entitlement.no_amount_with_flags.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e0be23e6-f582-7a1c-6ce3-243fa34c582f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - bca81492-6a2f-3e6a-d6ac-7e069df2721d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - df5c8acc-a6dd-415f-3be7-a59794dd89fd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 178
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - bf622051-ba66-60cc-2605-fdafe9375f5e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - 8ebcc2d6-9d2c-8d99-d3ea-05ed452bb499
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 4536f848-fdd5-f569-5ffd-a68d2a963b44
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 89832520-5b92-f675-583a-a83782388aca
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - 314529b2-c2bb-490a-26f1-35e0903ee7c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - e4f227e2-0015-a5aa-cead-f80e3046decc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 179
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_entitlement.update.yaml
+++ b/internal/provider/fixtures/resource_directory_entitlement.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 02439dba-22ac-b004-a3b9-090f5bb63b86
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 6cfa9814-dc2c-a8f8-95a4-185594698df5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 4229f8ff-5141-8a65-9421-4b59b33cae7a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - a1950d20-19f0-d35e-7389-90909d3d03cd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - fd360928-bce3-227f-8b4a-b8b6ce7ebd9f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 334bd784-3a83-062f-64ff-52e946da9c71
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 7e3ff305-b3c5-8ce6-de6c-308ace628927
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - c4e953b8-6b66-1f4d-93a7-5880e52e4067
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - 9f57d30d-1a68-09ed-81d6-429745bd8891
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - ce6d5cc4-8d51-c626-67a1-42bb6d9431e6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - ecb8dc3a-2a72-836b-f612-bea3405de240
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1133,7 +1133,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1154,7 +1154,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1203,7 +1203,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1218,7 +1218,7 @@ interactions:
                 - 18d821b0-8e10-f91a-45d7-3cc1c8db8533
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1267,7 +1267,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1282,7 +1282,7 @@ interactions:
                 - 5c152ac4-0226-8b15-5c11-6367f84bad5a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1331,7 +1331,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - ace34914-2c6b-c954-8f81-39ceef63f17f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1395,7 +1395,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1416,7 +1416,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -1465,7 +1465,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1486,7 +1486,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_entitlement.update_with_flags.yaml
+++ b/internal/provider/fixtures/resource_directory_entitlement.update_with_flags.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 8b802591-b787-b2c1-a4b5-07499323f319
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 6cd45eb7-a9cd-0b90-5670-6cf59600b822
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 993db62b-12e8-b5c3-e471-66607a28880b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - d2da0da9-39a3-2ce3-19f3-3daeea2f8095
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - aea8d8ef-b196-c31b-e68f-97ac96598364
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 39265482-90f4-3a54-8ae2-e059ffcdb723
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 1b270e2e-0a32-39a5-1837-646d9acd4d58
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - b8ad553f-0e3d-8f07-5b5e-589a1253880a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - 87d0b930-341b-ea7c-d56f-4562bbb9a0f1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 228
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - 0795bb50-ef6c-bd5c-b9c3-89e4898724dd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 122550ba-b819-2eda-064f-46b9f09b46e7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1133,7 +1133,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1154,7 +1154,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1203,7 +1203,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1218,7 +1218,7 @@ interactions:
                 - d211fd6d-4dcc-1e7f-ff1a-68a496c24478
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1267,7 +1267,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1282,7 +1282,7 @@ interactions:
                 - 2a29ee1a-796b-262f-9314-41a5edb6ab51
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1331,7 +1331,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1352,7 +1352,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1401,7 +1401,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1416,7 +1416,7 @@ interactions:
                 - 6bde9925-a864-3e8e-204b-c03aa9c4cfb3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1465,7 +1465,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1480,7 +1480,7 @@ interactions:
                 - fff6a63b-4485-2362-7a7f-b79c339c6ac3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1529,7 +1529,7 @@ interactions:
         content_length: 228
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1550,7 +1550,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -1599,7 +1599,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1669,7 +1669,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1684,7 +1684,7 @@ interactions:
                 - e3219476-870c-ccc4-0205-6d54ffaed872
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1733,7 +1733,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1748,7 +1748,7 @@ interactions:
                 - ece56d75-f043-2c55-a158-f9ec380291c3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1797,7 +1797,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1818,7 +1818,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1867,7 +1867,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1882,7 +1882,7 @@ interactions:
                 - 4427426e-dfa0-5e7d-3c8b-6e2ec2316cff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1931,7 +1931,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1946,7 +1946,7 @@ interactions:
                 - fd7cc2ec-5e29-a442-9638-beadadf0ebdd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1995,7 +1995,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2010,7 +2010,7 @@ interactions:
                 - 86d79d54-1a08-90c7-102b-29bb50255aa8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2059,7 +2059,7 @@ interactions:
         content_length: 229
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2080,7 +2080,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -2129,7 +2129,7 @@ interactions:
         content_length: 69
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2150,7 +2150,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection.error_import.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.error_import.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 2aab093f-7ff8-bc43-4f02-7a821933fa23
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 87bb3896-1c15-bf00-73a0-5cb8d1b78a9c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - d6b613b8-ecd3-cc8e-2f22-d5dcef7e13a6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 136
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 225
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - cefe155b-002e-7737-9de7-0a3fe6e567e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - d546e312-caf7-1b53-f706-f2cb08924d84
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 119
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - 0b943765-ee9f-bef1-2bbd-4697a8482c38
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - 64d80796-f24d-d1bc-ce65-f29e8aeaaf27
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -680,7 +680,7 @@ interactions:
                 - 22b29561-a0da-c6bc-150e-a47f12fc63c7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -729,7 +729,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -744,7 +744,7 @@ interactions:
                 - d713993d-db2a-6832-1fc5-fbae9f2c85c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -793,7 +793,7 @@ interactions:
         content_length: 119
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection.multiple_roles.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.multiple_roles.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - aac364d7-0356-1ad3-1ae1-54a95bc7571b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - db219ac3-66fe-5962-9b5c-dd7892300603
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 02aa3596-53a5-974a-429b-e9e10238e412
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 158
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 244
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 217
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -360,7 +360,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -407,7 +407,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -422,7 +422,7 @@ interactions:
                 - 70380881-dc88-ca00-b4f4-2f07ac1544f4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -471,7 +471,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -486,7 +486,7 @@ interactions:
                 - 26ee1ae4-d813-39bb-9be9-59a0c08007ba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -535,7 +535,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -556,7 +556,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -605,7 +605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -620,7 +620,7 @@ interactions:
                 - 115ac341-e580-a473-c120-a43da654c358
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -669,7 +669,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -684,7 +684,7 @@ interactions:
                 - daa6a497-09e0-d868-20f6-0705ba809485
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -733,7 +733,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -754,7 +754,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -803,7 +803,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -818,7 +818,7 @@ interactions:
                 - 84e0f6ae-526b-d456-2245-6edc095b933f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -867,7 +867,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -882,7 +882,7 @@ interactions:
                 - 2c1dbe8e-e8e3-3978-da6c-5aafe81480c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -931,7 +931,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -952,7 +952,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection.no_description.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.no_description.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 4cc3a7f3-cd5e-f00d-b604-8dd50948e99a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 68b7e35f-d996-3909-df5f-991aabd7b1a3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - df1a4c50-dff5-9400-f014-4ee76f13e1de
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 132
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - 0411d755-ac42-ef1b-1653-98db98bc9421
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - ee130be1-5363-d118-577d-a64ea23268d4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - 841f15de-7e94-04e3-b988-5114ac95f2bb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - f65e7d25-8bf3-2557-3976-1c18b9283aca
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - f3c23350-5352-dc06-62a1-0d4a70b162dc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - d2cdd647-d84f-cb51-79b9-486ca86b0dbc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection.update.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 635b0a34-f8a0-891b-38d7-cb16e512f411
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 5bc576b3-82a2-7373-33a5-6400127124d9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 8ee42918-ec1c-8220-dc47-98411802a1b7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 162
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - 7341b7c5-cc3e-a713-f431-513f9cfc2cfe
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - 0b2f4d72-3a52-082d-c1d3-232ca3dc9c71
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - cf41bd43-baa9-5012-13a2-9e98e789f505
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - 36e0c445-161c-6ef8-3add-c2d7dac01912
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - a10ee390-2a6e-a9dd-d908-cace0519c2ba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - 34c6038c-9696-6ff6-eb32-f1b3d7919938
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 166
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -931,7 +931,7 @@ interactions:
         content_length: 248
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -952,7 +952,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -999,7 +999,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 7237d694-55e5-222e-f8c2-01c125a54831
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1133,7 +1133,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1148,7 +1148,7 @@ interactions:
                 - 8e094c27-cc9a-741e-bdd1-482518bdbd7c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1197,7 +1197,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1218,7 +1218,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1267,7 +1267,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1282,7 +1282,7 @@ interactions:
                 - b2d960aa-45e1-02f6-6077-2e379bfea11a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1331,7 +1331,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - 1550bae3-1456-5555-bd31-884b03a08c91
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1395,7 +1395,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1416,7 +1416,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1465,7 +1465,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1480,7 +1480,7 @@ interactions:
                 - 4f59fbbc-136e-a158-3ac2-c666e2c5a3b0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1529,7 +1529,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1544,7 +1544,7 @@ interactions:
                 - 242a7c5c-e75a-2f7f-b07c-23c1deb90146
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1593,7 +1593,7 @@ interactions:
         content_length: 166
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1614,7 +1614,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1661,7 +1661,7 @@ interactions:
         content_length: 248
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1682,7 +1682,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1729,7 +1729,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1750,7 +1750,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1799,7 +1799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1814,7 +1814,7 @@ interactions:
                 - e988e1e1-7409-1aa8-db8a-a5c22e1b94de
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1863,7 +1863,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1878,7 +1878,7 @@ interactions:
                 - 2d3b2a4b-4f31-d4ce-6780-10d6b2122355
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1927,7 +1927,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1948,7 +1948,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1997,7 +1997,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2012,7 +2012,7 @@ interactions:
                 - 9fd6ec7b-93d7-09ef-feab-2bf3f5acbd04
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2061,7 +2061,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2076,7 +2076,7 @@ interactions:
                 - f465bf45-8979-6a0f-1c10-5a04382ec3cf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2125,7 +2125,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2146,7 +2146,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2195,7 +2195,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2210,7 +2210,7 @@ interactions:
                 - 4e06f423-a928-7624-86df-17be4acb9122
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2259,7 +2259,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2274,7 +2274,7 @@ interactions:
                 - 569ee8bc-35ab-ae6a-b82f-e5426d1a972d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2323,7 +2323,7 @@ interactions:
         content_length: 132
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2344,7 +2344,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -2391,7 +2391,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2412,7 +2412,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2461,7 +2461,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2476,7 +2476,7 @@ interactions:
                 - 9dd24306-6d3b-b2b0-4190-b99fa42cf7fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2525,7 +2525,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2540,7 +2540,7 @@ interactions:
                 - 0b310012-a219-abe1-51f0-e8a062b18f55
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2589,7 +2589,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2610,7 +2610,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2659,7 +2659,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2674,7 +2674,7 @@ interactions:
                 - 8d246877-4211-44b4-ee5c-f0961165bf1e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2723,7 +2723,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2738,7 +2738,7 @@ interactions:
                 - 14e4ae4c-3f37-ba47-b4d0-fd553d73a72c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2787,7 +2787,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2808,7 +2808,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2857,7 +2857,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2872,7 +2872,7 @@ interactions:
                 - 370ecc7f-2ba2-c902-c130-2dab9a81c23a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2921,7 +2921,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2936,7 +2936,7 @@ interactions:
                 - 5c9af021-52c7-eac7-f740-94b82dc6bc23
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2985,7 +2985,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -3006,7 +3006,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection.with_description.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection.with_description.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b5f9f725-7f22-72e5-7f94-c38f9e70a785
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - e6bffa09-614b-1d35-0bb1-322d3f5c61ec
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - b3875d04-0ca7-d1f8-b96b-4e102470fc13
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 162
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - 37abbb77-df03-5de7-e69e-c5f4e4b5b57d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - 29edc16d-55b2-3ef7-1a4e-67428b6ee2bb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - d3f7e7af-65d7-2480-d0d0-7d214addfae0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - 55f1d359-4661-8fc3-739c-1fef28b3aeb7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - 32d453fe-74e7-5ece-2339-80d9fed2a72e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - 706eab1f-2123-cc4f-3b46-f1afc57cc884
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment.import_error.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - dd777d46-b2c7-3269-ad26-2044878c1d6b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - e32e8c50-23b0-bf47-6da9-193115d5d84b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 1bf08eec-0486-ea1c-734d-53db5894a82f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 186
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - a1effd83-a018-08de-8e10-1dd1719c7e90
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - e86906e1-2dfb-1dbf-988a-c85d73f87050
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -414,7 +414,7 @@ interactions:
                 - 01be6fec-9a82-44b8-7820-7f3731839d13
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -463,7 +463,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -478,7 +478,7 @@ interactions:
                 - 8b5d5715-17cd-f02c-f8ee-a9f92f4bdeae
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -527,7 +527,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -542,7 +542,7 @@ interactions:
                 - a83b6056-4644-7a7b-9c47-e5fb052c91ff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -591,7 +591,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -606,7 +606,7 @@ interactions:
                 - 8e4f15da-388c-43c2-f2c8-a877643a0845
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -655,7 +655,7 @@ interactions:
         content_length: 157
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -676,7 +676,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment.with_origin.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment.with_origin.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d2150014-3fdd-c245-e2f6-da608d696fcb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 2801efe8-3f22-60ad-d75c-6c99358114af
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 41e41475-4729-b00d-0884-e019f3c9d619
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 202
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - 6557946b-12f1-e2ef-9c74-ea7351444d20
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - bccfe7f9-690e-50cb-d4fe-7cd137a5305b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -414,7 +414,7 @@ interactions:
                 - 2914565b-2ba3-89ab-6df3-01481a6adace
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -463,7 +463,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -478,7 +478,7 @@ interactions:
                 - 756eafb8-5e00-2732-5837-cc01a550d9b8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -527,7 +527,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -542,7 +542,7 @@ interactions:
                 - 117c3c73-d340-a605-3d64-98e3b448c601
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -591,7 +591,7 @@ interactions:
         content_length: 173
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -612,7 +612,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment.with_origin_and_attribute.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment.with_origin_and_attribute.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e7b4b594-8f66-b4da-0a10-407a1c9f1539
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 6776fc49-64d3-a104-89ee-9db2a7b2ecc5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - b840b539-11fa-69a9-bdc5-81749d8b0120
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 239
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -269,7 +269,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -284,7 +284,7 @@ interactions:
                 - 0730da13-a8ab-0f84-d9e0-108bc3a2c042
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -333,7 +333,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -348,7 +348,7 @@ interactions:
                 - 459354ed-0dc4-9934-b87d-a73da0ff59af
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -397,7 +397,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -412,7 +412,7 @@ interactions:
                 - 0feb09f0-a7e8-7eb7-94e8-82b59e5b163b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -461,7 +461,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -476,7 +476,7 @@ interactions:
                 - 9dda204f-2eab-7232-0412-f60c62e15e4c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -525,7 +525,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -540,7 +540,7 @@ interactions:
                 - 5b01d61f-fd3c-25aa-9661-75f68401c153
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -589,7 +589,7 @@ interactions:
         content_length: 210
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -610,7 +610,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment.with_origin_and_group.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment.with_origin_and_group.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - abe602d3-4153-79ca-a3be-fd36f904bf11
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - c4fa0c0f-4caf-45d7-f16d-6ac765851d32
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 4f7b9f02-69f4-dc45-c2dd-0814b420d805
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 195
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -269,7 +269,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -284,7 +284,7 @@ interactions:
                 - a0e99874-41d5-14d3-1f4e-b9fa0dd51f8c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -333,7 +333,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -348,7 +348,7 @@ interactions:
                 - a1f250b5-d65c-de16-bdc6-c09dd071acbb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -397,7 +397,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -412,7 +412,7 @@ interactions:
                 - f4f59d29-5b8b-a8c5-e826-43f1f90d0507
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -461,7 +461,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -476,7 +476,7 @@ interactions:
                 - 909caea2-b632-5da0-bfb4-0e09ed76d197
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -525,7 +525,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -540,7 +540,7 @@ interactions:
                 - 9555c009-0293-6db8-cf8b-da6a9424ee74
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -589,7 +589,7 @@ interactions:
         content_length: 166
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -610,7 +610,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_directory_role_collection_assignment.yaml
+++ b/internal/provider/fixtures/resource_directory_role_collection_assignment.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - b047d597-dbd7-8bf7-b62f-f4efc1ecf4cf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - df909ee5-03bb-1255-f3a0-b3b7e3203405
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 35fd973f-0fe3-e531-623b-337aac6e32f1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 186
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - 2741f87a-2104-1bb5-dcdc-f7927197041f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - 8e013cab-8f97-01ce-9d9e-f0280f2c3869
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -414,7 +414,7 @@ interactions:
                 - f0ea1230-581f-6c40-668f-d4f5808f6db7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -463,7 +463,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -478,7 +478,7 @@ interactions:
                 - e7c67f2a-7c69-90d2-7742-9596d02ad8e1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -527,7 +527,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -542,7 +542,7 @@ interactions:
                 - 8fae6e4e-0974-8918-abe2-ef6ffa5d1e6d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -591,7 +591,7 @@ interactions:
         content_length: 157
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -612,7 +612,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_resource_provider.create.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_resource_provider.create.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 294a6bf2-ecaa-9a48-1bc1-565e7f174a18
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 3088ce5b-8bee-f9d3-1c78-5c1b3a594eb5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 85f0404c-8b0c-5e7a-26a8-5d2522bfc8a3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 337
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - 55dcfae4-6744-e704-3cd3-3db5a41bfc32
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - 399a6a49-790e-0427-9366-ceaf6632599c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -484,7 +484,7 @@ interactions:
                 - d0834d10-b3d2-26b5-d24b-3c27450b0c31
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -533,7 +533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -548,7 +548,7 @@ interactions:
                 - 02aca5a6-2be2-034a-a79c-48d744fe9d86
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -597,7 +597,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -682,7 +682,7 @@ interactions:
                 - e37e3ef4-ec3d-1e4b-2a23-531e3f977261
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -731,7 +731,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -746,7 +746,7 @@ interactions:
                 - e76aa380-2b7b-97f5-05f8-e882313a75fd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -795,7 +795,7 @@ interactions:
         content_length: 132
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 308
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -950,7 +950,7 @@ interactions:
                 - b9234719-8e93-e1ae-7f3f-1791d5b9d8c3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -999,7 +999,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1014,7 +1014,7 @@ interactions:
                 - 1fd5e7fe-4c9d-250c-1e28-dcb23e3ca8f3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1063,7 +1063,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1133,7 +1133,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1148,7 +1148,7 @@ interactions:
                 - a863d9a3-03c3-f67f-2643-6357e1fced24
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1197,7 +1197,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1212,7 +1212,7 @@ interactions:
                 - 9a6172ad-6727-fa6e-e2f4-15b116a2cf8c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1261,7 +1261,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1276,7 +1276,7 @@ interactions:
                 - 6be0f2e4-6c78-072c-a709-96cf2abd7f59
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 133
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_resource_provider.update.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_resource_provider.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - c057ccfa-a91e-0c20-7018-3bd446e748f4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - e78c9a1f-e878-0e91-e9a7-65f5113061fc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 5a5cf7ef-7721-ea6f-5914-07516da02c59
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 337
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - b7dae90e-ccc0-044e-8f5d-586bfc0a32e9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - f08b95e4-c840-8af6-08a7-9406f90193e3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -484,7 +484,7 @@ interactions:
                 - 43cb323d-627f-2c2e-8642-b58398f4195d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -533,7 +533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -548,7 +548,7 @@ interactions:
                 - 060541d9-9c8d-83e0-b264-463fbb6ca4c4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -597,7 +597,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -682,7 +682,7 @@ interactions:
                 - b75683f7-2c4c-d72c-b7e0-a7ca9b15b662
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -731,7 +731,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -746,7 +746,7 @@ interactions:
                 - ca25a8c3-bc46-9462-3b96-94fbbb28a1bd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -795,7 +795,7 @@ interactions:
         content_length: 298
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -880,7 +880,7 @@ interactions:
                 - 581ef4b3-6e1e-4a58-eb2c-50a16dc9e7e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -929,7 +929,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -944,7 +944,7 @@ interactions:
                 - 25daff92-cc14-0384-3ed5-283aee64c3b8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -993,7 +993,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1014,7 +1014,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1063,7 +1063,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1078,7 +1078,7 @@ interactions:
                 - 4dc46978-0189-3f4d-38b4-417664571cab
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1142,7 +1142,7 @@ interactions:
                 - fd11eeb3-b362-5351-0fc1-31074c733e09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1191,7 +1191,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1206,7 +1206,7 @@ interactions:
                 - d8a6f0a1-6f0d-f258-32d4-f0c9489e454b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1255,7 +1255,7 @@ interactions:
         content_length: 132
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1276,7 +1276,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_resource_provider.update_wo_description.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_resource_provider.update_wo_description.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 77ebac71-e075-d863-665e-12c04165fdb6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 9b523b1e-6f14-ba6d-453f-7467220c2064
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 9cb718c8-4abd-a015-a0a5-51dfb0508501
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 337
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - 6ff68501-4d2b-77cd-92f6-7208dccf128c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - 5014d272-b063-d613-133f-bcdbe9e7e0ce
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -484,7 +484,7 @@ interactions:
                 - 9db69110-0699-2ce7-eec7-d2180d19eb8a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -533,7 +533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -548,7 +548,7 @@ interactions:
                 - 2975e10d-d59f-2c18-98d3-9b1222ca8044
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -597,7 +597,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -682,7 +682,7 @@ interactions:
                 - bad6d635-3cab-3d6a-8547-20b96ec1c102
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -731,7 +731,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -746,7 +746,7 @@ interactions:
                 - 97af31ac-3a09-e3b7-1d3e-8762cd99ccf0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -795,7 +795,7 @@ interactions:
         content_length: 329
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -880,7 +880,7 @@ interactions:
                 - 065ae365-ddec-50a8-57fc-f41e97b3f5ff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -929,7 +929,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -944,7 +944,7 @@ interactions:
                 - 1ad8a3b0-e937-bf07-994a-be30b614f07c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -993,7 +993,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1014,7 +1014,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1063,7 +1063,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1078,7 +1078,7 @@ interactions:
                 - 53dd0aa1-1afd-8a4e-f3fd-40663ee0471a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1142,7 +1142,7 @@ interactions:
                 - 3c1b7cab-d982-aab9-c9a3-d00f305defa1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1191,7 +1191,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1206,7 +1206,7 @@ interactions:
                 - 9c923abd-a4f1-529b-8299-3de1c4ee062d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1255,7 +1255,7 @@ interactions:
         content_length: 132
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1276,7 +1276,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/resource-provider?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/resource-provider?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.import_error.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 6566a840-70df-c5bb-e31f-5bf805e4df87
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 67e9242c-8d21-4b5e-d857-1c7305f3cd18
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - c59f817a-0028-e54c-ad50-8bace98e78e5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 155
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - 2c4b3717-d5dc-5cf2-79ec-61ad3404dbfb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - c119f97f-ebcc-ef31-57b0-452fa1f6341d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -484,7 +484,7 @@ interactions:
                 - d0dc4b21-6dc4-5152-e990-7a0580611f76
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -533,7 +533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -548,7 +548,7 @@ interactions:
                 - cf358347-7bc5-70de-16e7-ea2f82b9a72c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -597,7 +597,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -612,7 +612,7 @@ interactions:
                 - 81a910e9-8c50-7232-4c6f-408e9282582b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -661,7 +661,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -676,7 +676,7 @@ interactions:
                 - f5a7b4db-79a7-c58b-1844-4bcd5d2b3254
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -725,7 +725,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -746,7 +746,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.update.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 6de744a2-76f3-1a19-72a1-cc8958d66bf3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 373506c6-e9a9-5b8a-eb46-4f2b37960266
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 9b3ce80a-7b09-a960-9b70-2b423e51933d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 155
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - 903bcc3f-f288-67a3-b00b-fc5c71bcd5a7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - fc560885-51e3-9bbc-46bd-ac544e8a84a3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - 167fe389-e24d-4496-7b17-d01203ec84fc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - c4eaa7df-ac6a-8453-c346-b6d8911d81d1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - 8081dc9c-ee81-2230-fc2e-a352411a0228
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - 6065bd6d-e831-a6b0-5bbc-36f8d74cb157
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 159
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -931,7 +931,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -952,7 +952,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -999,7 +999,7 @@ interactions:
         content_length: 230
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -1067,7 +1067,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1088,7 +1088,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1137,7 +1137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1152,7 +1152,7 @@ interactions:
                 - 3db41273-fa5f-7a3d-ea29-57d16e2622fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1201,7 +1201,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1216,7 +1216,7 @@ interactions:
                 - 05768142-1fa8-625d-d07d-2064ff45c938
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1265,7 +1265,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1286,7 +1286,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1335,7 +1335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1350,7 +1350,7 @@ interactions:
                 - 5986046b-853c-e8ec-c97a-370298180b11
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1399,7 +1399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1414,7 +1414,7 @@ interactions:
                 - e447bcd6-fedc-6504-334f-38ae2023c1d7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1463,7 +1463,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1484,7 +1484,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1533,7 +1533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1548,7 +1548,7 @@ interactions:
                 - c14e8cff-9199-e15f-916c-6ddd378585f8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1597,7 +1597,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1612,7 +1612,7 @@ interactions:
                 - 69b6d7a8-c1d1-1289-07b0-4097e9c2d404
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1661,7 +1661,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1682,7 +1682,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.update_rm_desc.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.update_rm_desc.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 288703cc-8fa8-a485-6081-9ba8df26f583
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 8798341e-eb04-e812-3360-07d410470a1d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 07a53f37-57d4-6086-78e3-2c8447b8976c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 155
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - 9fbb7779-9752-274f-913a-eafb65ecc8fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - f663aaf7-af1d-7bac-c60f-f210ba740cbc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - 52324111-8f0c-757b-2323-8cb2b668f8ea
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - 248a2ed2-58c0-2a5a-72ab-1eff35fb49dc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - d6bb3efe-c4b0-fdb9-d9da-3aeb9611d928
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - c4e5ec45-1f47-0cf5-18e1-53a24353c533
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -931,7 +931,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -952,7 +952,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -999,7 +999,7 @@ interactions:
         content_length: 230
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -1067,7 +1067,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1088,7 +1088,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1137,7 +1137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1152,7 +1152,7 @@ interactions:
                 - 49fe2da3-38c7-2d48-0450-024f98eaace5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1201,7 +1201,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1216,7 +1216,7 @@ interactions:
                 - c38ea967-9744-5121-0bb1-aee48ba686b6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1265,7 +1265,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1286,7 +1286,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1335,7 +1335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1350,7 +1350,7 @@ interactions:
                 - 04d63946-a65d-2dfe-5d29-316cdc154ae3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1399,7 +1399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1414,7 +1414,7 @@ interactions:
                 - 071e4956-0982-9b8b-f55c-d5222d7a2ecb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1463,7 +1463,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1484,7 +1484,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1533,7 +1533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1548,7 +1548,7 @@ interactions:
                 - 3f5b1299-0204-c2f0-65a8-e0f29cf042f9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1597,7 +1597,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1612,7 +1612,7 @@ interactions:
                 - b2a23d52-e0d3-c872-ef4f-e8f4e56f4b8c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1661,7 +1661,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1682,7 +1682,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.update_wo_desc.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.update_wo_desc.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 7f6957b0-70f6-4ee0-33d3-1c598cc6434a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - e83a98b4-af8b-dd92-4df2-bc3a7f040882
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - ef8a63d3-5ab4-c764-8a15-fc9b5ebe5b44
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 155
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - 2a644fe4-dddc-8c8b-9adb-f043523317dc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - b366f2ac-7ec5-48ff-cbb0-fecb882d34ac
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - ee6fd3a9-fb6d-ddb4-57f9-c12c5b388130
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - 666270ba-f2c9-e7be-4b83-89584061a4ae
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - 7d391a91-b2a6-d310-ea4b-371ac932e42d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - f0e64f29-cac4-c82d-4653-edda8a0f9776
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 155
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -931,7 +931,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -952,7 +952,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -999,7 +999,7 @@ interactions:
         content_length: 230
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -1067,7 +1067,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1088,7 +1088,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1137,7 +1137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1152,7 +1152,7 @@ interactions:
                 - 121bcfe9-c982-462d-5812-eed58bc02489
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1201,7 +1201,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1216,7 +1216,7 @@ interactions:
                 - e11b8360-5874-f8c5-3f21-9ce84586db66
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1265,7 +1265,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1286,7 +1286,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1335,7 +1335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1350,7 +1350,7 @@ interactions:
                 - 3d92ba9c-6b83-cb58-8e8a-07ffb56a2418
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1399,7 +1399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1414,7 +1414,7 @@ interactions:
                 - 901e844d-ca82-9d4e-7975-6a22b94f5013
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1463,7 +1463,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1484,7 +1484,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1533,7 +1533,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1548,7 +1548,7 @@ interactions:
                 - 0d35f95a-9167-1d5b-336b-bd109ec58bf5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1597,7 +1597,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1612,7 +1612,7 @@ interactions:
                 - 76ca972b-24af-8a4d-95f8-d8068dd2202a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1661,7 +1661,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1682,7 +1682,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - af4942c1-8e21-146c-2fd3-9c3fc4bb68eb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - f5a5bbe6-38f1-8e71-3564-e5f6dc825eac
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - c533ea41-b142-34d0-a1c8-ad7abeae585f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 155
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 216
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -339,7 +339,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -354,7 +354,7 @@ interactions:
                 - c736d9c0-80ea-307b-376e-8065f727966f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -403,7 +403,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -418,7 +418,7 @@ interactions:
                 - 65fe56f3-2e32-436c-61dc-16d218bf9539
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -467,7 +467,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -488,7 +488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -552,7 +552,7 @@ interactions:
                 - 51c60965-a729-eede-0d13-2265393e5146
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -601,7 +601,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -616,7 +616,7 @@ interactions:
                 - beb31b49-36ab-6126-e85b-098fe52a1cf4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -665,7 +665,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -686,7 +686,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -735,7 +735,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -750,7 +750,7 @@ interactions:
                 - 866d72a2-2910-f286-487e-1ab72abcd571
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -799,7 +799,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -814,7 +814,7 @@ interactions:
                 - 25e31702-86fc-a11f-4500-372558c5707f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -863,7 +863,7 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -884,7 +884,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.import_error.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - dafa69d3-edc2-5742-9a06-ffa5eb7150ff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 33cc512e-ec10-eb65-ec80-679b88e5323a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 3040f5d5-d87d-6a3a-6483-6ccfdb888ac2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 177
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - e0eea364-c24e-e6a4-4487-28b3b871b45a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - 604cf543-0616-2eea-1230-9019fef92c93
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -414,7 +414,7 @@ interactions:
                 - 62d6c1d2-d79b-99f7-ae29-c91e0666418b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -463,7 +463,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -478,7 +478,7 @@ interactions:
                 - 8765cfdb-33cc-ef8c-fb38-c569fd83de7f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -527,7 +527,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -542,7 +542,7 @@ interactions:
                 - c6547592-4aac-3e7a-c91b-8809274a9da9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -591,7 +591,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -606,7 +606,7 @@ interactions:
                 - c91bb5f4-c109-fb51-64be-816c6f42a801
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -655,7 +655,7 @@ interactions:
         content_length: 148
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -676,7 +676,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.with_origin.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.with_origin.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e5a55b95-60dd-7db8-cc3c-6dc51e643292
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 77dbf074-e3c9-0c64-0d4a-97c1e34c0dd5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - abe95d39-2573-5be8-a260-e28fe5f864c3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 193
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - 2af34f6c-b5ed-4adb-5fbb-4adeefd80b9a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - 88316b71-5c65-a646-c41f-924995022e94
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -414,7 +414,7 @@ interactions:
                 - fcdefde0-4c4b-237d-4b4c-a18ca02f80b2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -463,7 +463,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -478,7 +478,7 @@ interactions:
                 - a27c59dd-076e-4794-055b-3c39d4960ebe
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -527,7 +527,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -542,7 +542,7 @@ interactions:
                 - 43a3f570-aee0-45d4-164e-dcaf9f8ede81
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -591,7 +591,7 @@ interactions:
         content_length: 164
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -612,7 +612,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.with_origin_and_attribute.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.with_origin_and_attribute.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 0f34d0c0-9d8d-10e2-b3ac-b0b691ae88e7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 40acce8b-de8f-bda5-0095-f4b87148db6e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - dcd65441-d683-814c-0e48-0c31e0a29530
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 230
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -269,7 +269,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -284,7 +284,7 @@ interactions:
                 - 20aa9b8b-7347-f7f7-b60e-074c7310c176
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -333,7 +333,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -348,7 +348,7 @@ interactions:
                 - 8bf4b5fe-1188-8209-3845-d66b7795b976
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -397,7 +397,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -412,7 +412,7 @@ interactions:
                 - 3abd6000-602b-de7c-b75e-752de7eccd2c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -461,7 +461,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -476,7 +476,7 @@ interactions:
                 - fac3914a-2438-dccb-1ea0-be5393d14acb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -525,7 +525,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -540,7 +540,7 @@ interactions:
                 - bc74b3e5-653f-d576-b31d-caad9d9cd8de
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -589,7 +589,7 @@ interactions:
         content_length: 201
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -610,7 +610,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.with_origin_and_group.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.with_origin_and_group.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 3f6fec27-f740-d2be-c169-66de9a5d162d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 277fd67c-ae1c-4821-35f2-dcab6c2e822f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 858f871a-6a9a-7a81-3df9-c4561b6eb003
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 186
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -269,7 +269,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -284,7 +284,7 @@ interactions:
                 - 7127d971-f57c-82da-bab2-0be88673735f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -333,7 +333,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -348,7 +348,7 @@ interactions:
                 - e88ec342-513c-fcfe-516a-42d400cf8f86
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -397,7 +397,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -412,7 +412,7 @@ interactions:
                 - 5598d85f-1603-6cfa-4fd4-a176baf6b31d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -461,7 +461,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -476,7 +476,7 @@ interactions:
                 - 28723cab-2282-daca-aca6-9a5ae54159a8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -525,7 +525,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -540,7 +540,7 @@ interactions:
                 - 62afa7d5-f1cc-0ef7-732c-f568ecdad39d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -589,7 +589,7 @@ interactions:
         content_length: 157
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -610,7 +610,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_role_collection_assignment.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 0b31768b-80ab-fc17-f976-ed1d2dd7206a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 2fb5f62e-bd43-9ab1-1b24-8e6a0bbfaa13
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 2711eadc-e7b7-23a6-7c04-b2fb84763445
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 177
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -286,7 +286,7 @@ interactions:
                 - f94e22d4-76b5-8193-1954-33835056f097
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -335,7 +335,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -350,7 +350,7 @@ interactions:
                 - 88a12504-aec4-5422-c7af-b547328c092a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -414,7 +414,7 @@ interactions:
                 - 0ca3dc4b-ee89-d25e-e42d-b09d12a50e9d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -463,7 +463,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -478,7 +478,7 @@ interactions:
                 - e20487e2-3500-3ce2-3557-4fd79ffa8b5e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -527,7 +527,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -542,7 +542,7 @@ interactions:
                 - e7d8a890-4358-1296-04dd-a1b395c99c93
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -591,7 +591,7 @@ interactions:
         content_length: 148
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -612,7 +612,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_trust_configuration.complete.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_trust_configuration.complete.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 1f12a6ab-4524-aa97-6e23-ea25a6b7db4e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - f90ab4fd-3dfb-8d61-fd51-3dce134bc748
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 13f3ea0d-7b6a-0e7d-2b2b-751b95fd5dff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 302
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - aa743ea6-f718-fa55-7372-accb4f8f912b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - 9eb14824-58ea-5aa0-c161-fe6a872e59ed
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 3915bf42-b5e2-7ffb-5c6d-64f36cf130c5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 9105b276-63e0-d63f-aaec-083f91910d73
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - 827d47ee-de08-f535-36a3-f7299498151c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - d761f369-0398-1061-4ba9-e4d4cec1c809
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -880,7 +880,7 @@ interactions:
                 - ccc7698a-2259-69f3-ced9-c1b1f6e66f96
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -929,7 +929,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -950,7 +950,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -999,7 +999,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1014,7 +1014,7 @@ interactions:
                 - 9b11026b-c9d5-b006-2631-56ab814c3dee
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1063,7 +1063,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1078,7 +1078,7 @@ interactions:
                 - 8d39d306-1e0b-e313-7141-ac80c9a83afc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1148,7 +1148,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1197,7 +1197,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1212,7 +1212,7 @@ interactions:
                 - 73c01ddc-86d9-bb33-9d12-7a46784c3617
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1261,7 +1261,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1276,7 +1276,7 @@ interactions:
                 - e7cb57c2-5bfd-5bce-b9e1-6a50b573332e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_trust_configuration.invalid_idp.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_trust_configuration.invalid_idp.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - dfa71719-39a0-06d0-71b5-b9311198dc1b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 0bae5d0d-db14-06a5-01cc-6fe592ada641
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - bf1da6f5-5a5b-bd61-2de8-efe4a088bc70
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 121
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_globalaccount_trust_configuration.minimal.yaml
+++ b/internal/provider/fixtures/resource_globalaccount_trust_configuration.minimal.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d06fedf8-c1d5-088c-0035-2e024fed9d2d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 4ef3ca05-32fb-9ced-f096-7c61fceb8813
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 3db409c4-ef2a-29af-a86a-7c0c88aac42f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 111
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -356,7 +356,7 @@ interactions:
                 - 810f4f90-54b4-858f-8214-3ee082ee2d35
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -405,7 +405,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -420,7 +420,7 @@ interactions:
                 - 6428d30d-18ed-8e7d-aedf-c2f57cb185d1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -469,7 +469,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - e465d412-1b12-f227-041d-4399e1ed9a85
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - ecd9be18-cafc-7602-937f-74d59587c7a7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -737,7 +737,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -752,7 +752,7 @@ interactions:
                 - b2201fc5-0ada-7674-361b-c40fcbfb6611
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -801,7 +801,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -816,7 +816,7 @@ interactions:
                 - 6d216670-9b71-0602-7ed5-becb40f1d492
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -865,7 +865,7 @@ interactions:
         content_length: 271
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -886,7 +886,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -935,7 +935,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1020,7 +1020,7 @@ interactions:
                 - 6c88a6ea-801f-f68a-9b0d-b254f1afb14f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1069,7 +1069,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1084,7 +1084,7 @@ interactions:
                 - 789d0af8-4e5e-3f7c-5e63-b0697a93e8d7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1133,7 +1133,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1154,7 +1154,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1203,7 +1203,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1218,7 +1218,7 @@ interactions:
                 - 62d8b4e3-38f5-d810-8a20-438d1ad2393a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1267,7 +1267,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1282,7 +1282,7 @@ interactions:
                 - 4b168b0f-6671-bb44-0fd9-b52cd3265a85
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1331,7 +1331,7 @@ interactions:
         content_length: 89
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1352,7 +1352,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1401,7 +1401,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1416,7 +1416,7 @@ interactions:
                 - 7f8743cf-1ca8-cfc9-455e-7449939b6684
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1465,7 +1465,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1480,7 +1480,7 @@ interactions:
                 - cee14d7c-f7ad-6f34-a9b9-b9c519d08f54
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1529,7 +1529,7 @@ interactions:
         content_length: 109
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1550,7 +1550,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount.change_to_used_for_production.yaml
+++ b/internal/provider/fixtures/resource_subaccount.change_to_used_for_production.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - bba6830e-9407-ca21-fc44-220bf28f8cad
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 25ef01ca-933a-2df2-ef08-736359b05a34
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - dd6acb87-51d0-f9e2-f0aa-868490642f84
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 187
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - f20a0d20-302f-2364-eb6c-08f2eb848fad
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 487ed8dc-ebdf-995a-2e2d-606529dff3b7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 693fae54-bf14-baec-4658-39098fd7c789
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -758,7 +758,7 @@ interactions:
                 - 8c44fe6b-f862-38ce-b8c6-ca4af6fd975b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -807,7 +807,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -892,7 +892,7 @@ interactions:
                 - b6a442d2-b770-38dd-7a5e-f59e6b111250
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - 609c499d-61b2-cedd-c0a0-774a48b5b07a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 264
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1026,7 +1026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1160,7 +1160,7 @@ interactions:
                 - 4c5ddd12-3413-1cdc-2b2c-06a059fdc1e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1209,7 +1209,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1224,7 +1224,7 @@ interactions:
                 - b3e2d074-34cd-dc2d-4420-9778351a1f6d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1273,7 +1273,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1294,7 +1294,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1343,7 +1343,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1358,7 +1358,7 @@ interactions:
                 - 3c4a5f40-80ff-8eeb-786e-f4202b399ac5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1422,7 +1422,7 @@ interactions:
                 - 8e267ca2-0c17-0894-42a0-070639ccf7e8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1486,7 +1486,7 @@ interactions:
                 - c3ca3b10-3789-f8be-51f2-cc5c4c3ba8e9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1535,7 +1535,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1556,7 +1556,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1605,7 +1605,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1626,7 +1626,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1675,7 +1675,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1696,7 +1696,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1745,7 +1745,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1766,7 +1766,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1815,7 +1815,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1836,7 +1836,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount.full_config.yaml
+++ b/internal/provider/fixtures/resource_subaccount.full_config.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - bdae71d4-f265-48fc-6e8f-3541cf13b8ff
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - a7dde499-ad84-fed7-d1f1-3e67841fea85
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 5f6e4e8d-7129-9111-951a-51e84726d0c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 273
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - 682d03e9-69fc-6e5a-984c-27e07db94972
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - bc4db915-e29d-8752-324e-23030ec37110
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 0f44f96d-861a-eb12-3cb9-597ea2554f63
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -758,7 +758,7 @@ interactions:
                 - b7375d8c-a637-e032-b339-6216263b048a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -807,7 +807,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -892,7 +892,7 @@ interactions:
                 - a0baf52f-7a2c-c916-eade-979d6a0cd4fb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - 84ee7a69-fd6a-74ab-2256-2abae306fe3f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 306
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1026,7 +1026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1160,7 +1160,7 @@ interactions:
                 - 800260d0-a845-ff88-818f-fa6da95d9dd7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1209,7 +1209,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1224,7 +1224,7 @@ interactions:
                 - 611bcac7-e5cc-48cb-7f04-f7eb3ebad128
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1273,7 +1273,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1294,7 +1294,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1343,7 +1343,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1358,7 +1358,7 @@ interactions:
                 - 5ebfbedb-738a-47c6-7339-8e191aa4b651
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1422,7 +1422,7 @@ interactions:
                 - dffacf15-ba20-a7b5-f18c-7875d2689188
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1492,7 +1492,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1541,7 +1541,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1556,7 +1556,7 @@ interactions:
                 - b319dde8-f9b1-c5f1-39b7-dd2724240d8c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1605,7 +1605,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - 6ee4f3a3-484a-0e69-64aa-0b139bdbdd08
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1669,7 +1669,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1690,7 +1690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1739,7 +1739,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1760,7 +1760,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1809,7 +1809,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1830,7 +1830,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1879,7 +1879,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1900,7 +1900,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1949,7 +1949,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1970,7 +1970,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2019,7 +2019,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2040,7 +2040,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount.used_for_production.yaml
+++ b/internal/provider/fixtures/resource_subaccount.used_for_production.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ed22000c-9e43-bc15-cb7a-b5c49363ef1a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 0bcc9285-363f-1696-6f8c-570095f3c9de
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 67ad3523-3d51-e49b-9ac4-30ee15695f47
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 214
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - de8956d4-f392-3be7-1bea-6abb412585f4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 2923d03d-fb7b-cde1-ffb6-356d14530b16
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 5de0cc78-7d67-a030-46ae-afadbea4ae92
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -758,7 +758,7 @@ interactions:
                 - 3a1109d9-b293-9e60-5d63-f830d79025bc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -807,7 +807,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -892,7 +892,7 @@ interactions:
                 - cba6fd9e-5202-d076-2bf0-91397dea983b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - 1ce2cd98-e66a-651f-dfb6-818abe300874
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 264
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1026,7 +1026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1160,7 +1160,7 @@ interactions:
                 - 145df024-67b4-7411-5cfb-22f646785ba9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1209,7 +1209,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1224,7 +1224,7 @@ interactions:
                 - a96cb40c-bb5d-eb04-7172-78fffd178545
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1273,7 +1273,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1294,7 +1294,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1343,7 +1343,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1358,7 +1358,7 @@ interactions:
                 - bf33490e-e84a-fa64-ed70-0699f1e0aa1c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1422,7 +1422,7 @@ interactions:
                 - 3d4c3ae4-8881-ec28-07e7-a3d4a69550e2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1492,7 +1492,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1541,7 +1541,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1556,7 +1556,7 @@ interactions:
                 - 468e355c-eca5-1b16-d70e-eaae241e5fcd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1605,7 +1605,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - ab6a7820-b72f-d450-d376-64250cdd32f8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1669,7 +1669,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1690,7 +1690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1739,7 +1739,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1760,7 +1760,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1809,7 +1809,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1830,7 +1830,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1879,7 +1879,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1900,7 +1900,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1949,7 +1949,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1970,7 +1970,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount.yaml
+++ b/internal/provider/fixtures/resource_subaccount.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 54cf93f7-5271-8503-8b9e-16bbf0b88763
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - a682b958-2ff1-5250-bf20-6764a3f4feb8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 14880f87-0284-d2f4-e0ad-ba8b611607d3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 187
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - a084f7f3-1b7a-ce1a-ec71-894ffccdfb64
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - bed58dbe-ee11-19ea-e640-86e5c28ddb3c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -694,7 +694,7 @@ interactions:
                 - 8f7686ea-7360-209f-3eb6-486935539d19
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -743,7 +743,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -758,7 +758,7 @@ interactions:
                 - dc40e962-f792-3770-e7e1-a33f83dbe5c9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -807,7 +807,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -828,7 +828,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -877,7 +877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -892,7 +892,7 @@ interactions:
                 - d2e37902-9136-7a0a-56b6-cbebda6e80e7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -956,7 +956,7 @@ interactions:
                 - 31c87c19-1b08-d517-fcfa-1ada95fee8bc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1005,7 +1005,7 @@ interactions:
         content_length: 237
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1026,7 +1026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1075,7 +1075,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1096,7 +1096,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1145,7 +1145,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1160,7 +1160,7 @@ interactions:
                 - 3f2cb212-e669-d131-2256-b2b064fbd25d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1209,7 +1209,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1224,7 +1224,7 @@ interactions:
                 - 719933a7-1583-9380-e7dd-270cd97d71f6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1273,7 +1273,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1294,7 +1294,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1343,7 +1343,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1358,7 +1358,7 @@ interactions:
                 - 5cd51fc3-70e3-1927-537f-5984e3ce0c49
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1422,7 +1422,7 @@ interactions:
                 - c4bff548-17bc-981a-6776-d84609628047
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1471,7 +1471,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1492,7 +1492,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1541,7 +1541,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1556,7 +1556,7 @@ interactions:
                 - 70d0cdf7-5bbf-40bc-3b6e-34cc7a1887c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1605,7 +1605,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1620,7 +1620,7 @@ interactions:
                 - 2c38a67b-81a8-2b9d-7e6a-8274880b7a4a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1669,7 +1669,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1690,7 +1690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1739,7 +1739,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1760,7 +1760,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1809,7 +1809,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1830,7 +1830,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1879,7 +1879,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1900,7 +1900,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1949,7 +1949,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1970,7 +1970,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount_entitlement.amount_set.yaml
+++ b/internal/provider/fixtures/resource_subaccount_entitlement.amount_set.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 54fff1cf-23f0-84f1-6f37-cb5f13961659
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 6a876f1b-5b5b-8db9-070d-8ea1c45779b8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 5015d6e0-d2bf-7774-0a07-239b649e9914
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 161
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - 97165502-5ac8-3997-8a4f-5570a737760d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 9f79cdf7-0bb5-4a14-46e6-4d5c87ead3fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -700,7 +700,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -749,7 +749,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -770,7 +770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -834,7 +834,7 @@ interactions:
                 - 4825af34-af82-a3d2-ae5c-91fe2f68e730
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -883,7 +883,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -898,7 +898,7 @@ interactions:
                 - 4480866a-dd10-1fd7-e25b-c8f02fb64d09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -947,7 +947,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -968,7 +968,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1017,7 +1017,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1038,7 +1038,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1087,7 +1087,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1108,7 +1108,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1172,7 +1172,7 @@ interactions:
                 - 021632d3-c9d3-c52b-c140-c16ff46954dd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1221,7 +1221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1236,7 +1236,7 @@ interactions:
                 - 70c06b6b-211a-efc5-6570-c65a98222b33
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1285,7 +1285,7 @@ interactions:
         content_length: 161
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1306,7 +1306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -1355,7 +1355,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1376,7 +1376,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1425,7 +1425,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1446,7 +1446,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1495,7 +1495,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1516,7 +1516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount_entitlement.dir_hierarchy.yaml
+++ b/internal/provider/fixtures/resource_subaccount_entitlement.dir_hierarchy.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 285ddd77-b7a6-66a4-a4f3-f08f4241370b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 534c364c-1bb0-da19-c710-027b2db98141
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - a25e861c-d6ad-c0ed-1397-dfb63824f75e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -502,7 +502,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -551,7 +551,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -566,7 +566,7 @@ interactions:
                 - c8d82e0d-7c22-235b-557a-465b768ac06c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -615,7 +615,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - adb30577-9826-b003-91f6-b440e1ddbb68
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -700,7 +700,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -749,7 +749,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -770,7 +770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -840,7 +840,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -889,7 +889,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -910,7 +910,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -959,7 +959,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -974,7 +974,7 @@ interactions:
                 - 2805c343-56f8-0f88-276b-8716bc02a003
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1023,7 +1023,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1038,7 +1038,7 @@ interactions:
                 - eb738374-c1eb-65cd-5ea8-fc9793b7a9ab
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1087,7 +1087,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1108,7 +1108,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1178,7 +1178,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1227,7 +1227,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1248,7 +1248,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1297,7 +1297,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1318,7 +1318,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1367,7 +1367,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1382,7 +1382,7 @@ interactions:
                 - d089322c-8952-1a6f-e6b5-35ab61afd57a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1431,7 +1431,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1446,7 +1446,7 @@ interactions:
                 - 26fe2436-72e6-36d9-b6e1-94ce1f47f8a0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1495,7 +1495,7 @@ interactions:
         content_length: 139
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1516,7 +1516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -1565,7 +1565,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1586,7 +1586,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1635,7 +1635,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1656,7 +1656,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1705,7 +1705,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1726,7 +1726,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1775,7 +1775,7 @@ interactions:
         content_length: 127
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1796,7 +1796,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount_entitlement.no_amount.yaml
+++ b/internal/provider/fixtures/resource_subaccount_entitlement.no_amount.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 8071be9c-6c1e-15e7-4235-f0ad5bca848f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 21aaf4e7-56ce-1ecd-49db-922ce35ac9f8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - a1419db1-b6c1-e21d-1278-5adb6d649237
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 138
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - 601159c9-4937-f76c-5a2a-d7b2c8885bb6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - 67be96b4-b87a-70c7-5150-3f9ab1c504eb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -700,7 +700,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -749,7 +749,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -770,7 +770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -834,7 +834,7 @@ interactions:
                 - e7a9ff95-80d2-cd06-454e-67af0731aff3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -883,7 +883,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -898,7 +898,7 @@ interactions:
                 - fd7d5fa9-6397-c219-e095-7c174cab5dfd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -947,7 +947,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -968,7 +968,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1017,7 +1017,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1038,7 +1038,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1087,7 +1087,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1108,7 +1108,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1172,7 +1172,7 @@ interactions:
                 - 9f556b66-9e53-9ea2-d372-351a9e0ced7d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1221,7 +1221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1236,7 +1236,7 @@ interactions:
                 - bfb719cb-99d6-5245-8fb3-df00ee35e0f9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1285,7 +1285,7 @@ interactions:
         content_length: 139
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1306,7 +1306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -1355,7 +1355,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1376,7 +1376,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1425,7 +1425,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1446,7 +1446,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1495,7 +1495,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1516,7 +1516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount_entitlement.update.yaml
+++ b/internal/provider/fixtures/resource_subaccount_entitlement.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 97e3f3bd-4227-9a30-1c62-6d76feab9734
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - bdd241aa-59e4-1b21-5810-a7f90b4d573b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 5212077e-dbe2-2a02-02a1-d3b38a58971b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 161
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -271,7 +271,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -292,7 +292,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -341,7 +341,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -432,7 +432,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -481,7 +481,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -496,7 +496,7 @@ interactions:
                 - efa42715-7f16-d221-c399-4adbbb0b53a9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -545,7 +545,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -560,7 +560,7 @@ interactions:
                 - fa9f0fa6-9ff7-7390-fd3c-59dda589ab0e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -609,7 +609,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -630,7 +630,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -679,7 +679,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -700,7 +700,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -749,7 +749,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -770,7 +770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -819,7 +819,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -834,7 +834,7 @@ interactions:
                 - ec7331be-2db1-477d-628e-c5f6beff6c0e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -883,7 +883,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -898,7 +898,7 @@ interactions:
                 - 185508dc-1ef4-d33d-f1c0-58351e12f428
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -947,7 +947,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -968,7 +968,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1017,7 +1017,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1038,7 +1038,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1087,7 +1087,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1108,7 +1108,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1157,7 +1157,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1172,7 +1172,7 @@ interactions:
                 - 59babc49-d7eb-7660-b374-ef9d3a8e8e44
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1221,7 +1221,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1236,7 +1236,7 @@ interactions:
                 - aef971b2-798c-0aad-99f2-639b1ac3dff9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1285,7 +1285,7 @@ interactions:
         content_length: 161
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1306,7 +1306,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -1355,7 +1355,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1376,7 +1376,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1425,7 +1425,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1446,7 +1446,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1495,7 +1495,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1516,7 +1516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1565,7 +1565,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1580,7 +1580,7 @@ interactions:
                 - 4e34f13b-cffa-87b3-6476-4aa3058467c1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1629,7 +1629,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1644,7 +1644,7 @@ interactions:
                 - 09f74f66-5d87-aa45-e4d0-f88aabd6ca27
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1693,7 +1693,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1714,7 +1714,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1763,7 +1763,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1784,7 +1784,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1833,7 +1833,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1854,7 +1854,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -1903,7 +1903,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1918,7 +1918,7 @@ interactions:
                 - 9c533e72-f070-4b3c-93f3-90c97484d7da
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1967,7 +1967,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1982,7 +1982,7 @@ interactions:
                 - 9fd51658-9242-9919-d753-14dbe442ddc9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2031,7 +2031,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2052,7 +2052,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2101,7 +2101,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2122,7 +2122,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2171,7 +2171,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2192,7 +2192,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -2241,7 +2241,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2256,7 +2256,7 @@ interactions:
                 - 8b7c92fb-4eda-c2f7-a48d-996ac023bdcf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2305,7 +2305,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2320,7 +2320,7 @@ interactions:
                 - 42c97c3f-4d11-c29f-80f2-a569a41ef689
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2369,7 +2369,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2384,7 +2384,7 @@ interactions:
                 - 542f97fd-f9f2-93f9-ac27-562c0e53a053
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2433,7 +2433,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2454,7 +2454,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2503,7 +2503,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2524,7 +2524,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2573,7 +2573,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2594,7 +2594,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0
@@ -2643,7 +2643,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2658,7 +2658,7 @@ interactions:
                 - 67c7c072-e15b-d0ee-29b9-1a9b441e1f8f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2707,7 +2707,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2722,7 +2722,7 @@ interactions:
                 - d36e429a-b0a9-71c8-8d2f-bd89cbe02cbb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2771,7 +2771,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2786,7 +2786,7 @@ interactions:
                 - 33169008-c7c9-ee1d-6fb5-e655511d0b32
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2835,7 +2835,7 @@ interactions:
         content_length: 161
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2856,7 +2856,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -2905,7 +2905,7 @@ interactions:
         content_length: 70
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2926,7 +2926,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2975,7 +2975,7 @@ interactions:
         content_length: 108
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2996,7 +2996,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/directory?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/directory?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -3045,7 +3045,7 @@ interactions:
         content_length: 76
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -3066,7 +3066,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/entitlement?list
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/entitlement?list
         method: POST
       response:
         proto: HTTP/2.0

--- a/internal/provider/fixtures/resource_subaccount_environment_instance.update.yaml
+++ b/internal/provider/fixtures/resource_subaccount_environment_instance.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 285494ab-a5de-573e-eff8-227f28aac99f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - af35be60-a38f-9407-3766-8144797a39f0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - fa60fa4e-6ac4-4a8b-d57a-02ea7ed3efb4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 348
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 1a6db126-54aa-0721-bd40-47dcb4b7f29f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 1e689905-0fa7-82dd-9682-8da72759177b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 8b312c42-17f3-855f-bdad-8e40d2b63caa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - b07980d5-c165-0c64-b3b8-c38e052ef1ca
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - 0997a9a7-16b4-6610-cb6e-877ac223cd56
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - 0ffb3024-d28b-3fa3-6509-50ba21e65b2c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 274
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1473,7 +1473,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1488,7 +1488,7 @@ interactions:
                 - d1893ec7-6b58-60f1-1dac-fd239621b47c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1537,7 +1537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1552,7 +1552,7 @@ interactions:
                 - 1bccce3d-15e6-ede7-1739-e4fd53798e2b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1601,7 +1601,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1622,7 +1622,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1683,7 +1683,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1749,7 +1749,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1764,7 +1764,7 @@ interactions:
                 - d305559c-db3c-523a-c4ad-c18c13d65a4f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1813,7 +1813,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1828,7 +1828,7 @@ interactions:
                 - 140f3d48-4840-1b7a-12f3-5a9e6b44c392
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1877,7 +1877,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1898,7 +1898,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1959,7 +1959,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2025,7 +2025,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2040,7 +2040,7 @@ interactions:
                 - d1c1c755-37f9-508e-ab22-520774e116c2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2089,7 +2089,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2104,7 +2104,7 @@ interactions:
                 - 1d275824-6763-75d4-c41a-37e3d8ce16a4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2153,7 +2153,7 @@ interactions:
         content_length: 199
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2174,7 +2174,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -2235,7 +2235,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2301,7 +2301,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2322,7 +2322,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2383,7 +2383,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2449,7 +2449,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2464,7 +2464,7 @@ interactions:
                 - 7adf71e1-d552-0c78-bdbb-699a2d4cc33a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2513,7 +2513,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2528,7 +2528,7 @@ interactions:
                 - 117fb291-89d9-8e01-77da-6d9f49e15a2d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2577,7 +2577,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2598,7 +2598,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2659,7 +2659,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2725,7 +2725,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2740,7 +2740,7 @@ interactions:
                 - 6af3a5ac-36d6-fccc-56d2-9be1a2e906bf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2789,7 +2789,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2804,7 +2804,7 @@ interactions:
                 - d9528d5a-6331-b87a-0736-3b4753f0018c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2853,7 +2853,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2868,7 +2868,7 @@ interactions:
                 - 4020319e-7c17-2267-3252-02c12d4604f8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2917,7 +2917,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2938,7 +2938,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2999,7 +2999,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -3065,7 +3065,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -3086,7 +3086,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -3147,7 +3147,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_environment_instance.with_timeout.yaml
+++ b/internal/provider/fixtures/resource_subaccount_environment_instance.with_timeout.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e5c462bb-aaca-a272-40a3-94502383ad8f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - c4d5ee54-8b07-7f0b-5af8-ede66401b66a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 736164d2-98c0-8d4a-5b41-370a665f984e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 348
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 97503675-1c48-0579-56fb-b1b745545d11
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - ac8ad35c-ce66-67c0-7562-845433da02ea
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - fa982248-c7ee-6cc7-2cfc-2c49ec0f1c2b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - d02a8c01-5985-bc11-b751-5ccc66158ba9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - cca43877-3750-31b0-c945-88d58352e526
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - afbb8af7-4336-3f4f-24aa-d33511ef04a1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 282
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1473,7 +1473,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1488,7 +1488,7 @@ interactions:
                 - 3793cb6a-f7ab-cff2-3b02-2b56e3cb7161
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1537,7 +1537,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1552,7 +1552,7 @@ interactions:
                 - 2f3bfd4f-64eb-7b7e-5d41-b7f8c5734532
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1601,7 +1601,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1622,7 +1622,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1683,7 +1683,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1749,7 +1749,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1764,7 +1764,7 @@ interactions:
                 - 66476269-cd42-63ef-3546-6949529fa371
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1813,7 +1813,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1828,7 +1828,7 @@ interactions:
                 - bb158290-6f5c-2bd9-92b1-d61fbdef4324
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1877,7 +1877,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1892,7 +1892,7 @@ interactions:
                 - d81c54da-fbf7-1b8a-716d-f8ef6c5e08c6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1941,7 +1941,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1962,7 +1962,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2023,7 +2023,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2089,7 +2089,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2110,7 +2110,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2171,7 +2171,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_environment_instance.yaml
+++ b/internal/provider/fixtures/resource_subaccount_environment_instance.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e5798dc0-9d0d-85ad-22e3-a738c61e4fd0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - d5d6211a-47ab-dafd-7d18-bac398be93a6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 8fe5c713-1e57-0b79-c58c-358e8e3983f3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 348
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 439184d3-481e-abef-6c65-91cecca71c40
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - f98a3a3b-9c5c-d332-f055-6ce171766434
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - d023f68d-b478-4b23-2c22-d427129534bb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - a5bc59cb-d213-93e9-7d75-d3bddd0158fd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - 05341589-8dba-3806-6375-8221bf1af857
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - e56873d9-2522-818c-6ff5-40e9f900798e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/environment-instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/environment-instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 98522124-25cf-c79f-717a-6ccd0f6f92c9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 69ca488c-2b75-c07a-612b-dbfdf37235d5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - e527dd18-d897-b827-bfb8-d4936d51206f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -364,7 +364,7 @@ interactions:
                 - 48aa3e89-3590-2dc6-051f-bb65c87cc149
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -413,7 +413,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -428,7 +428,7 @@ interactions:
                 - 440706d2-c4e2-4620-cd4b-955a2e0abb3c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -477,7 +477,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -498,7 +498,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -559,7 +559,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -625,7 +625,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -640,7 +640,7 @@ interactions:
                 - d7261be1-5b0f-231b-f34e-823b3a1c205a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -689,7 +689,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -704,7 +704,7 @@ interactions:
                 - a28fa45d-5a6f-cc4d-c58d-6780dcb36bea
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -753,7 +753,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -768,7 +768,7 @@ interactions:
                 - e8082504-bf8d-949b-a65d-c4be1b817424
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -817,7 +817,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -832,7 +832,7 @@ interactions:
                 - 94148569-db17-877a-3172-1ca753f1d66d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -881,7 +881,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -902,7 +902,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -963,7 +963,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection.update.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.update.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 94e32575-8866-7199-ebf6-ebe5b9dcdafe
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - d23ec1ec-8dfa-3612-74ea-498a2c4cb6b9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 0cf08e7c-f705-7c08-fe32-981663765628
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -495,7 +495,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -516,7 +516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -577,7 +577,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -641,7 +641,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -656,7 +656,7 @@ interactions:
                 - 7d857036-a9b6-eed5-cd8d-db04a30cb407
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -705,7 +705,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -720,7 +720,7 @@ interactions:
                 - bede888a-3ecf-1cec-4526-8e0c9d2f5d9d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -769,7 +769,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -790,7 +790,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -851,7 +851,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -917,7 +917,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -932,7 +932,7 @@ interactions:
                 - e942d768-83cc-9e25-64a8-0b817aed7a53
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -981,7 +981,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -996,7 +996,7 @@ interactions:
                 - 1760bde6-3801-7291-2c80-e55bad84f107
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1045,7 +1045,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1066,7 +1066,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1193,7 +1193,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1208,7 +1208,7 @@ interactions:
                 - 3e993683-a10d-5ba5-a21d-53dac1221b48
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1257,7 +1257,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1272,7 +1272,7 @@ interactions:
                 - 5e5afccf-5b51-70e2-31a7-a61843107960
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1321,7 +1321,7 @@ interactions:
         content_length: 178
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1342,7 +1342,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1403,7 +1403,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1467,7 +1467,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1488,7 +1488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1549,7 +1549,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1613,7 +1613,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1634,7 +1634,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1695,7 +1695,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1759,7 +1759,7 @@ interactions:
         content_length: 245
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1780,7 +1780,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -1841,7 +1841,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1905,7 +1905,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1926,7 +1926,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1987,7 +1987,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2053,7 +2053,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2068,7 +2068,7 @@ interactions:
                 - bf09c1d8-f61d-44ab-4a4a-738c320c4f57
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2117,7 +2117,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2132,7 +2132,7 @@ interactions:
                 - b28218ca-71a6-379f-c10b-88412460c3b2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2181,7 +2181,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2202,7 +2202,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2263,7 +2263,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2329,7 +2329,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2344,7 +2344,7 @@ interactions:
                 - 686f98a9-dbc9-ea13-ae8c-ec2e31f2b939
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2393,7 +2393,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2408,7 +2408,7 @@ interactions:
                 - 5c81956f-d72f-6485-cf64-92438c2a9202
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2457,7 +2457,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2478,7 +2478,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2539,7 +2539,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2605,7 +2605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2620,7 +2620,7 @@ interactions:
                 - 45c913c0-39bc-444c-8314-85b21b353366
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2669,7 +2669,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2684,7 +2684,7 @@ interactions:
                 - 36df4adf-f830-12f0-7e59-2cf2ba4697f4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2733,7 +2733,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2754,7 +2754,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2815,7 +2815,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection.update_rm_desc.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.update_rm_desc.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 4481b6cb-739a-dd5e-f195-bb44232d4778
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - ddc7dcdd-832b-72cc-b5a9-a98d7e060ee8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - b978003c-2833-fc9b-0b7c-92f6bb913479
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -495,7 +495,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -516,7 +516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -577,7 +577,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -641,7 +641,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -656,7 +656,7 @@ interactions:
                 - d668a15b-cb4c-e6bf-9eec-2df900f0b413
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -705,7 +705,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -720,7 +720,7 @@ interactions:
                 - d7a80b0c-6bd6-1ea8-24f4-f0d32a466743
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -769,7 +769,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -790,7 +790,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -851,7 +851,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -917,7 +917,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -932,7 +932,7 @@ interactions:
                 - 039cf076-e05f-e653-a8ff-e6d15a4308d1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -981,7 +981,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -996,7 +996,7 @@ interactions:
                 - 77c451d1-5843-9957-a06a-5f8a24a80054
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1045,7 +1045,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1066,7 +1066,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1193,7 +1193,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1208,7 +1208,7 @@ interactions:
                 - e94e1711-f32f-9cac-53bc-afb96c328ca1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1257,7 +1257,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1272,7 +1272,7 @@ interactions:
                 - 35706252-4515-bb05-5aca-c11a72b6553d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1321,7 +1321,7 @@ interactions:
         content_length: 133
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1342,7 +1342,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1403,7 +1403,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1467,7 +1467,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1488,7 +1488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1549,7 +1549,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1613,7 +1613,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1634,7 +1634,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1695,7 +1695,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1759,7 +1759,7 @@ interactions:
         content_length: 245
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1780,7 +1780,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -1841,7 +1841,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1905,7 +1905,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1926,7 +1926,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1987,7 +1987,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2053,7 +2053,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2068,7 +2068,7 @@ interactions:
                 - 4b56d4e6-33a3-b215-40c6-34ec9e9cb7d4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2117,7 +2117,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2132,7 +2132,7 @@ interactions:
                 - c5576e9b-4eab-1fef-3d39-6fd761ef922b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2181,7 +2181,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2202,7 +2202,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2263,7 +2263,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2329,7 +2329,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2344,7 +2344,7 @@ interactions:
                 - 4166b7b2-7967-d866-976a-95d77e9055a3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2393,7 +2393,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2408,7 +2408,7 @@ interactions:
                 - d8970d5d-f6ee-90a7-77c8-691c6fa3613a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2457,7 +2457,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2478,7 +2478,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2539,7 +2539,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2605,7 +2605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2620,7 +2620,7 @@ interactions:
                 - a18a773b-7f18-ba48-db29-b90a042a84fb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2669,7 +2669,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2684,7 +2684,7 @@ interactions:
                 - a95fb1f4-526d-19da-ea88-46c4e953443f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2733,7 +2733,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2754,7 +2754,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2815,7 +2815,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection.update_wo_desc.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.update_wo_desc.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 9b7fd4c3-2d77-d95f-02be-bd4daf0a308f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - d6060348-8bde-630a-6a1f-09ff35680e13
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 3d537e7a-5472-2be4-efb5-104d25e3b64b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -495,7 +495,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -516,7 +516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -577,7 +577,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -641,7 +641,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -656,7 +656,7 @@ interactions:
                 - dfd02c9e-f8e5-ca25-caeb-ee4df7b8c7c0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -705,7 +705,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -720,7 +720,7 @@ interactions:
                 - d5204ac7-0418-5b8c-d4ec-29fa454fa13b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -769,7 +769,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -790,7 +790,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -851,7 +851,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -917,7 +917,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -932,7 +932,7 @@ interactions:
                 - 12ae45a3-f1c4-8c33-7521-ae001120624e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -981,7 +981,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -996,7 +996,7 @@ interactions:
                 - 5392fe6e-bf6c-642c-1d64-5442fc892cc9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1045,7 +1045,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1066,7 +1066,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1193,7 +1193,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1208,7 +1208,7 @@ interactions:
                 - 8fb3cfd1-38e1-e4eb-5cdd-1c5c212dbf63
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1257,7 +1257,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1272,7 +1272,7 @@ interactions:
                 - 4d1be487-12f9-ba53-9a75-dc62e48ee94b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1321,7 +1321,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1342,7 +1342,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1403,7 +1403,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1467,7 +1467,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1488,7 +1488,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1549,7 +1549,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1613,7 +1613,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1634,7 +1634,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
         method: POST
       response:
         proto: HTTP/2.0
@@ -1695,7 +1695,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?remove
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?remove
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1759,7 +1759,7 @@ interactions:
         content_length: 245
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1780,7 +1780,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -1841,7 +1841,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1905,7 +1905,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1926,7 +1926,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1987,7 +1987,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2053,7 +2053,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2068,7 +2068,7 @@ interactions:
                 - ce7a9cf2-c616-f7eb-bc7f-e5c813a7bc36
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2117,7 +2117,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2132,7 +2132,7 @@ interactions:
                 - 5c6447a7-b2c9-014d-d377-cdce4b3772b5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2181,7 +2181,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2202,7 +2202,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2263,7 +2263,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2329,7 +2329,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2344,7 +2344,7 @@ interactions:
                 - fe177d9b-4141-8905-ec39-cba8556a7cf3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2393,7 +2393,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2408,7 +2408,7 @@ interactions:
                 - c90a666c-20c5-a3db-868b-26ea57bf1c55
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2457,7 +2457,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2478,7 +2478,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2539,7 +2539,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2605,7 +2605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2620,7 +2620,7 @@ interactions:
                 - 90fef4d2-8c4c-06a9-2abe-165975dff593
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2669,7 +2669,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2684,7 +2684,7 @@ interactions:
                 - 59c7b400-4d1a-f648-8fa8-406d90c04fab
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2733,7 +2733,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2754,7 +2754,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2815,7 +2815,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 6e6956ec-af88-0d22-14d1-c376e8b9ca09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 13294e1a-89dc-07e4-8c09-c27b9cbbb1fe
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - add57673-eda8-9511-ee50-b492053c3538
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 170
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 235
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -495,7 +495,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -516,7 +516,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
         method: POST
       response:
         proto: HTTP/2.0
@@ -577,7 +577,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role?add
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role?add
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -641,7 +641,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -656,7 +656,7 @@ interactions:
                 - e763c27f-1bdb-d596-f48e-965da1e9ea0e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -705,7 +705,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -720,7 +720,7 @@ interactions:
                 - 5ad1c5f0-df97-f8df-af60-e44d437a0414
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -769,7 +769,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -790,7 +790,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -851,7 +851,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -917,7 +917,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -932,7 +932,7 @@ interactions:
                 - 9e59d8c4-25ed-5337-2882-1fe521a25d47
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -981,7 +981,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -996,7 +996,7 @@ interactions:
                 - c2cad7ec-dfc6-2128-e862-52a51e950af0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1045,7 +1045,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1066,7 +1066,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1127,7 +1127,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1193,7 +1193,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1208,7 +1208,7 @@ interactions:
                 - 58ae70aa-b0ef-3cc8-c07b-4791a723f4ee
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1257,7 +1257,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1272,7 +1272,7 @@ interactions:
                 - 237acc1f-4c9c-b91a-ff92-6ca2d36f089e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1321,7 +1321,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1342,7 +1342,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1403,7 +1403,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - d81c2566-ee46-b3f3-e4be-56d3b1797b7e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - dd133198-e10b-f1e4-d127-01e5b74cb95a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 53953246-f33f-1d6e-a8fd-6272734f3838
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 196
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -364,7 +364,7 @@ interactions:
                 - d69c0b7b-6081-aaa0-f6e5-c88faaceb8a7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -413,7 +413,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -428,7 +428,7 @@ interactions:
                 - 8de2eb91-b8c2-7236-914b-d41e186162a2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -477,7 +477,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -492,7 +492,7 @@ interactions:
                 - 08961898-1d9c-0229-ec9d-29ea21ea4455
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -541,7 +541,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -556,7 +556,7 @@ interactions:
                 - 7c811afd-386d-cfa9-7a5a-5b4f05f551e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -605,7 +605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -620,7 +620,7 @@ interactions:
                 - f6e9f77b-fd5d-96a2-59cd-6e08339d31a4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -669,7 +669,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -684,7 +684,7 @@ interactions:
                 - 425c7aba-55f0-a2b3-80fe-c7c76b1e3505
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -733,7 +733,7 @@ interactions:
         content_length: 167
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -754,7 +754,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0
@@ -815,7 +815,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment.with_origin.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment.with_origin.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ae9a03be-d394-8068-08ce-e426a12f1188
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 10560241-e206-d7ef-49d6-387f2d563fcf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 824c0bb0-6e80-b19c-b33e-8cd929dfd206
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 212
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -364,7 +364,7 @@ interactions:
                 - 47eb02a4-8c77-4983-27d9-ed6e3aaea29f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -413,7 +413,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -428,7 +428,7 @@ interactions:
                 - 99b0f053-7165-4235-133e-b70e25d947ab
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -477,7 +477,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -492,7 +492,7 @@ interactions:
                 - 26033f5e-75ea-7145-9ee6-47a19ec01a52
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -541,7 +541,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -556,7 +556,7 @@ interactions:
                 - c61ff770-1c8b-eed8-6da7-725c3c0bfe17
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -605,7 +605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -620,7 +620,7 @@ interactions:
                 - 776f60f8-e631-ef6c-bad8-7d8dad1d3f83
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -669,7 +669,7 @@ interactions:
         content_length: 183
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -690,7 +690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0
@@ -751,7 +751,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment.with_origin_and_attribute.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment.with_origin_and_attribute.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - a8d1577f-f375-13f8-a7fd-9a091d368251
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 39703f0e-20ff-f608-c52a-56773e768689
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - a76803dc-f433-273a-bdf1-83c6bf2feb66
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 249
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -347,7 +347,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - 2aba4a5e-aaab-9758-7e02-be841a6e886c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 41e88db2-5bea-b0bd-3c90-4090ad2d24e1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - 076a701d-f933-459d-bda0-b99fa4cc5ea2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 6ea2f1cc-1d69-fa40-3cd4-e56cf8392683
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - e7a099f2-0800-529c-7139-17bbc539063b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 220
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0
@@ -749,7 +749,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment.with_origin_and_group.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment.with_origin_and_group.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - ae763fc1-464d-e036-abda-9fad28d1a2ba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 2106eee4-d369-d945-78b6-e94e8f33b5c6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - a119e402-c690-bd6b-3a30-5c7759c91352
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 205
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -347,7 +347,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -362,7 +362,7 @@ interactions:
                 - d313a8ab-1fcb-73c3-63d9-085de8c16519
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -411,7 +411,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -426,7 +426,7 @@ interactions:
                 - 4e20f48a-aabc-dfe5-d7c7-a34d63ac496f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -475,7 +475,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -490,7 +490,7 @@ interactions:
                 - 74084d8d-5e3c-3c76-d857-b80efdc29939
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -539,7 +539,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -554,7 +554,7 @@ interactions:
                 - 7450ab9b-9fd3-0cda-03d5-d09be30880f1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -603,7 +603,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -618,7 +618,7 @@ interactions:
                 - 59e4eaca-f5a6-2b7f-c8d3-808ee84a0f7f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -667,7 +667,7 @@ interactions:
         content_length: 176
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -688,7 +688,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0
@@ -749,7 +749,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_role_collection_assignment.yaml
+++ b/internal/provider/fixtures/resource_subaccount_role_collection_assignment.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 5c014170-d88c-d825-e0df-a89c8913e0c4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 9c79a80e-9fb3-05ba-a480-8deaf238c795
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 1bd16435-c167-5571-c002-7499aaaf4b7c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 196
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?assign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?assign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -364,7 +364,7 @@ interactions:
                 - ccd21b3e-94b1-b602-ab31-b7422eb1a8e1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -413,7 +413,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -428,7 +428,7 @@ interactions:
                 - b1a12351-2f9b-14ad-55b9-f97c96beaa13
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -477,7 +477,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -492,7 +492,7 @@ interactions:
                 - 43cc6331-3e9d-ef9c-8c16-750fc897118c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -541,7 +541,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -556,7 +556,7 @@ interactions:
                 - 1f8ad9d3-5491-132e-4e37-c1b436c1abcf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -605,7 +605,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -620,7 +620,7 @@ interactions:
                 - c6439241-5fff-525e-3394-f54475ae21e8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -669,7 +669,7 @@ interactions:
         content_length: 167
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -690,7 +690,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
         method: POST
       response:
         proto: HTTP/2.0
@@ -751,7 +751,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/role-collection?unassign
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/role-collection?unassign
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_binding.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_binding.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 8b806ce2-6cb9-11e7-09f8-4c5ee675e14f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 145caa19-7579-d3c6-0af5-06a564f77fe9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - af382e57-b04f-530b-7230-7c353544d786
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 176
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - da45ae9b-c718-429f-f4ef-1b44c1038dd1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - b5cf6804-a17a-b5bd-203b-c135bed5088f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 21932472-9061-962d-9182-e7ed32f39db8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - aef3816e-0929-97a7-f59a-d19c8c701ab5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - e473a47d-3644-febf-bc45-68a78db110f4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -980,7 +980,7 @@ interactions:
                 - 91a7e6d8-f185-2a65-adbe-63ec77ff3703
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1029,7 +1029,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1050,7 +1050,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1111,7 +1111,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_binding.with_labels.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_binding.with_labels.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 86e95dc5-5ead-c8d5-1354-20130263b896
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - ec9d7238-5fbf-da56-3979-207677d79858
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - da65e06f-8b0a-7eb7-d4af-2f660af13647
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 207
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - ecc40d71-e4a8-9b25-64e5-fc1d3e8fea7f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 3316891a-501c-ff2e-7f00-0d6ff97293d4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - cf7deebe-d717-c69c-0377-e10726685c74
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - e0694626-bd06-7162-942b-0da6ce88d1ea
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - 27a136de-cca1-b336-b44d-d4348e8ddf1e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -986,7 +986,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1047,7 +1047,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1134,7 +1134,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1195,7 +1195,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_binding.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_binding.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - dfdbc481-ab6b-dea9-6e2c-ccfbf76409f5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - d31d5861-e1bd-ab9c-7f40-7698cee7f5cd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - a988a59c-74cc-5a1b-b7cb-aec2d109db45
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 176
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 64eb2bcc-7978-651b-2310-f0102a0739b5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 14a4e3ff-8026-5e46-19b6-209dfed345fa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 03b3e6a6-2b89-a802-6cf3-3e7e0b8836b7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 17ba8594-e3d4-48db-c37d-6ac8efcb1fb1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - 72ee3774-55c2-6f94-ebde-38cc62c29b7b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - ebaff20a-6376-be46-d6f5-7d75251150b8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 114
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/binding?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/binding?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_instance.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - f0dfe9a6-ddc2-8737-0557-ee10e120f336
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 58372b0b-1000-a5ea-a023-12fece656958
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 94b9af4a-be0f-2b06-b26b-e947ba264c51
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 143
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 8daebc23-592a-cfac-303e-9d1b019e4dfd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 5f7a9ed9-d4dc-b952-9a9c-08ce983e61b2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 68986aff-d978-a087-d863-7deed8d5dff2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 705e7092-becf-063a-84f1-99e405b6be46
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - f940b067-2376-80cc-cfdb-2648014ea8e8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -980,7 +980,7 @@ interactions:
                 - 2942354d-5df6-1d97-4d8f-09d69cddf63f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1029,7 +1029,7 @@ interactions:
         content_length: 131
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1050,7 +1050,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1111,7 +1111,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_instance.with_labels.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance.with_labels.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 31ad3d76-a8cb-a296-eb93-f170bdedac59
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - c28f72ef-c9b8-c0ed-8bdf-89ff3b86ee46
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - f69e4863-f5eb-cff4-6b9f-e7671b4f730b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 176
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 2aab4870-303c-ba25-93fb-8a52e1ebc9db
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 3733a2bb-9daf-b933-d172-b41eff5c27eb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - c99a88a5-7b62-fb53-ce55-0bf318917a04
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 79e2b7fa-9861-3781-33f1-bf07e8cf2673
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - f69bd248-5691-0fc4-4492-4edeff9f665c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - b05940ef-a946-e0cd-113b-b50071b45f0c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 221
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1473,7 +1473,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1494,7 +1494,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1555,7 +1555,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1621,7 +1621,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1636,7 +1636,7 @@ interactions:
                 - f34592b9-5953-893f-dccc-e975e8244b14
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1685,7 +1685,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1700,7 +1700,7 @@ interactions:
                 - e29ed723-e58d-2f04-78cc-3acde72b0878
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1749,7 +1749,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1770,7 +1770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1831,7 +1831,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1897,7 +1897,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1912,7 +1912,7 @@ interactions:
                 - 1ef84143-6b0a-64a4-80b4-e00ee977631e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1961,7 +1961,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1976,7 +1976,7 @@ interactions:
                 - db895590-3c3e-3215-471e-8e061489b673
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2025,7 +2025,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2046,7 +2046,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2107,7 +2107,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2173,7 +2173,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2188,7 +2188,7 @@ interactions:
                 - aab4ff1a-c268-e06d-c265-773d25bd54e8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2237,7 +2237,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2252,7 +2252,7 @@ interactions:
                 - 8e993036-9114-3831-668d-1487e6b8ad56
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2301,7 +2301,7 @@ interactions:
         content_length: 131
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2322,7 +2322,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2383,7 +2383,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2449,7 +2449,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2470,7 +2470,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2531,7 +2531,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_instance.with_labels_change.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance.with_labels_change.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - dd0cfa70-77f6-93f8-1f95-7325beb13a8f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 128d0eb4-91e5-06d7-4aea-23b0d37f4d76
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - b15a1586-d1e3-682b-eca4-23a61c3597f1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 176
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - fab0ae8d-5a05-bc66-0ae6-9b7d0f3412cb
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 00df6d63-d04b-0b27-087a-71ada0bd4f30
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 010cccc3-62d7-b481-7886-f21caab9bf5a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 50b90d78-7969-4dc5-1cd8-31b515d35e2e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - 65cfcb4e-a60e-6897-2c00-8742bd7457b7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - 03a2095c-143f-7deb-d6e9-1a698a605872
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 399
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1473,7 +1473,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1494,7 +1494,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1555,7 +1555,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1621,7 +1621,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1636,7 +1636,7 @@ interactions:
                 - c57c03c1-b064-c5d8-aad1-ff64d5f7f6dd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1685,7 +1685,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1700,7 +1700,7 @@ interactions:
                 - 45230cee-8ba4-9267-ca60-2da01561e4e4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1749,7 +1749,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1770,7 +1770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1831,7 +1831,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1897,7 +1897,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1912,7 +1912,7 @@ interactions:
                 - 7cc936ac-7de0-183d-5df8-d284366fd665
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1961,7 +1961,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1976,7 +1976,7 @@ interactions:
                 - 3593d76e-dc5c-2841-5023-c9c8c873a53d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2025,7 +2025,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2040,7 +2040,7 @@ interactions:
                 - 16ff1e1c-4774-2d51-008e-74f079870200
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2089,7 +2089,7 @@ interactions:
         content_length: 131
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2110,7 +2110,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2171,7 +2171,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2237,7 +2237,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2258,7 +2258,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2319,7 +2319,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_instance.with_parameters.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance.with_parameters.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - a6e9b1e0-31c2-cd11-1010-ea49a6ddc4aa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 39d1ea79-91c7-0a28-b074-6423a629cdb5
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - ca5660fc-ce86-b5c7-bbb2-9c27b03e6412
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 496
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 9fe0061f-2da7-58fd-4995-9060b28398ba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - de5fac76-b4c6-8d38-5daa-f95002b80f86
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - ab654b95-6724-c35d-c6f3-4207cc070cdf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 5c51c716-ef42-53da-da2f-a4df1ba759da
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - 298e9457-1e03-462a-6b87-ab37b0a59aab
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 131
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -986,7 +986,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1047,7 +1047,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1134,7 +1134,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1195,7 +1195,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_instance.wo_parameters.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance.wo_parameters.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - e883cab5-a7da-16f2-8301-fa4ea6d2536d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 602e87c8-d839-cd42-f06f-81e5ed203032
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - c274213d-2a1f-b7b0-eb19-5e4079b0afe9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 143
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 55c2f5d5-3fd8-0931-f808-39f449b93ae4
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 10ecde06-c5ab-efa6-6c72-0155e5123621
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 92a3ec8a-c293-36e9-89c9-d8df6aef3228
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 60f65ad4-8ef6-115a-1116-f4d0dce67908
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - c04a8186-82c0-e606-025a-921233934696
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - 60b19f76-39a5-167a-9373-949e248da02e
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 217
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1473,7 +1473,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1494,7 +1494,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1555,7 +1555,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1621,7 +1621,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1636,7 +1636,7 @@ interactions:
                 - fb4e283f-a66a-04bc-f3d7-b147c9311db6
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1685,7 +1685,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1700,7 +1700,7 @@ interactions:
                 - 07257a18-9859-ee44-7597-431d014be899
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1749,7 +1749,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1770,7 +1770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1831,7 +1831,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1897,7 +1897,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1912,7 +1912,7 @@ interactions:
                 - b4320c88-b0be-efcb-d4cd-625a407bb62a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1961,7 +1961,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1976,7 +1976,7 @@ interactions:
                 - 1df091c0-b5b1-a1eb-bc16-ed3686966a72
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2025,7 +2025,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2046,7 +2046,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2107,7 +2107,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2173,7 +2173,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2188,7 +2188,7 @@ interactions:
                 - 22a35942-f763-a0a1-d9c6-c59c00e50c09
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2237,7 +2237,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2252,7 +2252,7 @@ interactions:
                 - ef0fad12-401a-da1e-86bf-36bebcbf3c67
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2301,7 +2301,7 @@ interactions:
         content_length: 131
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2322,7 +2322,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2383,7 +2383,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2449,7 +2449,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2470,7 +2470,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2531,7 +2531,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_service_instance_with_timeouts.yaml
+++ b/internal/provider/fixtures/resource_subaccount_service_instance_with_timeouts.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 8ee65d19-84c4-98be-045f-d6536fb4a6b8
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - a45a7003-8bc4-850b-77b1-0b60e586856a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 20ceee83-5291-0bba-afaf-63c4134d07f7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 143
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?create
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - d0584e57-10c9-3a9a-1250-5f8dbe013dbf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 0ffa101e-906f-5ba0-15e9-9bf8a94f2214
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 7e16e9cd-ed3e-d2ee-08e7-6e2b1d9bd5d2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - b9994e9b-895b-c19d-ed71-21b7b6258c3a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - b95b9266-bdf4-7668-a4b5-2c66bdccef4b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - be0d67eb-390c-075a-4a56-77f898b2a72a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 217
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?update
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1473,7 +1473,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1494,7 +1494,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1555,7 +1555,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1621,7 +1621,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1636,7 +1636,7 @@ interactions:
                 - 9848ec9a-f193-bc68-7716-55be7bafae3d
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1685,7 +1685,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1700,7 +1700,7 @@ interactions:
                 - 97f23f63-2f6d-a339-5826-d27e9969aacf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1749,7 +1749,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1770,7 +1770,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1831,7 +1831,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1897,7 +1897,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1912,7 +1912,7 @@ interactions:
                 - 631d08e2-b18d-33d6-90ac-bc296af6dd19
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1961,7 +1961,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1976,7 +1976,7 @@ interactions:
                 - 4545f664-63f7-7ac9-11d7-d5f72ca892a2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2025,7 +2025,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2040,7 +2040,7 @@ interactions:
                 - 73a03677-3466-b454-2a35-505edba542c9
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2089,7 +2089,7 @@ interactions:
         content_length: 131
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2110,7 +2110,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2171,7 +2171,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?delete
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -2237,7 +2237,7 @@ interactions:
         content_length: 135
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2258,7 +2258,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -2319,7 +2319,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/services/instance?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/services/instance?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_subscription.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_subscription.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - a480346a-381e-4f7d-ca0d-fe1e6635f748
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 50605ae2-1cb0-4e5c-6ba3-f1b189232fba
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - e08c9fc7-476a-39fb-44a6-2396ba5953aa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?subscribe
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?subscribe
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?subscribe
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?subscribe
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 48e60a85-a8f2-b067-f884-484940b43e51
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 21722375-2b67-f4e6-1909-4eb774ed7953
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 697d8b2e-47e5-839a-ba51-9eb946a93741
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 48db39c7-9470-5e09-18ef-71dc89960b6b
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - 431cb85e-f660-34e7-6c59-807dae7164f7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -980,7 +980,7 @@ interactions:
                 - 8e922b9c-8019-866d-23f9-9ffe5e1affdf
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1029,7 +1029,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1050,7 +1050,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?unsubscribe
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?unsubscribe
         method: POST
       response:
         proto: HTTP/2.0
@@ -1111,7 +1111,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?unsubscribe
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?unsubscribe
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_subscription.yaml
+++ b/internal/provider/fixtures/resource_subaccount_subscription.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 6fcf8b0e-2d1d-8c04-bb71-3a4df8fc818f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - d079eb4a-1c31-94c8-506d-1137082c222c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 80374d7d-d1bc-e0d5-5ddf-62e74d04e102
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 142
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?subscribe
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?subscribe
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?subscribe
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?subscribe
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 1f64fe33-443a-5761-036e-f22020261085
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - 396d6a8c-611a-807a-03fa-b6dd3c6e1e12
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - c92e02ba-d6f4-9d15-cf42-d95f83da627a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 0a2152f6-b46c-2621-60d0-6df04607f526
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - 1ff26d31-d82c-49cd-2bd1-74c5baedb3b7
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 124
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - 39b3c1fe-d4d3-e496-46e7-4cd27593a91f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 115
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?unsubscribe
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?unsubscribe
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subaccount?unsubscribe
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subaccount?unsubscribe
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 116
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1346,7 +1346,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1407,7 +1407,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/accounts/subscription?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/accounts/subscription?get
             User-Agent:
                 - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - cd9cb444-4f8d-7fd2-bbed-7588f0f2e880
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - c9cde927-3fe3-3a16-429a-5c3b95f070fc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 5f94a65e-9a66-c33f-6e8e-6929eed90516
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 280
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 313
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 2e086988-11b1-e573-47db-afa4ac5398db
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - d733330a-ce0c-3e77-10f2-775947024165
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - b338f7e9-0c9e-3bf2-71fb-3c2598885108
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - 94d5468b-2900-38e8-cb04-220b17ca2787
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - e766878a-a735-055c-7f88-c387b0ff06de
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - 2fdf1fe8-8a79-3ea1-d309-b3872d287b08
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 330
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1340,7 +1340,7 @@ interactions:
                 - 9b35e141-0eca-4c1e-8927-f9d53b394c2a
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1389,7 +1389,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1404,7 +1404,7 @@ interactions:
                 - 76f6aa44-5cf0-c45c-9fbf-e417459190f3
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1453,7 +1453,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1474,7 +1474,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1535,7 +1535,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1601,7 +1601,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1616,7 +1616,7 @@ interactions:
                 - 2602213d-0402-6476-c03c-ea66d1221507
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1665,7 +1665,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1680,7 +1680,7 @@ interactions:
                 - 9df90287-c401-a7d0-bb0a-7326651a3643
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1729,7 +1729,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1750,7 +1750,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1811,7 +1811,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1877,7 +1877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1892,7 +1892,7 @@ interactions:
                 - d57b7734-6eaa-5b52-d242-99059804756f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1941,7 +1941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1956,7 +1956,7 @@ interactions:
                 - 225710b9-d00b-30a8-2287-11c7b0d70b19
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2005,7 +2005,7 @@ interactions:
         content_length: 112
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2026,7 +2026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2087,7 +2087,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.import_error.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 7e486ef2-3bfe-8614-f423-baed8a058f16
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 3eec4f22-336b-30d1-d2ba-276e6f4171fc
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 1cb7f15c-7c7e-69db-4f9e-dfb59f37fc8f
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 230
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 833b798b-cb29-1f86-b7a5-96896c2ff960
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - d95161fc-baaf-251d-0537-f91425743f62
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - 5c0f87cd-41aa-b0b1-c004-b20515080ea1
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - be302e2f-4d2f-310e-2f61-144617aa2a04
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -916,7 +916,7 @@ interactions:
                 - b7b7afb6-9a25-ad58-22bc-b1f419dceea2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,7 +965,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -980,7 +980,7 @@ interactions:
                 - 692d9d75-654e-9fef-22b9-04214ae6ff9c
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1029,7 +1029,7 @@ interactions:
         content_length: 112
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1050,7 +1050,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -1111,7 +1111,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -24,7 +24,7 @@ interactions:
                 - 1ab9cfc4-2912-2779-3c00-5338902122cd
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -73,7 +73,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -88,7 +88,7 @@ interactions:
                 - 05712539-cc9e-4ae1-c88f-a88d90a4e442
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -137,7 +137,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -152,7 +152,7 @@ interactions:
                 - 95901095-fd70-3df6-d4f0-2eb145a995fe
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -201,7 +201,7 @@ interactions:
         content_length: 125
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -222,7 +222,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
         method: POST
       response:
         proto: HTTP/2.0
@@ -283,7 +283,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?create
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -349,7 +349,7 @@ interactions:
         content_length: 230
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -370,7 +370,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -431,7 +431,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -497,7 +497,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -512,7 +512,7 @@ interactions:
                 - 9994d283-4bc3-1d25-9773-71ae3945c5ce
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -561,7 +561,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -576,7 +576,7 @@ interactions:
                 - d5931788-9830-46a7-9ed2-8b68a0207e85
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -625,7 +625,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -646,7 +646,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -707,7 +707,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -773,7 +773,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -788,7 +788,7 @@ interactions:
                 - cf3dc702-4a52-a0c3-9111-13685c19f241
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -837,7 +837,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -852,7 +852,7 @@ interactions:
                 - e6424136-9fd6-203b-a8d1-b4ef191a3053
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -901,7 +901,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -922,7 +922,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -983,7 +983,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1049,7 +1049,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1064,7 +1064,7 @@ interactions:
                 - 54cc55d2-817b-4749-ff97-db0b68dfe897
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1113,7 +1113,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1128,7 +1128,7 @@ interactions:
                 - 464ba4a1-8bbf-5836-5206-1bbbeeb822c0
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1177,7 +1177,7 @@ interactions:
         content_length: 421
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1198,7 +1198,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
         method: POST
       response:
         proto: HTTP/2.0
@@ -1259,7 +1259,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?update
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1325,7 +1325,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1340,7 +1340,7 @@ interactions:
                 - fe3b6e91-a89c-27e8-91f4-8ff0b6e67b19
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1389,7 +1389,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1404,7 +1404,7 @@ interactions:
                 - c9d61df1-6311-f4bb-4762-8e0484b472a2
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1453,7 +1453,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1474,7 +1474,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1535,7 +1535,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1601,7 +1601,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1616,7 +1616,7 @@ interactions:
                 - dcea243c-55c9-e215-b1c9-ea1d3a88cada
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1665,7 +1665,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1680,7 +1680,7 @@ interactions:
                 - b848f100-6c08-4751-562b-0171d9c8effa
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1729,7 +1729,7 @@ interactions:
         content_length: 92
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1750,7 +1750,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
         method: POST
       response:
         proto: HTTP/2.0
@@ -1811,7 +1811,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?get
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:
@@ -1877,7 +1877,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1892,7 +1892,7 @@ interactions:
                 - 28a35173-e725-dcaf-3ed7-3e9a7fe3d050
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -1941,7 +1941,7 @@ interactions:
         content_length: 118
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -1956,7 +1956,7 @@ interactions:
                 - 0d4a1703-3fd5-c8ae-fad9-bcbc4884ae37
             X-Cpcli-Format:
                 - json
-        url: https://cpcli.cf.sap.hana.ondemand.com/login/v2.49.0
+        url: https://canary.cli.btp.int.sap/login/v2.49.0
         method: POST
       response:
         proto: HTTP/2.0
@@ -2005,7 +2005,7 @@ interactions:
         content_length: 112
         transfer_encoding: []
         trailer: {}
-        host: cpcli.cf.sap.hana.ondemand.com
+        host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
@@ -2026,7 +2026,7 @@ interactions:
                 - redacted
             X-Cpcli-Subdomain:
                 - terraformintcanary
-        url: https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+        url: https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
         method: POST
       response:
         proto: HTTP/2.0
@@ -2087,7 +2087,7 @@ interactions:
             Content-Type:
                 - application/json
             Referer:
-                - https://cpcli.cf.sap.hana.ondemand.com/command/v2.49.0/security/trust?delete
+                - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
             User-Agent:
                 - Terraform/1.6.1 terraform-provider-btp/dev
             X-Correlationid:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,7 +45,7 @@ func (p *btpcliProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 		MarkdownDescription: `The Terraform provider for SAP BTP enables you to automate the provisioning, management, and configuration of resources on [SAP Business Technology Platform](https://account.hana.ondemand.com/). By leveraging this provider, you can simplify and streamline the deployment and maintenance of BTP services and applications.`,
 		Attributes: map[string]schema.Attribute{
 			"cli_server_url": schema.StringAttribute{
-				MarkdownDescription: "The URL of the BTP CLI server (e.g. `https://cpcli.cf.eu10.hana.ondemand.com`).",
+				MarkdownDescription: "The URL of the BTP CLI server (e.g. `https://cli.btp.cloud.sap`).",
 				Optional:            true, // TODO validate URL
 			},
 			"globalaccount": schema.StringAttribute{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -50,7 +50,7 @@ var redactedTestUser = TestUser{
 }
 
 func hclProviderFor(user TestUser) string {
-	return hclProvider("https://cpcli.cf.sap.hana.ondemand.com", user)
+	return hclProvider("https://canary.cli.btp.int.sap", user)
 }
 
 func hclProviderForCLIServerAt(cliServerURL string) string {


### PR DESCRIPTION
## Purpose
This changes the cli server URLs to the newly introduced shorter versions.
The new default btp CLI server url for productive use is: https://btp.cli.cloud.sap
The new btp CLI server url for testing is: https://canary.btp.cli.int.sap

Resolves #410

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [ ] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
