### PR TITLE
fix: renamed provider config parameter for consistency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,11 +37,11 @@ provider "btp" {
 
 - `cli_server_url` (String) The URL of the BTP CLI server (e.g. `https://cli.btp.cloud.sap`).
 - `idp` (String) The identity provider to be used for authentication (default: SAP ID service with origin `sap.default`).
-- `idp_url` (String) The URL of the identity provider to be used for authentication (only required for x509 auth).
 - `idtoken` (String, Sensitive) A valid id token. To be provided instead of 'username' and 'password'. This can also be sourced from the `BTP_IDTOKEN` environment variable. (SAP-internal usage only)
 - `password` (String, Sensitive) Your password. Note that two-factor authentication is not supported. This can also be sourced from the `BTP_PASSWORD` environment variable.
-- `tls_client_certificate` (String) PEM encoded certificate
-- `tls_client_key` (String) PEM encoded private key
+- `tls_client_certificate` (String) PEM encoded certificate (only required for x509 auth).
+- `tls_client_key` (String) PEM encoded private key (only required for x509 auth).
+- `tls_idp_url` (String) The URL of the identity provider to be used for authentication (only required for x509 auth).
 - `username` (String) Your user name, usually an e-mail address. This can also be sourced from the `BTP_USERNAME` environment variable.
 
 ## Get Started

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -327,7 +327,7 @@ provider "btp" {
 	username               = ""
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = "tlsClientCertificate"
-	idp_url                = "idpUrl"
+	tls_idp_url                = "idpUrl"
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the username`),
@@ -339,7 +339,7 @@ provider "btp" {
 	username               = "username"
 	tls_client_key         = ""
 	tls_client_certificate = "tlsClientCertificate"
-	idp_url                = "idpUrl"
+	tls_idp_url                = "idpUrl"
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the tls_client_key`),
@@ -351,7 +351,7 @@ provider "btp" {
 	username               = "username"
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = ""
-	idp_url                = "idpUrl"
+	tls_idp_url                = "idpUrl"
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the tls_client_certificate`),
@@ -363,10 +363,10 @@ provider "btp" {
 	username               = "username"
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = "tlsClientCertificate"
-	idp_url                = ""
+	tls_idp_url                = ""
 }
 data "btp_whoami" "me" {}`,
-					ExpectError: regexp.MustCompile(`empty value for the idp_url`),
+					ExpectError: regexp.MustCompile(`empty value for the tls_idp_url`),
 				},
 			},
 		})

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -327,7 +327,7 @@ provider "btp" {
 	username               = ""
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = "tlsClientCertificate"
-	tls_idp_url                = "idpUrl"
+	tls_idp_url            = "idpUrl"
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the username`),
@@ -339,7 +339,7 @@ provider "btp" {
 	username               = "username"
 	tls_client_key         = ""
 	tls_client_certificate = "tlsClientCertificate"
-	tls_idp_url                = "idpUrl"
+	tls_idp_url            = "idpUrl"
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the tls_client_key`),
@@ -351,7 +351,7 @@ provider "btp" {
 	username               = "username"
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = ""
-	tls_idp_url                = "idpUrl"
+	tls_idp_url            = "idpUrl"
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the tls_client_certificate`),
@@ -363,7 +363,7 @@ provider "btp" {
 	username               = "username"
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = "tlsClientCertificate"
-	tls_idp_url                = ""
+	tls_idp_url            = ""
 }
 data "btp_whoami" "me" {}`,
 					ExpectError: regexp.MustCompile(`empty value for the tls_idp_url`),


### PR DESCRIPTION
## Purpose

* Renaming of potentially confusing parameter for x509 auth in provider configuration 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[X] Other... Please describe: improvement of usability
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```
## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

Potential internal refactoring can be done as a follow-up, but not a obligatory action

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
