### PR TITLE
fix: adapt to command changes from XSUAA-3964

### DIFF
--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.complete.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - cd9cb444-4f8d-7fd2-bbed-7588f0f2e880
+                - 5db08fe3-70e9-6d2b-d78c-00912366d2bf
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:47 GMT
+                - Mon, 13 Nov 2023 13:13:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,18 +59,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6d571e6d-c6b8-406a-6bf2-2fbc1a7e52c7
+                - 114680f5-4884-433b-7924-7005a88f660d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 596.2504ms
+        duration: 1.201921541s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -83,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c9cde927-3fe3-3a16-429a-5c3b95f070fc
+                - ab0c0ded-d8d5-a8f8-9cf1-49c251590068
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:52 GMT
+                - Mon, 13 Nov 2023 13:13:11 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,18 +123,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 67a9d83d-9896-457b-7265-8d941dd33292
+                - 851e3163-e705-488b-69c2-469823fcbcfe
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 4.5822841s
+        duration: 358.962416ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -147,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 5f94a65e-9a66-c33f-6e8e-6929eed90516
+                - b43d1366-bd53-7446-8387-3254d8f8c06b
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -160,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:52 GMT
+                - Mon, 13 Nov 2023 13:13:12 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,12 +187,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - e2f84034-c3e2-4340-5337-bd8404e349a2
+                - 32671317-f217-4a4c-5d05-be70e71fa9a5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 351.2081ms
+        duration: 488.237209ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -211,9 +211,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 0630fb23-d85a-8436-0763-549e39122511
+                - b6e269b7-7c6a-0d2c-742b-1bb4548dcc47
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:01:53 GMT
+                - Mon, 13 Nov 2023 13:13:12 GMT
             Expires:
                 - "0"
             Location:
@@ -259,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 9f5d0bb6-2098-4efc-741c-17e9598a6887
+                - 9d59e9e3-d394-49b6-70ee-99f5cb831a41
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 239.2371ms
+        duration: 262.780833ms
     - id: 4
       request:
         proto: ""
@@ -285,9 +285,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 0630fb23-d85a-8436-0763-549e39122511
+                - b6e269b7-7c6a-0d2c-742b-1bb4548dcc47
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformint.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"b859710e-3a21-4285-bee9-316254fd5ff6","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/653217d19f5f8d4e4db47c91"},"neoAuthnWithOidc":false},"id":"770065ec-b183-40c6-a62a-592c71c3e83b","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1697781714300,"last_modified":1697781714300,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformint.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"fb1cb55a-34a9-4993-88ec-8fdad1201171","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/655220e99944a9073b357baf"},"neoAuthnWithOidc":false},"id":"692acdda-c09d-491f-a85f-e8269a7ad779","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":0,"created":1699881193819,"last_modified":1699881193819,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:54 GMT
+                - Mon, 13 Nov 2023 13:13:13 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - bebf989f-36c5-49a5-5c3a-f4b6f2b7b949
+                - 858ffa0f-1043-4973-4a17-df8e481d930f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.1788583s
+        duration: 1.016630917s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2ba7be9a-96fb-1cdb-281c-12e635b3a1af
+                - 7e1692e7-4f8e-ca36-106d-d704609c8a6c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -387,7 +387,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:01:54 GMT
+                - Mon, 13 Nov 2023 13:13:14 GMT
             Expires:
                 - "0"
             Location:
@@ -407,12 +407,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 3860159a-1d37-4014-47f8-75ae02101270
+                - e9b2997c-35e4-46c1-53dd-03d1de16e2ae
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 119.8892ms
+        duration: 348.82725ms
     - id: 6
       request:
         proto: ""
@@ -433,9 +433,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2ba7be9a-96fb-1cdb-281c-12e635b3a1af
+                - 7e1692e7-4f8e-ca36-106d-d704609c8a6c
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -463,7 +463,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:55 GMT
+                - Mon, 13 Nov 2023 13:13:14 GMT
             Expires:
                 - "0"
             Pragma:
@@ -483,18 +483,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f5b4c162-b18b-4583-74eb-bdc2f0257491
+                - 57e74574-880a-4c8c-71ae-a6f11f63ebf4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 584.5992ms
+        duration: 717.756042ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -507,9 +507,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2e086988-11b1-e573-47db-afa4ac5398db
+                - db42545f-8347-e300-a0ad-fcbc18eccdeb
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -520,18 +520,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:55 GMT
+                - Mon, 13 Nov 2023 13:13:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -547,18 +547,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fe805971-fb76-4571-4fa8-788ef8c86a8e
+                - e84c302a-c8e2-43a5-6a0d-7b739078da24
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 349.4522ms
+        duration: 593.866667ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -571,9 +571,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - d733330a-ce0c-3e77-10f2-775947024165
+                - bc11a213-3265-efbd-6947-950e4a48345d
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -584,18 +584,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:55 GMT
+                - Mon, 13 Nov 2023 13:13:15 GMT
             Expires:
                 - "0"
             Pragma:
@@ -611,12 +611,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f568e91e-192b-4e04-7710-c3ef3cae1615
+                - 32e1b365-0fb9-4af8-6e7a-d4318c7d2525
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 288.3142ms
+        duration: 222.47ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -635,9 +635,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 36db39ca-3df5-c023-5b89-8c4ca79d44b7
+                - 97d626ff-a5fe-16f8-3762-9113dcb4d629
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -663,7 +663,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:01:56 GMT
+                - Mon, 13 Nov 2023 13:13:16 GMT
             Expires:
                 - "0"
             Location:
@@ -683,12 +683,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7d350e7b-f330-47a4-7f9f-d8bce8fbc237
+                - 0044209e-8be4-44ec-5763-49f28c3c4483
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 135.3568ms
+        duration: 222.782375ms
     - id: 10
       request:
         proto: ""
@@ -709,9 +709,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 36db39ca-3df5-c023-5b89-8c4ca79d44b7
+                - 97d626ff-a5fe-16f8-3762-9113dcb4d629
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -739,7 +739,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:56 GMT
+                - Mon, 13 Nov 2023 13:13:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -759,18 +759,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b18998a9-5d16-43a3-492a-1ae78cfc0356
+                - 49ce63d5-c5d9-4118-4c81-46e5659e9635
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 212.3679ms
+        duration: 237.288542ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -783,9 +783,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - b338f7e9-0c9e-3bf2-71fb-3c2598885108
+                - 703b861a-b9f6-8adf-0dbe-ce648f009136
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -796,18 +796,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:56 GMT
+                - Mon, 13 Nov 2023 13:13:16 GMT
             Expires:
                 - "0"
             Pragma:
@@ -823,18 +823,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 26ea9396-34bf-4d74-41c8-140ad996ad0d
+                - 2d47de12-286b-4076-5b1c-a56286eccdce
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 351.3612ms
+        duration: 284.213375ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -847,9 +847,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 94d5468b-2900-38e8-cb04-220b17ca2787
+                - 089d0271-13b9-39ef-4291-a2c925efee22
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -860,18 +860,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:57 GMT
+                - Mon, 13 Nov 2023 13:13:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -887,12 +887,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c3874bda-0b0d-4028-4384-2da5a96f38da
+                - e2e61654-a2cf-422c-4595-a638ca159bd9
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 300.9133ms
+        duration: 489.42025ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -911,9 +911,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c838e8df-12fb-78c7-f0b7-f8c0af30b7c6
+                - a2ad04dc-587f-c7b1-68ad-feaddc6a3bfe
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -939,7 +939,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:01:57 GMT
+                - Mon, 13 Nov 2023 13:13:17 GMT
             Expires:
                 - "0"
             Location:
@@ -959,12 +959,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 398690f5-55dc-47ff-5727-62a72f03baff
+                - 9462d347-8d17-419d-7591-e3916d2e77b4
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 173.9788ms
+        duration: 124.954167ms
     - id: 14
       request:
         proto: ""
@@ -985,9 +985,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c838e8df-12fb-78c7-f0b7-f8c0af30b7c6
+                - a2ad04dc-587f-c7b1-68ad-feaddc6a3bfe
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1015,7 +1015,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:57 GMT
+                - Mon, 13 Nov 2023 13:13:17 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1035,18 +1035,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 433ee085-92d3-4993-42fa-9ecf9648dae1
+                - 245a5583-f007-4c05-521b-599c1c544d98
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 108.6923ms
+        duration: 204.486667ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1059,9 +1059,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - e766878a-a735-055c-7f88-c387b0ff06de
+                - 0f56f838-df56-8f4b-c8a9-97fb8f818e95
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1072,18 +1072,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:57 GMT
+                - Mon, 13 Nov 2023 13:13:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1099,18 +1099,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 62346dbf-cbae-4435-559a-2dd97a530e07
+                - 5583fcaa-6d03-4384-7074-6416b5a1b39d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 278.6775ms
+        duration: 367.502458ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1123,9 +1123,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2fdf1fe8-8a79-3ea1-d309-b3872d287b08
+                - 15b928ae-6d4c-55c7-a874-d4f84ea5d0ab
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1136,18 +1136,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:58 GMT
+                - Mon, 13 Nov 2023 13:13:18 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1163,33 +1163,33 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 78f0adc2-0c52-4d9c-45de-89cbbc76d958
+                - e8c751ce-ed3c-429e-65ec-5ebba6e730ae
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 296.9486ms
+        duration: 420.376375ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 330
+        content_length: 379
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - f7d83fd0-00f3-f9f0-88d7-ec405c71bfa3
+                - 3d49942f-04a7-fe23-a6bc-fd256cf89bdb
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1215,7 +1215,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:01:58 GMT
+                - Mon, 13 Nov 2023 13:13:18 GMT
             Expires:
                 - "0"
             Location:
@@ -1235,25 +1235,25 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 4b7e294a-2637-4b5c-4ab3-b52f3d5dc972
+                - 32238045-fef8-4405-72d6-9d93c569bb69
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 98.6694ms
+        duration: 202.2765ms
     - id: 18
       request:
         proto: ""
         proto_major: 0
         proto_minor: 0
-        content_length: 330
+        content_length: 379
         transfer_encoding: []
         trailer: {}
         host: ""
         remote_addr: ""
         request_uri: ""
         body: |
-            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
+            {"paramValues":{"description":"Description for terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","iasTenantUrl":"terraformint.accounts400.ondemand.com","linkText":"custom link text","originKey":"sap.custom","refreshTrust":"true","shadowUsers":"true","status":"active","subaccount":"ef23ace8-6ade-4d78-9c1f-8df729548bbf","userLogon":"true"}}
         form: {}
         headers:
             Content-Type:
@@ -1261,9 +1261,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - f7d83fd0-00f3-f9f0-88d7-ec405c71bfa3
+                - 3d49942f-04a7-fe23-a6bc-fd256cf89bdb
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1284,14 +1284,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:58 GMT
+                - Mon, 13 Nov 2023 13:13:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1311,18 +1311,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 595ae9de-2429-45c1-5adf-cdf38eeca010
+                - fd38e5f6-d45d-46ef-6978-24eb3f96860a
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 425.5851ms
+        duration: 536.455125ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1335,9 +1335,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 9b35e141-0eca-4c1e-8927-f9d53b394c2a
+                - 72a75b49-6949-03cf-018c-ee5b2fdda485
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1348,18 +1348,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:59 GMT
+                - Mon, 13 Nov 2023 13:13:19 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1375,18 +1375,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - c949d3d6-d24f-486e-5a76-d15f71df1e31
+                - 31d10ac6-680b-4660-5e55-d0394ad73db3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 283.744ms
+        duration: 365.988542ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1399,9 +1399,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 76f6aa44-5cf0-c45c-9fbf-e417459190f3
+                - 6fae513e-aa15-b5bd-076e-236a5e5a42c2
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1412,18 +1412,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:01:59 GMT
+                - Mon, 13 Nov 2023 13:13:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1439,12 +1439,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a332f4db-f06c-4941-4fa8-f6db098de84f
+                - 3cf81e7d-a098-448f-48c9-1876fb9ab2c5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 257.0575ms
+        duration: 214.382834ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1463,9 +1463,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - b138dd7f-63f4-5cf0-9733-dcee02fd2da4
+                - d4c4ddeb-5e6a-bbfa-d0fc-8ced61cf08a7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1491,7 +1491,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:01:59 GMT
+                - Mon, 13 Nov 2023 13:13:20 GMT
             Expires:
                 - "0"
             Location:
@@ -1511,12 +1511,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - b615f09e-665a-4535-67d4-031fa0dc0d25
+                - 4596aa17-3486-4ff5-6857-6ecb31ade9be
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 119.3024ms
+        duration: 288.231375ms
     - id: 22
       request:
         proto: ""
@@ -1537,9 +1537,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - b138dd7f-63f4-5cf0-9733-dcee02fd2da4
+                - d4c4ddeb-5e6a-bbfa-d0fc-8ced61cf08a7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1560,14 +1560,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:00 GMT
+                - Mon, 13 Nov 2023 13:13:20 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1587,18 +1587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 15a83ccc-d7d4-4d3c-6956-98a0516566bd
+                - adbb21dc-67bb-45b8-4a5a-0efa37e61cd1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 265.1019ms
+        duration: 408.124917ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1611,9 +1611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2602213d-0402-6476-c03c-ea66d1221507
+                - 6b91a473-ce2f-b79a-b007-aeb77da0088a
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1624,18 +1624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:00 GMT
+                - Mon, 13 Nov 2023 13:13:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1651,18 +1651,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3be16e1a-bf24-4640-7188-a7b92ba5c5bb
+                - 75f8b4b3-9406-4e45-6ed3-20c34fb5736d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 311.7807ms
+        duration: 332.487375ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1675,9 +1675,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 9df90287-c401-a7d0-bb0a-7326651a3643
+                - 2c04ecf9-9914-3d51-fb7e-a226805f0b8f
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1688,18 +1688,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:01 GMT
+                - Mon, 13 Nov 2023 13:13:21 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1715,12 +1715,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - fe5cc505-c1d9-4b50-6a8b-7eef85f32904
+                - aafac817-1054-45b4-65df-5e759120be66
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 370.9786ms
+        duration: 353.765667ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1739,9 +1739,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 346a4a12-f783-ec4f-f279-25d5d65b8a10
+                - 9bd045e4-b1d6-6708-53fc-d757a9d484b2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1767,7 +1767,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:01 GMT
+                - Mon, 13 Nov 2023 13:13:21 GMT
             Expires:
                 - "0"
             Location:
@@ -1787,12 +1787,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5d130e05-df3d-4087-6c37-5c69f8abb081
+                - e93874f4-b4f7-4751-7a82-3fb78c19eaa0
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 141.1345ms
+        duration: 123.263459ms
     - id: 26
       request:
         proto: ""
@@ -1813,9 +1813,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 346a4a12-f783-ec4f-f279-25d5d65b8a10
+                - 9bd045e4-b1d6-6708-53fc-d757a9d484b2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1836,14 +1836,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":null,"linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
+        body: '{"name":"Custom IAS tenant for apps","originKey":"sap.custom","typeOfTrust":"Application","status":"active","description":"Description for terraformint.accounts400.ondemand.com","identityProvider":"terraformint.accounts400.ondemand.com","domain":"terraformint.accounts400.ondemand.com","linkTextForUserLogon":"custom link text","availableForUserLogon":"true","createShadowUsersDuringLogon":"true","sapBtpCli":"terraformint","protocol":"OpenID Connect","readOnly":false}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:01 GMT
+                - Mon, 13 Nov 2023 13:13:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1863,18 +1863,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9aef3efc-fd0f-4aec-63b7-aea3b5f91f8d
+                - f462f0c5-47dd-4a74-7df3-f242901b305f
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 178.646ms
+        duration: 361.880708ms
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1887,9 +1887,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - d57b7734-6eaa-5b52-d242-99059804756f
+                - b2e8a952-e5ce-fcc7-e1d9-db7ba9ceeeed
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1900,18 +1900,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:01 GMT
+                - Mon, 13 Nov 2023 13:13:22 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1927,18 +1927,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 264fdbbd-63fb-4b5e-415f-c2b77a006660
+                - 0b21a144-5e90-4b55-7d31-c33823b85b03
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 293.2371ms
+        duration: 329.507334ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1951,9 +1951,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 225710b9-d00b-30a8-2287-11c7b0d70b19
+                - d4d4e491-8ac1-3dc8-68c1-a1c374c06a34
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1964,18 +1964,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:02 GMT
+                - Mon, 13 Nov 2023 13:13:23 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1991,12 +1991,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d5d1ada8-015a-4e13-6e3e-bfbb8cb7aa3a
+                - f055c39a-7284-4fcf-4ac8-886719cfa116
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 295.8864ms
+        duration: 356.263208ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -2015,9 +2015,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2f56fa71-9548-e132-728a-1308d13ef2a7
+                - d3d9e249-4923-b00d-f3a7-6c0f12d64c08
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2043,7 +2043,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:02 GMT
+                - Mon, 13 Nov 2023 13:13:23 GMT
             Expires:
                 - "0"
             Location:
@@ -2063,12 +2063,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 2f848341-6208-412d-4fc2-73afcf1dc748
+                - 7a21c1b7-93e5-42e3-710d-71ac9bb14eb2
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 116.8082ms
+        duration: 209.55275ms
     - id: 30
       request:
         proto: ""
@@ -2089,9 +2089,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 2f56fa71-9548-e132-728a-1308d13ef2a7
+                - d3d9e249-4923-b00d-f3a7-6c0f12d64c08
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2112,14 +2112,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"b859710e-3a21-4285-bee9-316254fd5ff6","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/653217d19f5f8d4e4db47c91"},"neoAuthnWithOidc":false},"id":"770065ec-b183-40c6-a62a-592c71c3e83b","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1697781714300,"last_modified":1697781718851,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformint.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"fb1cb55a-34a9-4993-88ec-8fdad1201171","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/655220e99944a9073b357baf"},"neoAuthnWithOidc":false},"id":"692acdda-c09d-491f-a85f-e8269a7ad779","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1699881193819,"last_modified":1699881199424,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:03 GMT
+                - Mon, 13 Nov 2023 13:13:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2139,9 +2139,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9c567e42-cd5c-4f4c-58b9-1c9af7c8d73b
+                - d5926cad-f836-4a4b-6fcd-1e0981b4a610
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.0018394s
+        duration: 871.566083ms

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.error_missing_identityprovider.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.error_missing_identityprovider.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.2 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 3930a1a4-4118-bf53-3662-2aae0993736a
+                - 94a34676-7fde-66f4-b9b4-044c87a2ab3b
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Oct 2023 13:59:16 GMT
+                - Mon, 13 Nov 2023 13:13:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,18 +59,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 84e0f77f-8011-464d-5dc7-1088fca1f527
+                - 07a6ae82-0686-4157-4710-d593edda0404
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 311.6576ms
+        duration: 240.612ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -83,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.2 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 59fbe020-f927-0c04-9886-8210f975955c
+                - c667f4ed-76ac-137c-2f15-8fb10fa1d63d
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Oct 2023 13:59:17 GMT
+                - Mon, 13 Nov 2023 13:13:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,18 +123,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5ec6a141-b6db-4525-4135-ba60749f4ff8
+                - 04a7c715-e787-4c95-5a98-11b689b6eb47
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 294.5529ms
+        duration: 224.610417ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -147,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.2 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 3326c8af-3eb7-dca4-837e-95284d49701b
+                - 256ed5b1-7877-1d80-895c-9e0085ae8066
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -160,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Thu, 26 Oct 2023 13:59:17 GMT
+                - Mon, 13 Nov 2023 13:13:42 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,9 +187,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0bc1291b-a5a4-4f16-4b22-80f0663ec066
+                - f9f77b54-d85b-4472-7406-1e1b5838be2d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 394.2156ms
+        duration: 212.531125ms

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.import_error.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.import_error.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 7e486ef2-3bfe-8614-f423-baed8a058f16
+                - 2c3a8719-8f9f-b4d1-9884-ab3f2dd4ef8c
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:34 GMT
+                - Mon, 13 Nov 2023 13:13:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,18 +59,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b861269a-a3c4-48d4-6fe6-60aaf40b3bad
+                - dd72374a-3011-4cb8-463c-246d5cd686c1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 4.8222711s
+        duration: 246.973875ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -83,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 3eec4f22-336b-30d1-d2ba-276e6f4171fc
+                - 491d7862-7803-89a4-7efb-e8664f3b4f51
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:34 GMT
+                - Mon, 13 Nov 2023 13:13:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,18 +123,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - ab7ba368-b34a-4e36-4155-aedf2c9385b6
+                - 54595ab7-3503-494e-7afb-c9acab28a5d3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 279.5309ms
+        duration: 219.2385ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -147,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 1cb7f15c-7c7e-69db-4f9e-dfb59f37fc8f
+                - 54c162de-44a6-b91b-603f-585e64073726
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -160,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:35 GMT
+                - Mon, 13 Nov 2023 13:13:36 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,12 +187,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d486f31b-543a-41fe-66b6-1287d3748381
+                - edacf14f-b05e-4578-5901-64cf5a954607
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 332.1292ms
+        duration: 214.523917ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -211,9 +211,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 844cb435-8a85-ce83-acbd-8bbdc37bd1ad
+                - f2f6e02c-4443-014a-9680-dc841f75c94d
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:35 GMT
+                - Mon, 13 Nov 2023 13:13:37 GMT
             Expires:
                 - "0"
             Location:
@@ -259,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - bcd86bf8-b8af-40ae-57d3-5bc82b0afc3a
+                - 02b3f7c9-933c-482d-4b72-b392b818a8c5
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 95.4733ms
+        duration: 122.670167ms
     - id: 4
       request:
         proto: ""
@@ -285,9 +285,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 844cb435-8a85-ce83-acbd-8bbdc37bd1ad
+                - f2f6e02c-4443-014a-9680-dc841f75c94d
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"aa8a7ee5-3c04-4b7f-89fe-53ee2b1ee9c0","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/653217fbde8a6368c4e16ad6"},"neoAuthnWithOidc":false},"id":"08e0f612-9404-4309-86f7-cd4afcab7fa0","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1697781756407,"last_modified":1697781756407,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"5db94607-511d-490a-be7e-1d13ad9ab9f3","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/655221019944a9073b357bca"},"neoAuthnWithOidc":false},"id":"6dabd679-d194-453b-89c2-646b5be26d2f","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1699881217773,"last_modified":1699881217773,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:36 GMT
+                - Mon, 13 Nov 2023 13:13:37 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 4eea8955-45b7-4287-744e-362261a79139
+                - 4c07b952-24d2-45dc-4211-341f8b0edf9d
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 860.0434ms
+        duration: 764.545708ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - a2851dbf-64a0-525a-f166-2d2d28727b3e
+                - 2a13aa3c-2a51-0553-312c-b5aa1127c752
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -387,7 +387,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:36 GMT
+                - Mon, 13 Nov 2023 13:13:37 GMT
             Expires:
                 - "0"
             Location:
@@ -407,12 +407,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 891f473b-4e85-456e-7809-1e59982fdeb1
+                - e2f5d274-c55d-4b93-7c57-23eb5adf294e
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 131.9071ms
+        duration: 104.224459ms
     - id: 6
       request:
         proto: ""
@@ -433,9 +433,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - a2851dbf-64a0-525a-f166-2d2d28727b3e
+                - 2a13aa3c-2a51-0553-312c-b5aa1127c752
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -463,7 +463,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:36 GMT
+                - Mon, 13 Nov 2023 13:13:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -483,18 +483,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 9132e57c-0d4c-4a33-5d11-6d2fbbaaa4dc
+                - b9060411-5667-49cb-72a8-5d47c7e16a64
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 260.4232ms
+        duration: 391.730208ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -507,9 +507,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 833b798b-cb29-1f86-b7a5-96896c2ff960
+                - d7295583-28f2-9813-4385-c83ca29ecbd8
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -520,18 +520,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:37 GMT
+                - Mon, 13 Nov 2023 13:13:38 GMT
             Expires:
                 - "0"
             Pragma:
@@ -547,18 +547,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 5367354e-a13c-41be-67fb-009b3925712a
+                - 2bee7caa-e371-49dd-6fad-7b49c6e7e597
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 313.0012ms
+        duration: 221.809625ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -571,9 +571,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - d95161fc-baaf-251d-0537-f91425743f62
+                - 9c051bcc-f3a0-6b5b-c23d-97610bd3d3f7
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -584,18 +584,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:37 GMT
+                - Mon, 13 Nov 2023 13:13:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -611,12 +611,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 40787820-945f-4a09-5486-2a594091e321
+                - 720da011-c1c6-4bc4-5a9f-6af2b1a21723
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 262.3755ms
+        duration: 296.660083ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -635,9 +635,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 306fc843-8859-2275-5e9d-47d205cc4e49
+                - cd68ad49-ead7-6313-d8de-05fd07189771
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -663,7 +663,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:37 GMT
+                - Mon, 13 Nov 2023 13:13:39 GMT
             Expires:
                 - "0"
             Location:
@@ -683,12 +683,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 8885095e-308a-4dbe-7f63-2ce8e8aae5a4
+                - da9b0029-07fb-49b0-57d5-999fd99f0837
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 99.6321ms
+        duration: 128.415958ms
     - id: 10
       request:
         proto: ""
@@ -709,9 +709,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 306fc843-8859-2275-5e9d-47d205cc4e49
+                - cd68ad49-ead7-6313-d8de-05fd07189771
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -739,7 +739,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:38 GMT
+                - Mon, 13 Nov 2023 13:13:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -759,18 +759,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2b7083aa-d452-417b-7851-639479608655
+                - 6efc039e-1a3b-4271-7013-4994e5f99812
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 259.2913ms
+        duration: 307.315ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -783,9 +783,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 5c0f87cd-41aa-b0b1-c004-b20515080ea1
+                - 3ecc2387-b827-6479-d3ea-ecfa25cf069f
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -796,18 +796,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:38 GMT
+                - Mon, 13 Nov 2023 13:13:39 GMT
             Expires:
                 - "0"
             Pragma:
@@ -823,18 +823,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - da879c18-50d7-44ce-7e0b-07ff5f144ea9
+                - b231a051-73de-44f2-5e9f-ba64631a1b86
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 258.6197ms
+        duration: 236.766959ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -847,9 +847,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - be302e2f-4d2f-310e-2f61-144617aa2a04
+                - 3e8198e9-71a1-20f0-b117-5536a119555c
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -860,18 +860,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:38 GMT
+                - Mon, 13 Nov 2023 13:13:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -887,18 +887,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 282f26d9-1c0d-4255-6139-0aa166c62552
+                - 12b37800-eed1-41aa-5ec6-cbfb861d2b06
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 326.5269ms
+        duration: 379.603833ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -911,9 +911,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - b7b7afb6-9a25-ad58-22bc-b1f419dceea2
+                - 3ba615c1-6edc-cfe3-8806-e515b509a16c
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -924,18 +924,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:39 GMT
+                - Mon, 13 Nov 2023 13:13:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -951,18 +951,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - faa18510-1166-4314-40f3-7b7511f23b71
+                - 4332bb42-d28d-4e3c-68fb-2a0b809f9262
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 252.8525ms
+        duration: 292.798041ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -975,9 +975,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 692d9d75-654e-9fef-22b9-04214ae6ff9c
+                - ddf30867-c908-27e2-0d94-d5ffa559d6a4
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -988,18 +988,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:44 GMT
+                - Mon, 13 Nov 2023 13:13:40 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1015,12 +1015,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7e0e6ea3-e560-4d13-5c22-0b0434779ba5
+                - e7810954-a4da-46b7-4376-50cd01e4b86b
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 4.6341371s
+        duration: 239.833416ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1039,9 +1039,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - f5f0aef2-67e1-af46-a3e5-997ef00b63b7
+                - 7ff7c5ed-b1f6-3926-56a6-c48e577ae8c2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1067,7 +1067,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:44 GMT
+                - Mon, 13 Nov 2023 13:13:41 GMT
             Expires:
                 - "0"
             Location:
@@ -1087,12 +1087,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - b2f93670-cb0d-4d83-4ce7-55e2ed0c81e9
+                - 3af52289-1259-4a30-6018-4aed717727df
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 122.5565ms
+        duration: 191.524791ms
     - id: 16
       request:
         proto: ""
@@ -1113,9 +1113,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - f5f0aef2-67e1-af46-a3e5-997ef00b63b7
+                - 7ff7c5ed-b1f6-3926-56a6-c48e577ae8c2
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1136,14 +1136,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"aa8a7ee5-3c04-4b7f-89fe-53ee2b1ee9c0","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/653217fbde8a6368c4e16ad6"},"neoAuthnWithOidc":false},"id":"08e0f612-9404-4309-86f7-cd4afcab7fa0","originKey":"sap.custom","name":"Custom IAS tenant","version":1,"created":1697781756407,"last_modified":1697781756794,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":"https://terraformint.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformint.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformint.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"5db94607-511d-490a-be7e-1d13ad9ab9f3","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformint.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/655221019944a9073b357bca"},"neoAuthnWithOidc":false},"id":"6dabd679-d194-453b-89c2-646b5be26d2f","originKey":"sap.custom","name":"Custom IAS tenant","version":1,"created":1699881217773,"last_modified":1699881218320,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:45 GMT
+                - Mon, 13 Nov 2023 13:13:41 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1163,9 +1163,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6c934ac8-c366-406b-58c7-bcd0663d4c38
+                - 4c6b2ddc-70e5-4b29-7501-d2c657ecb638
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 894.1452ms
+        duration: 593.476208ms

--- a/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
+++ b/internal/provider/fixtures/resource_subaccount_trust_configuration.minimal.yaml
@@ -6,7 +6,7 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -19,9 +19,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 1ab9cfc4-2912-2779-3c00-5338902122cd
+                - 2e04a299-88a8-259e-138f-c33d690d18e9
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -32,18 +32,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:03 GMT
+                - Mon, 13 Nov 2023 13:13:24 GMT
             Expires:
                 - "0"
             Pragma:
@@ -59,18 +59,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3af374d9-661d-4dc4-4f97-a7e8997c34d8
+                - cfb1fbde-78be-433b-45b0-722e2b4eb846
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 322.4923ms
+        duration: 232.212292ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -83,9 +83,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 05712539-cc9e-4ae1-c88f-a88d90a4e442
+                - 9cfb72ad-d4ee-a6e0-9ca2-2e28d71ca883
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:04 GMT
+                - Mon, 13 Nov 2023 13:13:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -123,18 +123,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 96dbab40-34a0-4a1e-774a-6d070e2d3cdf
+                - 652269c5-2eec-4ff5-7a93-2de6afd9c802
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 283.6356ms
+        duration: 280.380875ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -147,9 +147,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 95901095-fd70-3df6-d4f0-2eb145a995fe
+                - 43cfb563-4211-83b3-ad68-c883cbc74ebc
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -160,18 +160,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:08 GMT
+                - Mon, 13 Nov 2023 13:13:25 GMT
             Expires:
                 - "0"
             Pragma:
@@ -187,12 +187,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2ad9f0a3-59f3-494f-7e72-1eff0924a1c3
+                - eb262153-93c5-42a7-42ee-dce2f1fde899
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 4.4137035s
+        duration: 493.851791ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -211,9 +211,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 7297516a-91ab-afbc-584e-0bfae41fd1a1
+                - cfe62b1b-7148-bff5-9918-18bb29f14b12
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -239,7 +239,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:08 GMT
+                - Mon, 13 Nov 2023 13:13:25 GMT
             Expires:
                 - "0"
             Location:
@@ -259,12 +259,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - ecd6bad4-3485-4e3c-4dd9-cbf0c98e47ea
+                - fc72c9dc-4fe3-41da-61e2-1c20671f7251
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 129.918ms
+        duration: 205.852083ms
     - id: 4
       request:
         proto: ""
@@ -285,9 +285,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?create
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 7297516a-91ab-afbc-584e-0bfae41fd1a1
+                - cfe62b1b-7148-bff5-9918-18bb29f14b12
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -308,14 +308,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"c03c5ec7-fca7-45ee-9a4f-d00ad2fdd0a8","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/653217e106c21011242f7443"},"neoAuthnWithOidc":false},"id":"447b1079-bcf5-4f19-8a34-7f548a113608","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1697781729834,"last_modified":1697781729834,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":null,"providerDescription":"IAS tenant terraformint.accounts400.ondemand.com (OpenID Connect)","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":true,"storeCustomAttributes":true,"authUrl":null,"tokenUrl":null,"tokenKeyUrl":null,"logoutUrl":null,"tokenKey":null,"linkText":"terraformint.accounts400.ondemand.com","showLinkText":true,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"087c59e3-8493-4d99-84d9-06f47e98ce93","scopes":["openid","email"],"issuer":"https://terraformint.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformint.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":null,"passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":true,"iasTenant":{"host":"terraformint.accounts400.ondemand.com","adminUrl":"https://terraformint.accounts400.ondemand.com/admin/#/applications/655220f6d6131067eeea9654"},"neoAuthnWithOidc":false},"id":"2ca55861-7cb4-490a-b41a-0df7725131c1","originKey":"sap.custom","name":"Custom IAS tenant","version":0,"created":1699881206591,"last_modified":1699881206591,"active":true,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:09 GMT
+                - Mon, 13 Nov 2023 13:13:26 GMT
             Expires:
                 - "0"
             Pragma:
@@ -335,12 +335,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - db2ebfa9-543f-4665-67cb-6c83e82ed278
+                - 331a653a-30ba-4005-4590-d05af6eae157
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 876.0339ms
+        duration: 749.3595ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -359,9 +359,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c2b18146-40f0-8be8-f99b-2225eace75f2
+                - e83c4c75-333c-7c08-b6cb-bcfbf47a3d81
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -387,7 +387,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:09 GMT
+                - Mon, 13 Nov 2023 13:13:26 GMT
             Expires:
                 - "0"
             Location:
@@ -407,12 +407,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 5496eaf9-1f3e-47c1-58b4-60ff9d8e4610
+                - c06c8935-8fca-42b3-6733-0d9f977ed310
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 145.3411ms
+        duration: 144.443959ms
     - id: 6
       request:
         proto: ""
@@ -433,9 +433,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c2b18146-40f0-8be8-f99b-2225eace75f2
+                - e83c4c75-333c-7c08-b6cb-bcfbf47a3d81
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -463,7 +463,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:10 GMT
+                - Mon, 13 Nov 2023 13:13:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -483,18 +483,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - d81c4773-ca53-4f77-5dd0-a91d467d4bb8
+                - 6cae4728-031b-4f4d-4454-02858b34dcbb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 256.6515ms
+        duration: 498.9405ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -507,9 +507,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 9994d283-4bc3-1d25-9773-71ae3945c5ce
+                - 1d7de353-8ba3-8e02-c13b-802382e97e97
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -520,18 +520,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:14 GMT
+                - Mon, 13 Nov 2023 13:13:27 GMT
             Expires:
                 - "0"
             Pragma:
@@ -547,18 +547,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 0a9b219c-8550-4ee1-5ca1-dd6565828e25
+                - 31e83f37-7645-4318-6f5f-5d4a39df0ca1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 3.815721s
+        duration: 352.403042ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -571,9 +571,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - d5931788-9830-46a7-9ed2-8b68a0207e85
+                - feedef90-d998-63d5-a2a7-58160f6dc903
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -584,18 +584,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:14 GMT
+                - Mon, 13 Nov 2023 13:13:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -611,12 +611,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - cf4924f7-0eab-44f9-44ac-9cab0e3bd2a9
+                - f15107c0-0417-4202-61fe-bdefd24370ea
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 278.6981ms
+        duration: 348.605917ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -635,9 +635,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - e5313546-9473-6832-1b95-96de07a417a8
+                - 2e8543f3-f0d7-f22a-64bc-650c662433ed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -663,7 +663,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:14 GMT
+                - Mon, 13 Nov 2023 13:13:28 GMT
             Expires:
                 - "0"
             Location:
@@ -683,12 +683,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7a043900-bfa1-4c5a-4c0c-98eb714454c7
+                - 8212627e-bccc-4705-5ec3-c5da1487f0d9
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 108.5759ms
+        duration: 229.280916ms
     - id: 10
       request:
         proto: ""
@@ -709,9 +709,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - e5313546-9473-6832-1b95-96de07a417a8
+                - 2e8543f3-f0d7-f22a-64bc-650c662433ed
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -739,7 +739,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:14 GMT
+                - Mon, 13 Nov 2023 13:13:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -759,18 +759,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7b83195b-8a70-429d-5be6-1b04150cec58
+                - 1970132a-8a1e-4a68-71d3-a0f52244d1f3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 125.4146ms
+        duration: 179.230959ms
     - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -783,9 +783,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - cf3dc702-4a52-a0c3-9111-13685c19f241
+                - 96471aa4-6eb2-08bc-65b0-fef45996199a
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -796,18 +796,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:15 GMT
+                - Mon, 13 Nov 2023 13:13:28 GMT
             Expires:
                 - "0"
             Pragma:
@@ -823,18 +823,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 8191e988-dc7d-4c09-772e-994815f2e8e4
+                - 6abced9f-b125-4a1d-4aa0-8c6cd8861639
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 319.914ms
+        duration: 331.327ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -847,9 +847,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - e6424136-9fd6-203b-a8d1-b4ef191a3053
+                - 849049ad-b47f-a68d-6d96-c9c5fe1ec6a7
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -860,18 +860,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:15 GMT
+                - Mon, 13 Nov 2023 13:13:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -887,12 +887,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dce664b2-bad2-4002-53d2-33a25020d993
+                - 0aa1e78c-966e-481c-7db5-e80ca79baed0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 296.1289ms
+        duration: 229.093166ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -911,9 +911,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - f62903b5-5af2-efa0-cd9e-3b4b8b8802ce
+                - ea025908-e58e-db20-3527-15795bb5d047
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -939,7 +939,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:15 GMT
+                - Mon, 13 Nov 2023 13:13:29 GMT
             Expires:
                 - "0"
             Location:
@@ -959,12 +959,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 96d9b969-ed9a-47cf-7538-a556b433e33e
+                - 9883478e-627a-41ad-49b0-7f3fceb1ce40
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 110.1649ms
+        duration: 126.280917ms
     - id: 14
       request:
         proto: ""
@@ -985,9 +985,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - f62903b5-5af2-efa0-cd9e-3b4b8b8802ce
+                - ea025908-e58e-db20-3527-15795bb5d047
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1015,7 +1015,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:15 GMT
+                - Mon, 13 Nov 2023 13:13:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1035,18 +1035,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 1377f395-d95d-44f9-74ff-e297fe300c07
+                - d1ec6bc5-b768-49f9-47d0-5ca27ec9ce65
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 177.7206ms
+        duration: 129.1365ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1059,9 +1059,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 54cc55d2-817b-4749-ff97-db0b68dfe897
+                - fee33302-b1c2-76e5-1bbd-84776ac14bd7
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1072,18 +1072,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:16 GMT
+                - Mon, 13 Nov 2023 13:13:29 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1099,18 +1099,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - b9a9ecf5-09dd-4daa-6f8c-0177e26e73c3
+                - e1788da1-8c92-422b-5991-1a8c2df7c0aa
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 285.407ms
+        duration: 223.750625ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1123,9 +1123,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 464ba4a1-8bbf-5836-5206-1bbbeeb822c0
+                - e9ea6214-6e17-8800-dd5b-8b9272634191
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1136,18 +1136,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:16 GMT
+                - Mon, 13 Nov 2023 13:13:30 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1163,12 +1163,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2ae0b27e-99e2-48e4-423c-9da642d9d13f
+                - 8e2c118b-512c-4746-4633-23927bd72ca1
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 276.0775ms
+        duration: 243.517292ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1187,9 +1187,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - e0a379b7-c814-90c8-1b0d-72fdfc98f70f
+                - 3e38609b-f4b2-6952-4245-766bb08bc129
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1215,7 +1215,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:16 GMT
+                - Mon, 13 Nov 2023 13:13:30 GMT
             Expires:
                 - "0"
             Location:
@@ -1235,12 +1235,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 7cbfc435-4dd3-430d-5f49-25b068693ab9
+                - c0236ce0-aca0-48f0-4a6a-8941336a02e6
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 125.7065ms
+        duration: 130.239667ms
     - id: 18
       request:
         proto: ""
@@ -1261,9 +1261,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?update
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - e0a379b7-c814-90c8-1b0d-72fdfc98f70f
+                - 3e38609b-f4b2-6952-4245-766bb08bc129
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1291,7 +1291,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:18 GMT
+                - Mon, 13 Nov 2023 13:13:31 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1311,18 +1311,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - a4691c89-87ad-47a5-599d-baef4565fabe
+                - 537b855e-faf2-415f-4d9b-e5e80a424bf2
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.4764666s
+        duration: 1.409929083s
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1335,9 +1335,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - fe3b6e91-a89c-27e8-91f4-8ff0b6e67b19
+                - 4b2077a2-e52a-4fe2-cde6-b6caca53632f
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1348,18 +1348,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:21 GMT
+                - Mon, 13 Nov 2023 13:13:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1375,18 +1375,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - dcfb4da1-78ad-4054-6228-99fc633c02fa
+                - 16493525-765c-43e2-494f-eac9a38a2077
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 2.9711616s
+        duration: 404.991333ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1399,9 +1399,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c9d61df1-6311-f4bb-4762-8e0484b472a2
+                - caaf1c7d-0e91-7522-ac09-187974eb29d3
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1412,18 +1412,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:21 GMT
+                - Mon, 13 Nov 2023 13:13:32 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1439,12 +1439,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - f7531666-fd21-424a-5cf5-d31219779e00
+                - 52f57182-5c0c-479c-64ba-621fe19cbff4
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 281.4431ms
+        duration: 399.925125ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1463,9 +1463,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c08c2ce4-dcee-d332-a753-6184b3b68154
+                - fe1ec892-f6f8-64d2-f376-670efa2ad6c7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1491,7 +1491,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:22 GMT
+                - Mon, 13 Nov 2023 13:13:32 GMT
             Expires:
                 - "0"
             Location:
@@ -1511,12 +1511,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 597d1a47-13c0-4727-5de3-aeab20cf44ab
+                - bf8b8a3c-e15d-4778-75cc-648945ea2a30
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 108.4281ms
+        duration: 122.900791ms
     - id: 22
       request:
         proto: ""
@@ -1537,9 +1537,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - c08c2ce4-dcee-d332-a753-6184b3b68154
+                - fe1ec892-f6f8-64d2-f376-670efa2ad6c7
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1567,7 +1567,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:22 GMT
+                - Mon, 13 Nov 2023 13:13:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1587,18 +1587,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 6669b212-d262-486f-68c8-95445fca21f7
+                - b4998dfe-8a11-4e2e-4594-c54efbcb49d5
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 172.6582ms
+        duration: 282.783208ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1611,9 +1611,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - dcea243c-55c9-e215-b1c9-ea1d3a88cada
+                - 827e7c5f-5570-f565-b657-b8058ffa87ad
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1624,18 +1624,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:26 GMT
+                - Mon, 13 Nov 2023 13:13:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1651,18 +1651,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 68b30d40-0faf-4295-74b4-5aa090edf02d
+                - 5bfc891a-403f-4a24-72e2-bd2036051dbb
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 4.5988255s
+        duration: 220.545666ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1675,9 +1675,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - b848f100-6c08-4751-562b-0171d9c8effa
+                - 1fe5b3b6-9bad-9d50-a367-4520508b94b9
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1688,18 +1688,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:27 GMT
+                - Mon, 13 Nov 2023 13:13:33 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1715,12 +1715,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 7134841b-4b1d-45db-5f64-670fa94b9545
+                - 7cdd31c0-17a9-4ab4-40c4-e05d2d54a0f3
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 249.5766ms
+        duration: 261.2795ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1739,9 +1739,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 89ec3991-2278-b0e9-f5e3-66b25ca48f0a
+                - e0bcacde-58f5-54ad-9320-f6cee34f31ae
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1767,7 +1767,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:27 GMT
+                - Mon, 13 Nov 2023 13:13:34 GMT
             Expires:
                 - "0"
             Location:
@@ -1787,12 +1787,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - eddfa044-9824-4da3-5636-96c0f169237d
+                - 95e072bf-5e04-4fd7-56b8-9cd96d38a0c9
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 107.4689ms
+        duration: 123.434666ms
     - id: 26
       request:
         proto: ""
@@ -1813,9 +1813,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?get
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 89ec3991-2278-b0e9-f5e3-66b25ca48f0a
+                - e0bcacde-58f5-54ad-9320-f6cee34f31ae
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -1843,7 +1843,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:27 GMT
+                - Mon, 13 Nov 2023 13:13:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1863,18 +1863,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 49324fd1-582d-43be-41a7-4a57ef77cba1
+                - c55b4680-add3-4712-7711-ba83f42b53b0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 166.8446ms
+        duration: 236.936416ms
     - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1887,9 +1887,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 28a35173-e725-dcaf-3ed7-3e9a7fe3d050
+                - 8659c18f-3856-3976-578c-af96ccbb01a5
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1900,18 +1900,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:28 GMT
+                - Mon, 13 Nov 2023 13:13:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1927,18 +1927,18 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 51494281-32b1-48f0-6ecb-0a55b15fbb9f
+                - 73958ae0-b76a-4a47-4293-ffeb74fe57e0
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 251.8036ms
+        duration: 243.657959ms
     - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 118
+        content_length: 124
         transfer_encoding: []
         trailer: {}
         host: canary.cli.btp.int.sap
@@ -1951,9 +1951,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 0d4a1703-3fd5-c8ae-fad9-bcbc4884ae37
+                - 74034a12-ff98-33c3-aabd-3e4d51378c29
             X-Cpcli-Format:
                 - json
         url: https://canary.cli.btp.int.sap/login/v2.49.0
@@ -1964,18 +1964,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 153
+        content_length: 163
         uncompressed: false
         body: '{"issuer":"identity.provider.test","refreshToken":"redacted","user":"john.doe@int.test","mail":"john.doe@int.test"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Length:
-                - "153"
+                - "163"
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:28 GMT
+                - Mon, 13 Nov 2023 13:13:34 GMT
             Expires:
                 - "0"
             Pragma:
@@ -1991,12 +1991,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 3f0457e9-3458-46c7-464c-f3206696e363
+                - e794fea0-643b-4350-6199-283928643135
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 299.2948ms
+        duration: 227.889125ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -2015,9 +2015,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 64f9e1a2-2065-aaa9-f63a-dbae4af3ad03
+                - 9b439dc9-7dde-95e7-b4c9-59b8fd3a8f5e
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2043,7 +2043,7 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Fri, 20 Oct 2023 06:02:28 GMT
+                - Mon, 13 Nov 2023 13:13:35 GMT
             Expires:
                 - "0"
             Location:
@@ -2063,12 +2063,12 @@ interactions:
             X-Id-Token:
                 - redacted
             X-Vcap-Request-Id:
-                - 9d8047ed-0caf-4f62-59ef-72ee822d1162
+                - bb7d489e-5873-4df9-7749-1022e6ae846b
             X-Xss-Protection:
                 - "0"
         status: 307 Temporary Redirect
         code: 307
-        duration: 133.0181ms
+        duration: 125.304625ms
     - id: 30
       request:
         proto: ""
@@ -2089,9 +2089,9 @@ interactions:
             Referer:
                 - https://canary.cli.btp.int.sap/command/v2.49.0/security/trust?delete
             User-Agent:
-                - Terraform/1.6.1 terraform-provider-btp/dev
+                - Terraform/1.5.7 terraform-provider-btp/dev
             X-Correlationid:
-                - 64f9e1a2-2065-aaa9-f63a-dbae4af3ad03
+                - 9b439dc9-7dde-95e7-b4c9-59b8fd3a8f5e
             X-Cpcli-Customidp:
                 - identityProvider
             X-Cpcli-Format:
@@ -2112,14 +2112,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformtest.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":false,"storeCustomAttributes":true,"authUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":false,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"ef8691f0-a50f-488e-8a41-2ebe45bc3214","scopes":["openid","email"],"issuer":"https://terraformtest.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformtest.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":false,"neoAuthnWithOidc":false},"id":"447b1079-bcf5-4f19-8a34-7f548a113608","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1697781729834,"last_modified":1697781738433,"active":false,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
+        body: '{"type":"oidc1.0","config":{"emailDomain":null,"additionalConfiguration":{"domain":"terraformtest.accounts400.ondemand.com"},"providerDescription":"Description for terraformint.accounts400.ondemand.com","externalGroupsWhitelist":[],"attributeMappings":{"user.attribute.groups":"groups","user.attribute.remoteEntityId":"iss","user_uuid":"user_uuid"},"addShadowUserOnLogin":false,"storeCustomAttributes":true,"authUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/authorize","tokenUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/token","tokenKeyUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/certs","logoutUrl":null,"tokenKey":null,"linkText":"custom link text","showLinkText":false,"clientAuthInBody":false,"skipSslValidation":false,"relyingPartyId":"51f4a3ad-0290-44e6-abcd-62b5c62e1623","scopes":["openid","email"],"issuer":"https://terraformtest.accounts400.ondemand.com","responseType":"code","discoveryUrl":"https://terraformtest.accounts400.ondemand.com/.well-known/openid-configuration","userInfoUrl":"https://terraformtest.accounts400.ondemand.com/oauth2/userinfo","passwordGrantEnabled":true,"setForwardHeader":true,"platformIdp":false,"applicationIdp":false,"neoAuthnWithOidc":false},"id":"2ca55861-7cb4-490a-b41a-0df7725131c1","originKey":"sap.custom","name":"Custom IAS tenant for apps","version":2,"created":1699881206591,"last_modified":1699881211805,"active":false,"identityZoneId":"ef23ace8-6ade-4d78-9c1f-8df729548bbf"}'
         headers:
             Cache-Control:
                 - no-cache, no-store, max-age=0, must-revalidate
             Content-Type:
                 - application/json
             Date:
-                - Fri, 20 Oct 2023 06:02:29 GMT
+                - Mon, 13 Nov 2023 13:13:35 GMT
             Expires:
                 - "0"
             Pragma:
@@ -2139,9 +2139,9 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Vcap-Request-Id:
-                - 2a3dbc80-1b03-4657-7379-0d2160c21d5f
+                - 4bebcc08-ac07-44fe-7264-b50c339205df
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 951.3914ms
+        duration: 817.8435ms

--- a/internal/provider/resource_subaccount_trust_configuration.go
+++ b/internal/provider/resource_subaccount_trust_configuration.go
@@ -67,6 +67,10 @@ __Further documentation:__
 			"domain": schema.StringAttribute{
 				MarkdownDescription: "The tenant's domain which should be used for user logon.",
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The display name of the trust configuration.",
@@ -216,7 +220,7 @@ func (rs *subaccountTrustConfigurationResource) Create(ctx context.Context, req 
 		cliCreateReq.Description = &description
 	}
 
-	if !plan.Domain.IsNull() {
+	if !plan.Domain.IsUnknown() {
 		domain := plan.Domain.ValueString()
 		cliCreateReq.Domain = &domain
 	}
@@ -291,7 +295,7 @@ func (rs *subaccountTrustConfigurationResource) Update(ctx context.Context, req 
 		Status:                &status,
 	}
 
-	if !plan.Domain.IsNull() {
+	if !plan.Domain.IsUnknown() {
 		domain := plan.Domain.ValueString()
 		cliUpdateReq.Domain = &domain
 	}

--- a/internal/provider/resource_subaccount_trust_configuration_test.go
+++ b/internal/provider/resource_subaccount_trust_configuration_test.go
@@ -44,7 +44,7 @@ func TestResourceSubaccountTrustConfiguration(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestMatchResourceAttr("btp_subaccount_trust_configuration.uut", "subaccount_id", regexpValidUUID),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "identity_provider", "terraformint.accounts400.ondemand.com"),
-						resource.TestCheckNoResourceAttr("btp_subaccount_trust_configuration.uut", "domain"),
+						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "domain", "terraformint.accounts400.ondemand.com"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "name", "Custom IAS tenant for apps"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "description", "Description for terraformint.accounts400.ondemand.com"),
 						resource.TestCheckResourceAttr("btp_subaccount_trust_configuration.uut", "link_text", "custom link text"),


### PR DESCRIPTION
## Purpose

The domain is no longer reset to null if omitted in btp CLI command for updating a subaccount trust configuration.
This PR fixes the corresponding resource by changing the domain to computed and reading from state is unknown.

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
