### PR TITLE
test: Configurable Global Accounts For Tests

### DIFF
--- a/internal/provider/datasource_globalaccount_roles_test.go
+++ b/internal/provider/datasource_globalaccount_roles_test.go
@@ -24,7 +24,7 @@ func TestDataSourceGlobalaccountRoles(t *testing.T) {
 				{
 					Config: hclProviderFor(user) + hclDatasourceGlobalaccountRoles("uut"),
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "id", "terraformintcanary"),
+						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "id", testGlobalAccount),
 						resource.TestCheckResourceAttr("data.btp_globalaccount_roles.uut", "values.#", "11"),
 						resource.TestCheckResourceAttrSet("data.btp_globalaccount_roles.uut", "values.0.app_name"),
 					),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -49,6 +49,16 @@ var redactedTestUser = TestUser{
 	Lastname:  "Doe",
 }
 
+var testGlobalAccount = getenv("BTP_GLOBALACCOUNT", "terraformintcanary")
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
+
 func hclProviderFor(user TestUser) string {
 	return hclProvider("https://canary.cli.btp.int.sap", user)
 }
@@ -62,12 +72,12 @@ func hclProvider(cliServerURL string, user TestUser) string {
 	return fmt.Sprintf(`
 provider "btp" {
     cli_server_url = "%s"
-    globalaccount  = "terraformintcanary"
+    globalaccount  = "%s"
     username       = "%s"
     password       = "%s"
     idp            = "%s"
 }
-    `, cliServerURL, user.Username, user.Password, user.Idp)
+    `, cliServerURL, testGlobalAccount, user.Username, user.Password, user.Idp)
 }
 
 func getProviders(httpClient *http.Client) map[string]func() (tfprotov6.ProviderServer, error) {
@@ -292,7 +302,7 @@ func TestProvider_ConfigurationFlows(t *testing.T) {
 				{
 					Config: `
 provider "btp" {
-	globalaccount  = "terraformintcanary"
+	globalaccount  = "ga"
 	username       = ""
 	password       = "password"
 }
@@ -302,7 +312,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount  = "terraformintcanary"
+	globalaccount  = "ga"
 	username       = "username"
 	password       = ""
 }
@@ -323,7 +333,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount          = "terraformintcanary"
+	globalaccount          = "ga"
 	username               = ""
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = "tlsClientCertificate"
@@ -335,7 +345,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount          = "terraformintcanary"
+	globalaccount          = "ga"
 	username               = "username"
 	tls_client_key         = ""
 	tls_client_certificate = "tlsClientCertificate"
@@ -347,7 +357,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount          = "terraformintcanary"
+	globalaccount          = "ga"
 	username               = "username"
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = ""
@@ -359,7 +369,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount          = "terraformintcanary"
+	globalaccount          = "ga"
 	username               = "username"
 	tls_client_key         = "tlsClientKey"
 	tls_client_certificate = "tlsClientCertificate"
@@ -382,7 +392,7 @@ func TestProvider_ConfigurationWithIdToken(t *testing.T) {
 				{
 					Config: `
 provider "btp" {
-	globalaccount  = "terraformintcanary"
+	globalaccount  = "ga"
 	username       = "username"
 	idtoken        = "idtoken"
 }
@@ -392,7 +402,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount  = "terraformintcanary"
+	globalaccount  = "ga"
 	password       = "password"
 	idtoken        = "idtoken"
 }
@@ -402,7 +412,7 @@ data "btp_whoami" "me" {}`,
 				{
 					Config: `
 provider "btp" {
-	globalaccount  = "terraformintcanary"
+	globalaccount  = "ga"
 	idp            = "idp"
 	idtoken        = "idtoken"
 }


### PR DESCRIPTION
## Purpose
Enables to configure different global accounts for test recordings. Defaults to terraformintcanary.

## Does this introduce a breaking change?
```
[ ] Yes
[  x ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ x ] Other... Please describe: Test Extension
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```


* Additional test steps

```
* Execute Tests in provider_test.go 
* Set environment variable BTP_GLOBALACCOUNT to different global account and re-run. 
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Additional Information

Building block for #59 

## Checklist for reviewer

The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
