### PR TITLE
chore: remove edit event from pull

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,6 @@ on:
     branches: [ "main" ]
     types:
       - opened
-      - edited
       - reopened
       - synchronize
       - ready_for_review

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
       - ready_for_review


### PR DESCRIPTION
## Purpose

* Remove the "edit" event for PR trigger for CodeQL and Test workflows as editing the PR does not change anything on the codebase of the PR

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: infrastructure setup
```

## How to Test

Check execution triggers of GH Actions

## What to Check

Verify that the following are valid:

No execution of CodeQl and test if a PR is edited

## Other Information

n.a.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
