### PR TITLE
chore: changes in test workflow for coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+# Define the latest Terraform version to use for upload of coverage report  
+env: 
+  LATEST_VERSION: 16
+  
 jobs:
   # Ensure project builds before running testing matrix
   build:
@@ -100,7 +104,11 @@ jobs:
           TF_ACC: "1"
         run: go test -v -cover -coverprofile=cover.out -timeout=900s -parallel=4 ./...
         timeout-minutes: 20
-      - uses: actions/upload-artifact@v3
+      # Determine stripped version of Terraform
+      - run: echo "CURRENT_TF_VERSION=$(echo ${{ matrix.terraform }} | sed 's/[^a-zA-Z0-9]//g')" >> $GITHUB_ENV
+      # Upload coverage report for latest Terraform version only to avoid nameing issues in upload (see also https://github.com/actions/upload-artifact/tree/v4/?tab=readme-ov-file#breaking-changes)
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.CURRENT_TF_VERSION == env.LATEST_VERSION}}  
         with:
           name: coverage-report
           path: cover.out


### PR DESCRIPTION
## Purpose

* Adjustment of test workflow due to breaking change of upload Action
* The new version uploads the coverage report from the latest Terraform version only for later processing by Sonar Cloud
* This PR overrules PR #616

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

For details of breaking change see <https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes>

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
