### PR TITLE
chore: enhance feature request issue with auto reply

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: 💡Feature request
 description: Suggest an idea for this project
 title: "[FEATURE]"
-labels: [enhancement, needs-triage]
+labels: [enhancement, pending-decision]
 body:
   - type: dropdown
     attributes:

--- a/.github/workflows/feature-request-response.yml
+++ b/.github/workflows/feature-request-response.yml
@@ -1,0 +1,31 @@
+name: "Feature Request - Community Note"
+
+on:
+  issues:
+    types:
+      - opened
+      
+jobs:
+  community_note:
+    name: 'Add Community Note'
+    if: ${{ github.event.label.name == 'enhancement' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Add community note to new Issues'
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Thanks for the feature request. We evaluate it and update the issue accordingly.
+            
+            ## Community Note
+
+            ### Voting for Prioritization
+
+            * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original post to help the community and maintainers prioritize this request.
+            * Please **do not** leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
+
+            ### Volunteering to Work on This Issue
+
+            * If you are interested in working on this issue, please leave a comment.
+            * If this would be your first contribution, please review the [contribution guide](https://github.com/SAP/terraform-provider-btp/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Purpose

* Automatically add a community message to feature requests
* Add label `pending-decision` instead of `needs triage` - this helps us to filter new bugs and feature requests 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Issue handling setup
```

## How to Test

Create a issue of type "feature Request"

## What to Check

Check for automatic reply

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
