### PR TITLE
ci: Adds flexible IDP configuration to GA setup TF scripts

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -17,7 +17,7 @@ This directory contains Terraform definitions for setting up a Global Account fo
     - Audit Log Service | auditlog: standard (Quota: 1)
     - Malware Scanning Service | malware-scanner: clamav (Quota: 1)
 - IDP with Technical User
-  - Groups need to be properly configured
+  - Using groups is required for automatic resource assignments (see variables.tf)
 
 # Setup
 To setup a global account set the following environment variables:

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -3,18 +3,27 @@
 ###
 
 locals {
-  prefix_integration_test                       = "integration-test-"
-  prefix_integration_test_dir                   = "${local.prefix_integration_test}dir-"
-  prefix_integration_test_account               = "${local.prefix_integration_test}acc-"
-  integration_test_account_static               = "${local.prefix_integration_test_account}static"
-  integration_test_account_entitlements_stacked = "${local.prefix_integration_test_account}entitlements-stacked"
-  integration_test_services_static              = "${local.prefix_integration_test}services-static"
-  integration_test_security_settings            = "${local.prefix_integration_test}security-settings"
-  integration_test_dir_static                   = "${local.prefix_integration_test_dir}static"
-  integration_test_dir_se_static                = "${local.prefix_integration_test_dir}se-static"
-  integration_test_dir_entitlements             = "${local.prefix_integration_test_dir}entitlements"
-  integration_test_dir_entitlements_stacked     = "${local.prefix_integration_test_dir}entitlements-stacked"
-  disclaimer_description                        = "Please don't modify. This is used for integration tests."
+  datetime                                                  = formatdate("YYYYMMDDhhmmss", timestamp())
+  prefix_integration_test                                   = "integration-test-"
+  prefix_integration_test_dir                               = "${local.prefix_integration_test}dir-"
+  prefix_integration_test_account                           = "${local.prefix_integration_test}acc-"
+  integration_test_account_static                           = "${local.prefix_integration_test_account}static"
+  integration_test_account_static_timestamped               = "${local.integration_test_account_static}-${local.datetime}"
+  integration_test_account_entitlements_stacked             = "${local.prefix_integration_test_account}entitlements-stacked"
+  integration_test_account_entitlements_stacked_timestamped = "${local.integration_test_account_entitlements_stacked}-${local.datetime}"
+  integration_test_services_static                          = "${local.prefix_integration_test}services-static"
+  integration_test_services_static_timestamped              = "${local.integration_test_services_static}-${local.datetime}"
+  integration_test_security_settings                        = "${local.prefix_integration_test}security-settings"
+  integration_test_security_settings_timestamped            = "${local.integration_test_security_settings}-${local.datetime}"
+  integration_test_dir_static                               = "${local.prefix_integration_test_dir}static"
+  integration_test_dir_se_static                            = "${local.prefix_integration_test_dir}se-static"
+  integration_test_dir_entitlements                         = "${local.prefix_integration_test_dir}entitlements"
+  integration_test_dir_entitlements_stacked                 = "${local.prefix_integration_test_dir}entitlements-stacked"
+  disclaimer_description                                    = "Please don't modify. This is used for integration tests."
+  testing_idps                                              = ["sap.default", btp_globalaccount_trust_configuration.gtc_idp_testing.origin]
+  idp_groups                                                = ["BTP Terraform Administrator", "BTP Terraform Developer"]
+  testing_idps_group_mapping                                = {for val in setproduct(var.trusted_idp_origin_keys, local.idp_groups):
+                                                                "${val[0]}-${val[1]}" => val}
 }
 
 ###
@@ -24,7 +33,7 @@ locals {
 resource "btp_subaccount" "sa_acc_static" {
   name        = local.integration_test_account_static
   description = local.disclaimer_description
-  subdomain   = local.integration_test_account_static
+  subdomain   = local.integration_test_account_static_timestamped
   region      = var.region
   labels      = {
     label1 = [
@@ -37,20 +46,20 @@ resource "btp_subaccount" "sa_acc_static" {
 resource "btp_subaccount" "sa_acc_entitlements_stacked" {
   parent_id = btp_directory.dir_entitlements_stacked.id
   name      = local.integration_test_account_entitlements_stacked
-  subdomain = local.integration_test_account_entitlements_stacked
+  subdomain = local.integration_test_account_entitlements_stacked_timestamped
   region    = var.region
 }
 
 resource "btp_subaccount" "sa_services_static" {
   name         = local.integration_test_services_static
-  subdomain    = local.integration_test_services_static
+  subdomain    = local.integration_test_services_static_timestamped
   region       = var.region
   description  = "Subaccount to test:\n- Service Instances\n- Service Bindings\n- App Subscriptions"
 }
 
 resource "btp_subaccount" "sa_security_settings" {
   name      = local.integration_test_security_settings
-  subdomain = local.integration_test_security_settings
+  subdomain = local.integration_test_security_settings_timestamped
   region    = var.region
 }
 
@@ -90,29 +99,22 @@ resource "btp_directory" "dir_se_static" {
 ###
 
 resource "btp_directory_role_collection_assignment" "drca_dir_se_static_jenny_directory_viewer" {
-  for_each             = toset(["sap.default", "terraformint-platform"])
+  count                = length(local.testing_idps)
   directory_id         = btp_directory.dir_se_static.id
   role_collection_name = "Directory Viewer"
   user_name            = "jenny.doe@test.com"
-  origin               = each.value
+  origin               = local.testing_idps[count.index]
 }
 
 ###
 # global account role collection assignments
 ###
 
-resource "btp_globalaccount_role_collection_assignment" "grca_globalaccount_administrators" {
-  for_each             = toset(["BTP Terraform Administrator", "BTP Terraform Developer"])
-  role_collection_name = "Global Account Administrator"
-  group_name           = each.value
-  origin               = "terraform-platform"
-}
-
 resource "btp_globalaccount_role_collection_assignment" "grca_jenny_ga_viewer" {
-  for_each             = toset(["sap.default", "terraformint-platform"])
+  count                = length(local.testing_idps)
   role_collection_name = "Global Account Viewer"
   user_name            = "jenny.doe@test.com"
-  origin               = each.value
+  origin               = local.testing_idps[count.index]
 }
 
 ###
@@ -121,42 +123,42 @@ resource "btp_globalaccount_role_collection_assignment" "grca_jenny_ga_viewer" {
 
 resource "btp_subaccount_role_collection_assignment" "srca_sa_acc_static_subaccount_administrators" {
   subaccount_id        = btp_subaccount.sa_acc_static.id
-  for_each             = toset(["BTP Terraform Administrator", "BTP Terraform Developer"])
+  for_each             = local.testing_idps_group_mapping
   role_collection_name = "Subaccount Administrator"
-  group_name           = each.value
-  origin               = "terraform-platform"
+  group_name           = each.value[1]
+  origin               = each.value[0]
 }
 
 resource "btp_subaccount_role_collection_assignment" "srca_sa_acc_entitlements_stacked_subaccount_administrators" {
   subaccount_id        = btp_subaccount.sa_acc_entitlements_stacked.id
-  for_each             = toset(["BTP Terraform Administrator", "BTP Terraform Developer"])
+  for_each             = local.testing_idps_group_mapping
   role_collection_name = "Subaccount Administrator"
-  group_name           = each.value
-  origin               = "terraform-platform"
+  group_name           = each.value[1]
+  origin               = each.value[0]
 }
 
 resource "btp_subaccount_role_collection_assignment" "srca_sa_services_static_subaccount_administrators" {
   subaccount_id        = btp_subaccount.sa_services_static.id
-  for_each             = toset(["BTP Terraform Administrator", "BTP Terraform Developer"])
+  for_each             = local.testing_idps_group_mapping
   role_collection_name = "Subaccount Administrator"
-  group_name           = each.value
-  origin               = "terraform-platform"
+  group_name           = each.value[1]
+  origin               = each.value[0]
 }
 
 resource "btp_subaccount_role_collection_assignment" "srca_sa_security_settings_subaccount_administrators" {
   subaccount_id        = btp_subaccount.sa_security_settings.id
-  for_each             = toset(["BTP Terraform Administrator", "BTP Terraform Developer"])
+  for_each             = local.testing_idps_group_mapping
   role_collection_name = "Subaccount Administrator"
-  group_name           = each.value
-  origin               = "terraform-platform"
+  group_name           = each.value[1]
+  origin               = each.value[0]
 }
 
 resource "btp_subaccount_role_collection_assignment" "srca_sa_acc_static_jenny_ga_viewer" {
+  count                = length(local.testing_idps)
   subaccount_id        = btp_subaccount.sa_acc_static.id
-  for_each             = toset(["sap.default", "terraformint-platform"])
   role_collection_name = "Subaccount Viewer"
   user_name            = "jenny.doe@test.com"
-  origin               = each.value
+  origin               = local.testing_idps[count.index]
 }
 
 ###
@@ -203,11 +205,10 @@ resource "btp_globalaccount_resource_provider" "grp_aws" {
 # global account trust configuration
 ###
 
-resource "btp_globalaccount_trust_configuration" "gtc_idp_terraformint" {
-  identity_provider = "terraformint.accounts400.ondemand.com"
-  name              = "terraformint-platform"
-  description       = "Custom Platform Identity Provider"
-  origin            = "terraformint-platform"
+resource "btp_globalaccount_trust_configuration" "gtc_idp_testing" {
+  identity_provider = var.testing_idp
+  name              = split(".", var.testing_idp)[0]
+  description       = "Custom Platform Identity Provider for Test Cases"
 }
 
 ###

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -3,27 +3,26 @@
 ###
 
 locals {
-  datetime                                                  = formatdate("YYYYMMDDhhmmss", timestamp())
-  prefix_integration_test                                   = "integration-test-"
-  prefix_integration_test_dir                               = "${local.prefix_integration_test}dir-"
-  prefix_integration_test_account                           = "${local.prefix_integration_test}acc-"
-  integration_test_account_static                           = "${local.prefix_integration_test_account}static"
-  integration_test_account_static_timestamped               = "${local.integration_test_account_static}-${local.datetime}"
-  integration_test_account_entitlements_stacked             = "${local.prefix_integration_test_account}entitlements-stacked"
-  integration_test_account_entitlements_stacked_timestamped = "${local.integration_test_account_entitlements_stacked}-${local.datetime}"
-  integration_test_services_static                          = "${local.prefix_integration_test}services-static"
-  integration_test_services_static_timestamped              = "${local.integration_test_services_static}-${local.datetime}"
-  integration_test_security_settings                        = "${local.prefix_integration_test}security-settings"
-  integration_test_security_settings_timestamped            = "${local.integration_test_security_settings}-${local.datetime}"
-  integration_test_dir_static                               = "${local.prefix_integration_test_dir}static"
-  integration_test_dir_se_static                            = "${local.prefix_integration_test_dir}se-static"
-  integration_test_dir_entitlements                         = "${local.prefix_integration_test_dir}entitlements"
-  integration_test_dir_entitlements_stacked                 = "${local.prefix_integration_test_dir}entitlements-stacked"
-  disclaimer_description                                    = "Please don't modify. This is used for integration tests."
-  testing_idps                                              = ["sap.default", btp_globalaccount_trust_configuration.gtc_idp_testing.origin]
-  idp_groups                                                = ["BTP Terraform Administrator", "BTP Terraform Developer"]
-  testing_idps_group_mapping                                = {for val in setproduct(var.trusted_idp_origin_keys, local.idp_groups):
-                                                                "${val[0]}-${val[1]}" => val}
+  prefix_integration_test                                = "integration-test-"
+  prefix_integration_test_dir                            = "${local.prefix_integration_test}dir-"
+  prefix_integration_test_account                        = "${local.prefix_integration_test}acc-"
+  integration_test_account_static                        = "${local.prefix_integration_test_account}static"
+  integration_test_account_static_extended               = "${local.integration_test_account_static}-${var.subaccount_subdomain_extension}"
+  integration_test_account_entitlements_stacked          = "${local.prefix_integration_test_account}entitlements-stacked"
+  integration_test_account_entitlements_stacked_extended = "${local.integration_test_account_entitlements_stacked}-${var.subaccount_subdomain_extension}"
+  integration_test_services_static                       = "${local.prefix_integration_test}services-static"
+  integration_test_services_static_extended              = "${local.integration_test_services_static}-${var.subaccount_subdomain_extension}"
+  integration_test_security_settings                     = "${local.prefix_integration_test}security-settings"
+  integration_test_security_settings_extended            = "${local.integration_test_security_settings}-${var.subaccount_subdomain_extension}"
+  integration_test_dir_static                            = "${local.prefix_integration_test_dir}static"
+  integration_test_dir_se_static                         = "${local.prefix_integration_test_dir}se-static"
+  integration_test_dir_entitlements                      = "${local.prefix_integration_test_dir}entitlements"
+  integration_test_dir_entitlements_stacked              = "${local.prefix_integration_test_dir}entitlements-stacked"
+  disclaimer_description                                 = "Please don't modify. This is used for integration tests."
+  testing_idps                                           = ["sap.default", btp_globalaccount_trust_configuration.gtc_idp_testing.origin]
+  idp_groups                                             = ["BTP Terraform Administrator", "BTP Terraform Developer"]
+  testing_idps_group_mapping                             = {for val in setproduct(var.trusted_idp_origin_keys, local.idp_groups):
+                                                             "${val[0]}-${val[1]}" => val}
 }
 
 ###
@@ -33,7 +32,7 @@ locals {
 resource "btp_subaccount" "sa_acc_static" {
   name        = local.integration_test_account_static
   description = local.disclaimer_description
-  subdomain   = local.integration_test_account_static_timestamped
+  subdomain   = local.integration_test_account_static_extended
   region      = var.region
   labels      = {
     label1 = [
@@ -46,20 +45,20 @@ resource "btp_subaccount" "sa_acc_static" {
 resource "btp_subaccount" "sa_acc_entitlements_stacked" {
   parent_id = btp_directory.dir_entitlements_stacked.id
   name      = local.integration_test_account_entitlements_stacked
-  subdomain = local.integration_test_account_entitlements_stacked_timestamped
+  subdomain = local.integration_test_account_entitlements_stacked_extended
   region    = var.region
 }
 
 resource "btp_subaccount" "sa_services_static" {
   name         = local.integration_test_services_static
-  subdomain    = local.integration_test_services_static_timestamped
+  subdomain    = local.integration_test_services_static_extended
   region       = var.region
   description  = "Subaccount to test:\n- Service Instances\n- Service Bindings\n- App Subscriptions"
 }
 
 resource "btp_subaccount" "sa_security_settings" {
   name      = local.integration_test_security_settings
-  subdomain = local.integration_test_security_settings_timestamped
+  subdomain = local.integration_test_security_settings_extended
   region    = var.region
 }
 

--- a/integration/variables.tf
+++ b/integration/variables.tf
@@ -4,3 +4,17 @@ variable "region" {
   default     = "eu12"
 }
 
+variable "testing_idp" {
+  description = "The IDP used for testing. Contains test users and should not be used for other purposes. URL must not contain a protocol prefix. Must not be part of trusted_idps."
+  type        = string
+  default = "terraformint.accounts400.ondemand.com"
+}
+
+variable "trusted_idp_origin_keys" {
+  description = "List of IDP origin keys added to created resources. IDPs must contain group 'BTP Terraform Administrator' and group 'BTP Terraform Developer'. Enables members of listed groups to access created resources with corresponding scope."
+  type        = list(string)
+  default = [
+    "terraform-platform"
+  ]
+}
+

--- a/integration/variables.tf
+++ b/integration/variables.tf
@@ -4,6 +4,12 @@ variable "region" {
   default     = "eu12"
 }
 
+variable "subaccount_subdomain_extension" {
+  type        = string
+  description = "Subaccount subdomains are required to be unique across landscapes. Define a custom extension to avoid subdomain collision if operating multiple integration Global Accounts in the same landscape."
+  default     = "main"
+}
+
 variable "testing_idp" {
   description = "The IDP used for testing. Contains test users and should not be used for other purposes. URL must not contain a protocol prefix. Must not be part of trusted_idps."
   type        = string


### PR DESCRIPTION
## Purpose
Up to know the trust configuration in the integration GA setup script was hard coded. This change introduces the ability to flexibly configure the test IDP and set origin keys for other trusted IDPs. This change introduces also a variable for extending subdomains of subaccounts to be able to configure multiple GAs in the same landscape.

## Does this introduce a breaking change?
```
[ ] Yes
[ x ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ x ] Other... Please describe:
```

## How to Test

* Create a new Global Account according to integration/README.md
* Configure the Global Account using the provided Terraform files. 

## What to Check

Verify that the following are valid:

* Successful creation of all defined resources.
* The variable definition is easily understandable.

## Other Information
The trust configuration for natural users is supposed to be done manual (anyways required before the first Terraform run). Corresponding origin keys are supposed to be passed to Terrafrom (via variables). 

## Checklist for reviewer

The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
