### PR TITLE
docs: wrong path to devcontainer configuration

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -12,10 +12,9 @@ First, you need to setup your development environment. The following sections de
 
 **Step 2:** There is no step 2 😎.
 
-The following variants are supported for the GitHub Codespace:
+The following variant is supported for the GitHub Codespace:
 
 * "Terraform provider for SAP BTP - Development" - the configuration in [.devcontainer/default/devcontainer.json](.devcontainer/default/devcontainer.json) contains the development override for the Terraform provider so that the local build is used. You must set the environment variables `BTP_USERNAME` and `BTP_PASSWORD` yourself.
-* "Terraform provider for SAP BTP - Development (with remote state)" - the configuration in [.devcontainer/default_remote/devcontainer.json](.devcontainer/default_remote/devcontainer.json) enhances the "Terraform provider for SAP BTP - Development" by adding the configuration JSON for a state backend of type `remote`. To complete the setup you must add your access token to the file `~/.terraform.d/credentials.tfrc.json`.
 
 ## Dev Container
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Wrong path to devcontainer config in documentation
* fixes #667 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

Run the GH workflow to check for broken Links

## What to Check

Verify that the following are valid:

* GH Workflow passes

## Other Information

Validated via <https://github.com/SAP/terraform-provider-btp/actions/runs/7607550684>

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
