### PR TITLE
chore: setup of pre-release checks

### DIFF
--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -1,0 +1,15 @@
+# Terraform Provider pre-release check workflow.
+# This workflow can be manually triggered and executes the check workflows
+# needed to publish a release
+name: Terraform Provider Pre-Release Check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-workflow-test:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+  call-workflow-regression-test:
+    uses: ./.github/workflows/schema-regression-test.yml  
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,15 @@ jobs:
   call-workflow-test:
     uses: ./.github/workflows/test.yml
     secrets: inherit
-#  call-workflow-regression-test:
-#    uses: ./.github/workflows/schema-regression-test.yml  
+  call-workflow-regression-test:
+    uses: ./.github/workflows/schema-regression-test.yml  
+    secrets: inherit
 
   goreleaser:
     runs-on: ubuntu-latest
     needs: 
       - call-workflow-test
-#     - call-workflow-regression-test
+      - call-workflow-regression-test
     steps:
       - uses: actions/checkout@v4 # v4.0.0
         with:

--- a/.github/workflows/schema-regression-test.yml
+++ b/.github/workflows/schema-regression-test.yml
@@ -107,7 +107,7 @@ jobs:
     - name: State deviation - find existing issue for deviation
       id: find_deviation_issue
       uses: micalevisk/last-issue-action@v2
-      if: ${{ steps.execute_deviation_check.outputs.SCHEMA_DEVIATIONS_FOUND == 'true'}}
+      if: ${{ steps.execute_deviation_check.outputs.SCHEMA_DEVIATIONS_FOUND == 'true' || failure() }} 
       with: 
         state: open
         labels: |
@@ -116,7 +116,7 @@ jobs:
 
     - name: State deviation - create or update issue
       uses: peter-evans/create-issue-from-file@v4
-      if: ${{ steps.execute_deviation_check.outputs.SCHEMA_DEVIATIONS_FOUND == 'true'}}
+      if: ${{ steps.execute_deviation_check.outputs.SCHEMA_DEVIATIONS_FOUND == 'true' || failure() }}
       with:
         title: State deviation found
         # If issue number is empty a new issue gets created
@@ -132,7 +132,7 @@ jobs:
         rm -rf ${{ env.TEMP_PLAN_OUTPUT }}
 
     - name: State deviation - Set run to failed
-      if: ${{ steps.execute_deviation_check.outputs.SCHEMA_DEVIATIONS_FOUND == 'true'}}
+      if: ${{ steps.execute_deviation_check.outputs.SCHEMA_DEVIATIONS_FOUND == 'true' || failure() }}
       uses: actions/github-script@v7
       with:
         script: |


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR re-activates the regression test for the release workflow as mandatory prerequisite
* The workflow for schema regression test is improved by also reacting on "hard" errors from the `terraform plan` step which might occur
* Added a workflow `prerelease-check.yml` that can be manually triggered in order to execute the checks before the release in an isolated way
* Closes #650 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: GitHub workflow setup
```

## How to Test

Execute the workflows

## What to Check

Verify that the following are valid:

Workflows are executed in accordance to the constraints

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
