### PR TITLE
chore: pin GA version for regression

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+      - github_actions
     authors:
       - dependabot
   categories:
@@ -15,7 +16,7 @@ changelog:
         - enhancement
     - title: Bug Fixes 🐞
       labels:
-        - bug    
+        - bug
     - title: Other Changes
       labels:
         - "*"

--- a/regression-test/provider.tf
+++ b/regression-test/provider.tf
@@ -1,8 +1,9 @@
+# Regression/compatibility must always be ensured versus the GA version 1.0.0
 terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "1.0.0-rc2"
+      version = "1.0.0"
     }
   }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Pin provider version for regression test to 1.0.0
* Add label `github_actions`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Internal Setup
```

## How to Test

* Execute release precheck GH Action

## What to Check

Verify that the following are valid:

* Provider version 1.0.0 is taken

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
