### PR TITLE
docs: add example for subaccount data source

### DIFF
--- a/docs/data-sources/subaccount.md
+++ b/docs/data-sources/subaccount.md
@@ -17,8 +17,15 @@ You must be assigned to the admin or viewer role of the global account, director
 ## Example Usage
 
 ```terraform
-data "btp_subaccount" "my_account" {
+# Read a subaccount by ID
+data "btp_subaccount" "my_account_byid" {
   id = "6aa64c2f-38c1-49a9-b2e8-cf9fea769b7f"
+}
+
+# Read a subaccount by region and subdomain
+data "btp_subaccount" "my_account-bysubdomain" {
+  region    = "eu10" 
+	subdomain = "my-subaccount-subdomain"
 }
 ```
 

--- a/examples/data-sources/btp_subaccount/data-source.tf
+++ b/examples/data-sources/btp_subaccount/data-source.tf
@@ -1,3 +1,10 @@
-data "btp_subaccount" "my_account" {
+# Read a subaccount by ID
+data "btp_subaccount" "my_account_byid" {
   id = "6aa64c2f-38c1-49a9-b2e8-cf9fea769b7f"
+}
+
+# Read a subaccount by region and subdomain
+data "btp_subaccount" "my_account-bysubdomain" {
+  region    = "eu10" 
+	subdomain = "my-subaccount-subdomain"
 }


### PR DESCRIPTION
## Purpose

* This PR adds an example for the datasource `subaccount` and the option to fetch data via subdomain and region
* Example was missed in PR #727 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Check the documentation

## What to Check

Verify that the following are valid:

* Examples for different variants are available

## Other Information

Original issue: #272 

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
