### PR TITLE
fix: make binding state response more resillient

### DIFF
--- a/internal/provider/type_subaccount_service_binding.go
+++ b/internal/provider/type_subaccount_service_binding.go
@@ -35,9 +35,14 @@ func subaccountServiceBindingValueFrom(ctx context.Context, value servicemanager
 		ServiceInstanceId: types.StringValue(value.ServiceInstanceId),
 		Context:           types.StringValue(string(value.Context)),
 		Credentials:       types.StringValue(string(value.Credentials)),
-		State:             types.StringValue(value.LastOperation.State),
-		CreatedDate:       timeToValue(value.CreatedAt),
-		LastModified:      timeToValue(value.UpdatedAt),
+		//		State:             types.StringValue(value.LastOperation.State),
+		CreatedDate:  timeToValue(value.CreatedAt),
+		LastModified: timeToValue(value.UpdatedAt),
+	}
+
+	// Temporal workaround and explicit mapping to make state handling more resillient
+	if value.LastOperation != nil {
+		serviceBinding.State = types.StringValue(value.LastOperation.State)
 	}
 
 	var diags, diagnostics diag.Diagnostics

--- a/internal/provider/type_subaccount_service_binding.go
+++ b/internal/provider/type_subaccount_service_binding.go
@@ -35,12 +35,11 @@ func subaccountServiceBindingValueFrom(ctx context.Context, value servicemanager
 		ServiceInstanceId: types.StringValue(value.ServiceInstanceId),
 		Context:           types.StringValue(string(value.Context)),
 		Credentials:       types.StringValue(string(value.Credentials)),
-		//		State:             types.StringValue(value.LastOperation.State),
-		CreatedDate:  timeToValue(value.CreatedAt),
-		LastModified: timeToValue(value.UpdatedAt),
+		CreatedDate:       timeToValue(value.CreatedAt),
+		LastModified:      timeToValue(value.UpdatedAt),
 	}
 
-	// Temporal workaround and explicit mapping to make state handling more resillient
+	// CREATE and GET repsonses might differ - safeguarding nil reference of LastOperation
 	if value.LastOperation != nil {
 		serviceBinding.State = types.StringValue(value.LastOperation.State)
 	}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Response structure of CREATE and GET for Service Bindings differ. 
* This PR implements the safeguarding of NIL reference in this diff
* Closes #757 757

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

Seems to be an issue specifically with Cloud Logging, however due to API of service manager we must cover this diff on our side

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
