### PR TITLE
chore: release-120 fix fix-regression-test version

### DIFF
--- a/regression-test/provider.tf
+++ b/regression-test/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "1.1.0"
+      version = "1.0.0"
     }
   }
 }


### PR DESCRIPTION
- Revert provider version to 1.0

We should keep it to 1.0.0 as customers can start with 1.0.0 and then jump to any minor versions.

## Purpose

* Prep work for release v1.2.0
* regression-test should be pinned to 1.0.0 as customers can jump from this to any minor version

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: regression-test fix
```

## How to Test

* Test the code via automated test

n/a
## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
