### PR TITLE
fix: transfer human readable error message from service broker

### DIFF
--- a/internal/provider/resource_subaccount_service_instance.go
+++ b/internal/provider/resource_subaccount_service_instance.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,6 +27,21 @@ import (
 
 func newSubaccountServiceInstanceResource() resource.Resource {
 	return &subaccountServiceInstanceResource{}
+}
+
+// We need to manually model the Service Manager Error structure
+// Reason: the Swagger document is not consistent with the actual API response
+type svcMgrError struct {
+	Error        string
+	Description  string
+	Broker_Error brokerError
+}
+
+type brokerError struct {
+	StatusCode    int32
+	ErrorMessage  string
+	Description   string
+	ResponseError string
 }
 
 type subaccountServiceInstanceResource struct {
@@ -81,7 +97,7 @@ func (rs *subaccountServiceInstanceResource) Schema(ctx context.Context, _ resou
 			},
 			"shared": schema.BoolAttribute{
 				MarkdownDescription: "The configuration parameter for service instance sharing. Ensure that the instance is created with a plan that supports instance sharing.",
-				Optional:  			 true,
+				Optional:            true,
 				Computed:            true,
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
@@ -199,7 +215,7 @@ func (rs *subaccountServiceInstanceResource) Create(ctx context.Context, req res
 		return
 	}
 
-	createStateConf, diags := rs.CreateStateChange(ctx,cliRes,plan,"creation")
+	createStateConf, diags := rs.CreateStateChange(ctx, cliRes, plan, "creation")
 	resp.Diagnostics.Append(diags...)
 	updatedRes, err := createStateConf.WaitForStateContext(ctx)
 	if err != nil {
@@ -227,7 +243,7 @@ func (rs *subaccountServiceInstanceResource) Create(ctx context.Context, req res
 			return
 		}
 
-		createStateConf, diags := rs.CreateStateChange(ctx,cliRes,plan,"sharing")
+		createStateConf, diags := rs.CreateStateChange(ctx, cliRes, plan, "sharing")
 		resp.Diagnostics.Append(diags...)
 		updatedRes, err := createStateConf.WaitForStateContext(ctx)
 		if err != nil {
@@ -291,7 +307,7 @@ func (rs *subaccountServiceInstanceResource) Update(ctx context.Context, req res
 		return
 	}
 
-	updateStateConf, diags := rs.UpdateStateChange(ctx,cliRes,plan,"update")
+	updateStateConf, diags := rs.UpdateStateChange(ctx, cliRes, plan, "update")
 	resp.Diagnostics.Append(diags...)
 	updatedRes, err := updateStateConf.WaitForStateContext(ctx)
 	if err != nil {
@@ -306,45 +322,45 @@ func (rs *subaccountServiceInstanceResource) Update(ctx context.Context, req res
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 
-	if (!plan.Shared.IsUnknown() && plan.Shared != stateCurrent.Shared) {
+	if !plan.Shared.IsUnknown() && plan.Shared != stateCurrent.Shared {
 
-			cliReq := btpcli.ServiceInstanceShareInput{
-				Id:         cliRes.Id,
-				Subaccount: cliRes.SubaccountId,
-				Name:       cliRes.Name,
-			}
+		cliReq := btpcli.ServiceInstanceShareInput{
+			Id:         cliRes.Id,
+			Subaccount: cliRes.SubaccountId,
+			Name:       cliRes.Name,
+		}
 
-			if plan.Shared.ValueBool() && !stateCurrent.Shared.ValueBool() {
-				cliRes, _, err = rs.cli.Services.Instance.Share(ctx, &cliReq)
-				if err != nil {
-					resp.Diagnostics.AddError("API Error Sharing Resource Service Instance (Subaccount) while Updating", fmt.Sprintf("%s", err))
-					return
-				}
-			}
-
-			if !plan.Shared.ValueBool() && stateCurrent.Shared.ValueBool() {
-				cliRes, _, err = rs.cli.Services.Instance.Unshare(ctx, &cliReq)
-				if err != nil {
-					resp.Diagnostics.AddError("API Error Unsharing Resource Service Instance (Subaccount) while Updating", fmt.Sprintf("%s", err))
-					return
-				}
-			}
-
-			updateStateConf, diags := rs.UpdateStateChange(ctx,cliRes,plan,"sharing/unsharing")
-			resp.Diagnostics.Append(diags...)
-			updatedRes, err := updateStateConf.WaitForStateContext(ctx)
+		if plan.Shared.ValueBool() && !stateCurrent.Shared.ValueBool() {
+			cliRes, _, err = rs.cli.Services.Instance.Share(ctx, &cliReq)
 			if err != nil {
 				resp.Diagnostics.AddError("API Error Sharing Resource Service Instance (Subaccount) while Updating", fmt.Sprintf("%s", err))
+				return
 			}
+		}
 
-			state, diags := subaccountServiceInstanceValueFrom(ctx, updatedRes.(servicemanager.ServiceInstanceResponseObject))
-			state.Parameters = plan.Parameters
-			state.Timeouts = plan.Timeouts
-			resp.Diagnostics.Append(diags...)
+		if !plan.Shared.ValueBool() && stateCurrent.Shared.ValueBool() {
+			cliRes, _, err = rs.cli.Services.Instance.Unshare(ctx, &cliReq)
+			if err != nil {
+				resp.Diagnostics.AddError("API Error Unsharing Resource Service Instance (Subaccount) while Updating", fmt.Sprintf("%s", err))
+				return
+			}
+		}
 
-			diags = resp.State.Set(ctx, state)
-			resp.Diagnostics.Append(diags...)
-	} 
+		updateStateConf, diags := rs.UpdateStateChange(ctx, cliRes, plan, "sharing/unsharing")
+		resp.Diagnostics.Append(diags...)
+		updatedRes, err := updateStateConf.WaitForStateContext(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError("API Error Sharing Resource Service Instance (Subaccount) while Updating", fmt.Sprintf("%s", err))
+		}
+
+		state, diags := subaccountServiceInstanceValueFrom(ctx, updatedRes.(servicemanager.ServiceInstanceResponseObject))
+		state.Parameters = plan.Parameters
+		state.Timeouts = plan.Timeouts
+		resp.Diagnostics.Append(diags...)
+
+		diags = resp.State.Set(ctx, state)
+		resp.Diagnostics.Append(diags...)
+	}
 }
 
 func (rs *subaccountServiceInstanceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -381,7 +397,8 @@ func (rs *subaccountServiceInstanceResource) Delete(ctx context.Context, req res
 
 			// No error returned even if operation failed
 			if subRes.LastOperation.State == servicemanager.StateFailed {
-				return subRes, subRes.LastOperation.State, errors.New("undefined API error during service instance deletion")
+				opsError := extractDetailedError(subRes.LastOperation.Errors, "deletion")
+				return subRes, subRes.LastOperation.State, opsError
 			}
 
 			return subRes, subRes.LastOperation.State, nil
@@ -414,10 +431,10 @@ func (rs *subaccountServiceInstanceResource) ImportState(ctx context.Context, re
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
 }
 
-func (rs *subaccountServiceInstanceResource) CreateStateChange (ctx context.Context, cliRes servicemanager.ServiceInstanceResponseObject, plan subaccountServiceInstanceType, operation string) (tfutils.StateChangeConf, diag.Diagnostics){
-	
+func (rs *subaccountServiceInstanceResource) CreateStateChange(ctx context.Context, cliRes servicemanager.ServiceInstanceResponseObject, plan subaccountServiceInstanceType, operation string) (tfutils.StateChangeConf, diag.Diagnostics) {
+
 	var summary diag.Diagnostics
-	
+
 	state, diags := subaccountServiceInstanceValueFrom(ctx, cliRes)
 	state.Parameters = plan.Parameters
 	summary.Append(diags...)
@@ -428,31 +445,32 @@ func (rs *subaccountServiceInstanceResource) CreateStateChange (ctx context.Cont
 	delay, minTimeout := tfutils.CalculateDelayAndMinTimeOut(createTimeout)
 
 	return tfutils.StateChangeConf{
-				Pending: []string{servicemanager.StateInProgress},
-				Target:  []string{servicemanager.StateSucceeded},
-				Refresh: func() (interface{}, string, error) {
-					subRes, _, err := rs.cli.Services.Instance.GetById(ctx, state.SubaccountId.ValueString(), cliRes.Id)
+			Pending: []string{servicemanager.StateInProgress},
+			Target:  []string{servicemanager.StateSucceeded},
+			Refresh: func() (interface{}, string, error) {
+				subRes, _, err := rs.cli.Services.Instance.GetById(ctx, state.SubaccountId.ValueString(), cliRes.Id)
 
-					if err != nil {
-						return subRes, "", err
-					}
+				if err != nil {
+					return subRes, "", err
+				}
 
-					// No error returned even if operation failed
-					if subRes.LastOperation.State == servicemanager.StateFailed {
-						return subRes, subRes.LastOperation.State, errors.New("undefined API error during service instance " + operation)
-					}
+				// No error returned even if operation failed
+				if subRes.LastOperation.State == servicemanager.StateFailed {
+					opsError := extractDetailedError(subRes.LastOperation.Errors, operation)
+					return subRes, subRes.LastOperation.State, opsError
+				}
 
-					return subRes, subRes.LastOperation.State, nil
-				},
-				Timeout:    createTimeout,
-				Delay:      delay,
-				MinTimeout: minTimeout,
+				return subRes, subRes.LastOperation.State, nil
 			},
-			summary
+			Timeout:    createTimeout,
+			Delay:      delay,
+			MinTimeout: minTimeout,
+		},
+		summary
 }
 
-func (rs *subaccountServiceInstanceResource) UpdateStateChange (ctx context.Context, cliRes servicemanager.ServiceInstanceResponseObject, plan subaccountServiceInstanceType, operation string) (tfutils.StateChangeConf, diag.Diagnostics){
-	
+func (rs *subaccountServiceInstanceResource) UpdateStateChange(ctx context.Context, cliRes servicemanager.ServiceInstanceResponseObject, plan subaccountServiceInstanceType, operation string) (tfutils.StateChangeConf, diag.Diagnostics) {
+
 	var summary diag.Diagnostics
 
 	timeoutsLocal := plan.Timeouts
@@ -465,24 +483,35 @@ func (rs *subaccountServiceInstanceResource) UpdateStateChange (ctx context.Cont
 	delay, minTimeout := tfutils.CalculateDelayAndMinTimeOut(updateTimeout)
 
 	return tfutils.StateChangeConf{
-				Pending: []string{servicemanager.StateInProgress},
-				Target:  []string{servicemanager.StateSucceeded},
-				Refresh: func() (interface{}, string, error) {
-					subRes, _, err := rs.cli.Services.Instance.GetById(ctx, state.SubaccountId.ValueString(), cliRes.Id)
+		Pending: []string{servicemanager.StateInProgress},
+		Target:  []string{servicemanager.StateSucceeded},
+		Refresh: func() (interface{}, string, error) {
+			subRes, _, err := rs.cli.Services.Instance.GetById(ctx, state.SubaccountId.ValueString(), cliRes.Id)
 
-					if err != nil {
-						return subRes, "", err
-					}
+			if err != nil {
+				return subRes, "", err
+			}
 
-					// No error returned even if operation failed
-					if subRes.LastOperation.State == servicemanager.StateFailed {
-						return subRes, subRes.LastOperation.State, errors.New("undefined API error during service instance " + operation)
-					}
+			// No error returned even if operation failed
+			if subRes.LastOperation.State == servicemanager.StateFailed {
+				opsError := extractDetailedError(subRes.LastOperation.Errors, operation)
+				return subRes, subRes.LastOperation.State, opsError
+			}
 
-					return subRes, subRes.LastOperation.State, nil
-				},
-				Timeout:    updateTimeout,
-				Delay:      delay,
-				MinTimeout: minTimeout,
-		  }, summary
+			return subRes, subRes.LastOperation.State, nil
+		},
+		Timeout:    updateTimeout,
+		Delay:      delay,
+		MinTimeout: minTimeout,
+	}, summary
+}
+
+func extractDetailedError(errorAsRawJson json.RawMessage, operation string) error {
+	// Manual extraction of the error message details (human readable error mesage) from the API response
+	var modelErr svcMgrError
+	if err := json.Unmarshal(errorAsRawJson, &modelErr); err == nil {
+		return errors.New("API error during service instance " + operation + " - " + modelErr.Broker_Error.Description)
+	}
+
+	return errors.New("undefined API error during service instance " + operation)
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR implements a solution to transport the human readable error message for service instance creation/update/deletion
* Due to the inconsistency between the Swagger document of the service manager and the API response we must handle the mapping in a manual setup in the service instance resource
* closes #764 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

Old NGPBUG that lead to a change in the model for `OperationResponseObject ` used for JSON deserialization is: NGPBUG-371222 which returns the error as a `json.RawMessage`.  

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
