### PR TITLE
chore: set tf docs plugin version to 0.18.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-//go:generate go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
+//go:generate go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.18.0
 //go:generate tfplugindocs generate --rendered-provider-name "SAP BTP"
 
 package main


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Workaround for tf-docs-plugin issue as described in <https://github.com/hashicorp/terraform-plugin-docs/issues/355>

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: version pinning
```

## How to Test

```bash
make generate
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully: header of docs contains links and bullet lists (see e.g. resource for directory

## Other Information

- See GitHub Action run for diff: <https://github.com/SAP/terraform-provider-btp/actions/runs/8698319409/job/23855116473>
- Follow-up issue is #774 

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
