### PR TITLE
chore: fix permission for reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 # GitHub considers creating releases and uploading assets as writing contents.
 permissions:
   contents: write
+  issues: write
 
 jobs:
   call-workflow-test:
@@ -20,6 +21,9 @@ jobs:
   call-workflow-regression-test:
     uses: ./.github/workflows/schema-regression-test.yml  
     secrets: inherit
+    permissions:
+      contents: read
+      issues: write
   goreleaser:
     runs-on: ubuntu-latest
     needs: 


### PR DESCRIPTION
## Purpose

* Fix permission propagation to reusable workflows

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: GitHub Action Setup
```

## How to Test

* Execute GH Action for release

## What to Check

Verify that the following are valid:

* GH Action gets executed without issues

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
