### PR TITLE
feat(btp_subaccount_service_instance): default value for parameters

### DIFF
--- a/internal/provider/resource_subaccount_service_instance.go
+++ b/internal/provider/resource_subaccount_service_instance.go
@@ -94,6 +94,10 @@ You must be assigned to the admin or the service administrator role of the subac
 				MarkdownDescription: "The configuration parameters for the service instance.",
 				Optional:            true,
 				Sensitive:           true,
+				Default:             stringdefault.StaticString(`{}`),
+				PlanModifiers:		 []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					jsonvalidator.ValidJSON(),
 				},

--- a/internal/provider/resource_subaccount_service_instance.go
+++ b/internal/provider/resource_subaccount_service_instance.go
@@ -95,8 +95,9 @@ You must be assigned to the admin or the service administrator role of the subac
 				MarkdownDescription: "The configuration parameters for the service instance.",
 				Optional:            true,
 				Sensitive:           true,
+				Computed:            true,
 				Default:             stringdefault.StaticString(`{}`),
-				PlanModifiers:		 []planmodifier.String{
+				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{

--- a/internal/provider/resource_subaccount_service_instance.go
+++ b/internal/provider/resource_subaccount_service_instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"


### PR DESCRIPTION
## Purpose

Sets `{}` as default value for `btp_subaccount_service_instance.x.parameters`. This way the they don't need to be specified for services which don't expect any parameters. This is in sync with the behaviour of the `btp_subaccount_service_binding` resource.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [ ] The PR has the matching labels assigned to it.
* [ ] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
