### PR TITLE
fix: allow creation of duplicate service instances in different environments

### DIFF
--- a/internal/btpcli/facade_services_instance.go
+++ b/internal/btpcli/facade_services_instance.go
@@ -114,7 +114,7 @@ func (f servicesInstanceFacade) Create(ctx context.Context, args *ServiceInstanc
 	if cmdRes.StatusCode != 202 && err == nil {
 		return serviceInstanceResponseObject, cmdRes, err
 	} else if cmdRes.StatusCode == 202 && err == nil {
-		return f.GetByName(ctx, args.Subaccount, args.Name)
+		return f.GetById(ctx, args.Subaccount, serviceInstanceResponseObject.Id)
 	} else {
 		// Error case as default
 		return servicemanager.ServiceInstanceResponseObject{}, cmdRes, err


### PR DESCRIPTION
## Purpose

This PR addresses the issue mentioned in #834. 

The BadRequest error was due to the service instances being read by their name after its creation. Thus the provider was unable to distinguish between two instances with the same name (although in different environments). 

A change was made to read the instances by their ID instead, which is a unique identifier which resolves the above mentioned issue.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->


## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
