### PR TITLE
fix: Improved Error Handling for Entitlement Destruction

### DIFF
--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -369,7 +369,7 @@ func (rs *subaccountEntitlementResource) Delete(ctx context.Context, req resourc
 
 			// No error returned even if operation failed
 			if entitlement.Assignment.EntityState == cis_entitlements.StateProcessingFailed {
-				return *entitlement, entitlement.Assignment.EntityState, fmt.Errorf(entitlement.Assignment.StateMessage)
+				return *entitlement, entitlement.Assignment.EntityState, errors.New(entitlement.Assignment.StateMessage)
 			}
 
 			return entitlement, cis_entitlements.StateProcessing, nil

--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -369,7 +369,7 @@ func (rs *subaccountEntitlementResource) Delete(ctx context.Context, req resourc
 
 			// No error returned even if operation failed
 			if entitlement.Assignment.EntityState == cis_entitlements.StateProcessingFailed {
-				return *entitlement, entitlement.Assignment.EntityState, errors.New("undefined API error during entitlement processing")
+				return *entitlement, entitlement.Assignment.EntityState, fmt.Errorf(entitlement.Assignment.StateMessage)
 			}
 
 			return entitlement, cis_entitlements.StateProcessing, nil


### PR DESCRIPTION
## Purpose

This PR resolves issue #837 
The issue at hand highlights the lack of a relevant error message when attempting to destroy entitlements under specific conditions. One such scenario arises when trying to destroy an entitlement for which a service instance exists outside of Terraform's lifecycle.
 
To address this, an update has been made to the `Delete()` function of the `resourceSubaccountEntitlement`. This update allows the error message to be propagated from the `AssignedServicePlanSubaccountDto` response object, providing more informative feedback during the destruction process.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
