### PR TITLE
feat: increased timeout for resource subaccount subscription

### DIFF
--- a/internal/provider/resource_subaccount_subscription.go
+++ b/internal/provider/resource_subaccount_subscription.go
@@ -228,6 +228,9 @@ func (rs *subaccountSubscriptionResource) Create(ctx context.Context, req resour
 		return
 	}
 
+	timeout := 60 * time.Minute
+	delay, minTimeout := tfutils.CalculateDelayAndMinTimeOut(timeout)
+
 	createStateConf := &tfutils.StateChangeConf{
 		Pending: []string{saas_manager_service.StateInProcess},
 		Target:  []string{saas_manager_service.StateSubscribed},
@@ -245,9 +248,9 @@ func (rs *subaccountSubscriptionResource) Create(ctx context.Context, req resour
 
 			return subRes, subRes.State, nil
 		},
-		Timeout:    10 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Timeout:    timeout,
+		Delay:      delay,
+		MinTimeout: minTimeout,
 	}
 
 	updatedRes, err := createStateConf.WaitForStateContext(ctx)
@@ -291,6 +294,9 @@ func (rs *subaccountSubscriptionResource) Delete(ctx context.Context, req resour
 		return
 	}
 
+	timeout := 60 * time.Minute
+	delay, minTimeout := tfutils.CalculateDelayAndMinTimeOut(timeout)
+
 	deleteStateConf := &tfutils.StateChangeConf{
 		Pending: []string{saas_manager_service.StateInProcess},
 		Target:  []string{saas_manager_service.StateNotSubscribed},
@@ -308,9 +314,9 @@ func (rs *subaccountSubscriptionResource) Delete(ctx context.Context, req resour
 
 			return subRes, subRes.State, nil
 		},
-		Timeout:    10 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Timeout:    timeout,
+		Delay:      delay,
+		MinTimeout: minTimeout,
 	}
 
 	_, err = deleteStateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
## Purpose

This PR provides a temporal workaround for #848 

The timeout for subaccount application subscriptions has been increased from 10 minutes to 60 minutes to accommodate scenarios where the subscription process may take longer.

 Instead of making the timeout a configurable parameter in the resource, the values for the Create and Delete functions were adjusted to avoid a schema change..

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [x] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [x] The PR has the matching labels assigned to it.
* [x] The PR has a milestone assigned to it.
* [x] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
