### PR TITLE
fix: removed idp from regression tests

### DIFF
--- a/.github/workflows/schema-regression-test.yml
+++ b/.github/workflows/schema-regression-test.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         export BTP_USERNAME=${{ secrets.BTP_USERNAME }}
         export BTP_PASSWORD=${{ secrets.BTP_PASSWORD }}
-        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} apply -var globalaccount=${{ secrets.GLOBALACCOUNT }} -var idp=${{ secrets.BTP_IDP }} -auto-approve -no-color 
+        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} apply -var globalaccount=${{ secrets.GLOBALACCOUNT }} -auto-approve -no-color 
 
     - name: Setup Go
       uses: actions/setup-go@v5.0.2
@@ -74,7 +74,7 @@ jobs:
       run: |
         export BTP_USERNAME=${{ secrets.BTP_USERNAME }}
         export BTP_PASSWORD=${{ secrets.BTP_PASSWORD }}
-        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} plan -var globalaccount=${{ secrets.GLOBALACCOUNT }} -var idp=${{ secrets.BTP_IDP }} -no-color -detailed-exitcode
+        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} plan -var globalaccount=${{ secrets.GLOBALACCOUNT }} -no-color -detailed-exitcode
 
 
     - name: Remove init data and override
@@ -98,7 +98,7 @@ jobs:
       run: |
         export BTP_USERNAME=${{ secrets.BTP_USERNAME }}
         export BTP_PASSWORD=${{ secrets.BTP_PASSWORD }}
-        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} destroy -var globalaccount='${{ secrets.GLOBALACCOUNT }}' -var idp='${{ secrets.BTP_IDP }}' -auto-approve -no-color
+        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} destroy -var globalaccount='${{ secrets.GLOBALACCOUNT }}' -auto-approve -no-color
 
     - name: State deviation - find existing issue for deviation
       id: find_deviation_issue

--- a/regression-test/provider.tf
+++ b/regression-test/provider.tf
@@ -12,5 +12,4 @@ terraform {
 provider "btp" {
   globalaccount  = var.globalaccount
   cli_server_url = var.cli_server
-  idp            = var.idp
 }


### PR DESCRIPTION
## Purpose
Tenant on the productive landscape seems to be broken, due to which the regression tests are failing. 
The idp has been removed as a temporary fix. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [ ] The PR has the matching labels assigned to it.
* [ ] The PR has a milestone assigned to it.
* [ ] If the PR closes an issue, the issue is referenced.
* [ ] Possible follow-up items are created and linked.
