### PR TITLE
fix: empty placeholders in error message

### DIFF
--- a/internal/provider/datasource_subaccount.go
+++ b/internal/provider/datasource_subaccount.go
@@ -170,10 +170,12 @@ func (ds *subaccountDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	if !data.Subdomain.IsNull() && !data.Region.IsNull() {
 
+		cachedData := data
+
 		data, accountFound, _ := ds.getSubbacountByRegionSubdomain(ctx, data.Region.ValueString(), data.Subdomain.ValueString(), resp)
 
 		if !accountFound {
-			resp.Diagnostics.AddError("API Error Reading Resource Subaccount : Please provide correct value for subdomain and region", fmt.Sprintf("Subaccount not found with subdomain %s in region %s", data.Subdomain.ValueString(), data.Region.ValueString()))
+			resp.Diagnostics.AddError("API Error Reading Resource Subaccount : Please provide correct value for subdomain and region", fmt.Sprintf("Subaccount not found with subdomain %q in region %q", cachedData.Subdomain.ValueString(), cachedData.Region.ValueString()))
 			return
 		}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix wrong setting of placeholders in error message for the datasource `subaccount`
* Closes #870

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information

n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
