### PR TITLE
feat: add retry logic for rate limit for entitlement

### DIFF
--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -224,7 +224,7 @@ func (rs *subaccountEntitlementResource) createOrUpdate(ctx context.Context, req
 				return callResult, entitlementCallRetrySucceeded, nil
 			}
 
-			if err != nil && isRetriableError(err) {
+			if isRetriableError(err) {
 				return callResult, entitlementCallRetryPending, nil
 			}
 
@@ -234,9 +234,9 @@ func (rs *subaccountEntitlementResource) createOrUpdate(ctx context.Context, req
 
 			return callResult, entitlementCallRetryPending, err
 		},
-		Timeout:    5 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 
 	_, err := RetryApiCallConf.WaitForStateContext(ctx)
@@ -272,8 +272,8 @@ func (rs *subaccountEntitlementResource) createOrUpdate(ctx context.Context, req
 			return *entitlement, entitlement.Assignment.EntityState, nil
 		},
 		Timeout:    10 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 
 	entitlement, err := createStateConf.WaitForStateContext(ctx)
@@ -327,7 +327,7 @@ func (rs *subaccountEntitlementResource) Delete(ctx context.Context, req resourc
 				return callResult, entitlementCallRetrySucceeded, nil
 			}
 
-			if err != nil && isRetriableError(err) {
+			if isRetriableError(err) {
 				return callResult, entitlementCallRetryPending, nil
 			}
 
@@ -337,9 +337,9 @@ func (rs *subaccountEntitlementResource) Delete(ctx context.Context, req resourc
 
 			return callResult, entitlementCallRetryPending, err
 		},
-		Timeout:    5 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 
 	_, err := RetryApiCallConf.WaitForStateContext(ctx)
@@ -375,8 +375,8 @@ func (rs *subaccountEntitlementResource) Delete(ctx context.Context, req resourc
 			return entitlement, cis_entitlements.StateProcessing, nil
 		},
 		Timeout:    10 * time.Minute,
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 
 	_, err = deleteStateConf.WaitForStateContext(ctx)
@@ -429,8 +429,11 @@ func isRetriableError(err error) bool {
 	if strings.Contains(err.Error(), "[Error: 30004/400]") {
 		// Error code for a locking scenario - API call must be retried
 		return true
+	} else if strings.Contains(err.Error(), "[Error: 11006/429]") {
+		// Error code when hitting a rate limit - API call must be retried
+		return true
 	} else {
-		// No retry possible as errro code does not indicate a valid retry scenario
+		// No retry possible as error code does not indicate a valid retry scenario
 		return false
 	}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add retry logic in case of rate limiting to the following resources:
   * subaccount_entitlement
   * subaccount_service_instance
   * subaccount_subscription
* Increase waiting time for entitlement assignment/creation and deletion to avoid unnecessary retries when hitting a rate limit
* Closes #872

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
Execute assignment of entitlements in parallel to hit rate limit error
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
* Verify that rate limit error is mitigated by retries

## Other Information

- Adding the retry context which anyway wraps the state change context is not necessary as we can add the logic to the existing waiting logic 

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
