### PR TITLE
fix: Broken Lint Tests

### DIFF
--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -447,7 +447,7 @@ func (v2 *v2Client) Execute(ctx context.Context, cmdReq *CommandRequest, options
 		var backendError BtpClientError
 
 		if err = json.NewDecoder(res.Body).Decode(&backendError); err == nil {
-			err = fmt.Errorf(backendError.Message)
+			err = fmt.Errorf("%s", backendError.Message)
 			// Handle scenarios where more error context can potentially be provided
 			err = handleSpecialErrors(backendError, err)
 		} else if res.Header.Get(HeaderCLIServerMessage) != "" {

--- a/internal/btpcli/client_test.go
+++ b/internal/btpcli/client_test.go
@@ -609,7 +609,7 @@ func simulateV2Call(t *testing.T, config v2SimulationConfig) {
 				w.Header().Add(key, value)
 			}
 			w.WriteHeader(config.srvReturnStatus)
-			fmt.Fprintf(w, config.srvReturnContent)
+			fmt.Fprintf(w,"%s",config.srvReturnContent)
 		}
 	}))
 	defer srv.Close()


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
The PR build was failing due to failure of lint tests in 2 files. The reason of failure is usage of non-constant format string in a call to fmt.Errorf and fmt.Fprintf, the fixes will ensure to prevent any unintended interpretation of format specifiers.

Closes: #887 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
* Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
