### PR TITLE
docs: fix wrong link for API credentials

### DIFF
--- a/docs/resources/directory_api_credential.md
+++ b/docs/resources/directory_api_credential.md
@@ -8,7 +8,7 @@ description: |-
   Tip:
   You must be assigned to directory admin or viewer role.
   Further documentation:
-  https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas
+  https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service
 ---
 
 # btp_directory_api_credential (Resource)
@@ -21,7 +21,7 @@ __Tip:__
 You must be assigned to directory admin or viewer role.
 
 __Further documentation:__
-<https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas>
+<https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service>
 
 ## Example Usage
 

--- a/docs/resources/globalaccount_api_credential.md
+++ b/docs/resources/globalaccount_api_credential.md
@@ -8,7 +8,7 @@ description: |-
   Tip:
   You must be assigned to the global account admin or viewer role.
   Further documentation:
-  https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas
+  https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service
 ---
 
 # btp_globalaccount_api_credential (Resource)
@@ -21,7 +21,7 @@ __Tip:__
 You must be assigned to the global account admin or viewer role.
 
 __Further documentation:__
-<https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas>
+<https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service>
 
 ## Example Usage
 

--- a/docs/resources/subaccount_api_credential.md
+++ b/docs/resources/subaccount_api_credential.md
@@ -8,7 +8,7 @@ description: |-
   Tip:
   You must be assigned to the subaccount admin or viewer role.
   Further documentation:
-  https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas
+  https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service
 ---
 
 # btp_subaccount_api_credential (Resource)
@@ -21,7 +21,7 @@ __Tip:__
 You must be assigned to the subaccount admin or viewer role.
 
 __Further documentation:__
-<https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas>
+<https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service>
 
 ## Example Usage
 

--- a/internal/provider/resource_directory_api_credential.go
+++ b/internal/provider/resource_directory_api_credential.go
@@ -47,7 +47,7 @@ __Tip:__
 You must be assigned to directory admin or viewer role.
 
 __Further documentation:__
-<https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas>`,
+<https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service>`,
 		Attributes: map[string]schema.Attribute{
 			"directory_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the directory.",

--- a/internal/provider/resource_globalaccount_api_credential.go
+++ b/internal/provider/resource_globalaccount_api_credential.go
@@ -47,7 +47,7 @@ __Tip:__
 You must be assigned to the global account admin or viewer role.
 
 __Further documentation:__
-<https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas>`,
+<https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service>`,
 		Attributes: map[string]schema.Attribute{
 			"globalaccount_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the globalaccount.",

--- a/internal/provider/resource_subaccount_api_credential.go
+++ b/internal/provider/resource_subaccount_api_credential.go
@@ -47,7 +47,7 @@ __Tip:__
 You must be assigned to the subaccount admin or viewer role.
 
 __Further documentation:__
-<https://help.sap.com/docs/btp/sap-business-technology-platform/entitlements-and-quotas>`,
+<https://help.sap.com/docs/btp/sap-business-technology-platform-internal/managing-api-credentials-for-calling-rest-apis-of-sap-authorization-and-trust-management-service>`,
 		Attributes: map[string]schema.Attribute{
 			"subaccount_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the subaccount.",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add link from help.sap.com for API credentials resource
* Closes #912

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
* Check markdown to contain same link as help.sap.com

## Other Information
<!-- Add any other helpful information that may be needed here. -->

Validated layout of markdown files at https://registry.terraform.io/tools/doc-preview

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [x] Possible follow-up items are created and linked.
