### PR TITLE
fix: handling timeouts with proper error messages

### DIFF
--- a/internal/provider/resource_subaccount_subscription.go
+++ b/internal/provider/resource_subaccount_subscription.go
@@ -248,6 +248,10 @@ func (rs *subaccountSubscriptionResource) Create(ctx context.Context, req resour
 		resp.Diagnostics.AddError("API Error Creating Resource Subscription (Subaccount)", fmt.Sprintf("%s", err))
 	}
 
+	if updatedRes == nil {
+		return
+	}
+
 	updatedPlan, diags := subaccountSubscriptionValueFrom(ctx, updatedRes.(saas_manager_service.EntitledApplicationsResponseObject))
 	updatedPlan.Parameters = plan.Parameters
 	updatedPlan.Timeouts = plan.Timeouts

--- a/internal/provider/resource_subaccount_subscription.go
+++ b/internal/provider/resource_subaccount_subscription.go
@@ -316,7 +316,7 @@ func (rs *subaccountSubscriptionResource) CreateStateChange(ctx context.Context,
 
 	timeoutsLocal := plan.Timeouts
 
-	createTimeout, diags := timeoutsLocal.Update(ctx, tfutils.DefaultTimeout)
+	createTimeout, diags := timeoutsLocal.Create(ctx, tfutils.DefaultTimeout)
 	summary.Append(diags...)
 	delay, minTimeout := tfutils.CalculateDelayAndMinTimeOut(createTimeout)
 

--- a/internal/tfutils/error.go
+++ b/internal/tfutils/error.go
@@ -95,7 +95,7 @@ func (e *TimeoutError) Error() string {
 			expectedState, suffix, e.LastError)
 	}
 
-	return fmt.Sprintf("timeout while waiting for %s%s",
+	return fmt.Sprintf("timeout while waiting for %s%s\ntry increasing the timeout for this particular operation",
 		expectedState, suffix)
 }
 

--- a/internal/tfutils/state.go
+++ b/internal/tfutils/state.go
@@ -5,6 +5,7 @@ package tfutils
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 )
@@ -260,6 +261,12 @@ func (conf *StateChangeConf) WaitForStateContext(ctx context.Context) (interface
 				case <-timeout:
 					log.Println("[ERROR] WaitForState exceeded refresh grace period")
 					break forSelect
+				}
+			}
+
+			for _, state := range conf.Pending{
+				if lastResult.State == state {
+					return nil, fmt.Errorf("%s","The timeout has exceeded. Try increasing the timeout for the particular operation.")
 				}
 			}
 

--- a/internal/tfutils/state.go
+++ b/internal/tfutils/state.go
@@ -5,7 +5,6 @@ package tfutils
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 )
@@ -261,12 +260,6 @@ func (conf *StateChangeConf) WaitForStateContext(ctx context.Context) (interface
 				case <-timeout:
 					log.Println("[ERROR] WaitForState exceeded refresh grace period")
 					break forSelect
-				}
-			}
-
-			for _, state := range conf.Pending{
-				if lastResult.State == state {
-					return nil, fmt.Errorf("%s","The timeout has exceeded. Try increasing the timeout for the particular operation.")
 				}
 			}
 

--- a/internal/tfutils/state_test.go
+++ b/internal/tfutils/state_test.go
@@ -177,7 +177,7 @@ func TestWaitForState_timeout(t *testing.T) {
 		t.Fatal("Expected timeout error. No error returned.")
 	}
 
-	expectedErr := "timeout while waiting for state to become 'running' (timeout: 1ms)"
+	expectedErr := "timeout while waiting for state to become 'running' (timeout: 1ms)\ntry increasing the timeout for this particular operation"
 	if err.Error() != expectedErr {
 		t.Fatalf("Errors don't match.\nExpected: %q\nGiven: %q\n", expectedErr, err.Error())
 	}
@@ -235,7 +235,7 @@ func TestWaitForState_cancel(t *testing.T) {
 		t.Fatal("Expected timeout error. No error returned.")
 	}
 
-	expectedErr := "timeout while waiting for state to become 'running'"
+	expectedErr := "timeout while waiting for state to become 'running' (last state: 'pending', timeout: 10ms)\ntry increasing the timeout for this particular operation"
 	if !strings.HasPrefix(err.Error(), expectedErr) {
 		t.Fatalf("Errors don't match.\nExpected: %q\nGiven: %q\n", expectedErr, err.Error())
 	}
@@ -322,7 +322,7 @@ func TestWaitForState_failureEmpty(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected timeout error. Got none.")
 	}
-	expectedErr := "timeout while waiting for resource to be gone (last state: 'pending', timeout: 100ms)"
+	expectedErr := "timeout while waiting for resource to be gone (last state: 'pending', timeout: 100ms)\ntry increasing the timeout for this particular operation"
 	if err.Error() != expectedErr {
 		t.Fatalf("Errors don't match.\nExpected: %q\nGiven: %q\n", expectedErr, err.Error())
 	}


### PR DESCRIPTION
## Purpose

fixes #916 

When a timeout occurs and the subscription hasn't reached the target state, the plugin would crash without providing a readable error message. While the logic for generating a relevant error is already in place, the absence of a check for "nil" responses causes the execution to terminate abruptly. This PR resolves the issue by adding the necessary check and enhancing the error message for better clarity.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully


## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [ ] The PR has the matching labels assigned to it.
* [ ] The PR has a milestone assigned to it.
* [ ] If the PR closes an issue, the issue is referenced.
* [ ] Possible follow-up items are created and linked.
