### PR TITLE
feat: add retry logic for Gateway timeout

### DIFF
--- a/internal/provider/resource_subaccount_environment_instance.go
+++ b/internal/provider/resource_subaccount_environment_instance.go
@@ -270,6 +270,10 @@ func (rs *subaccountEnvironmentInstanceResource) Create(ctx context.Context, req
 		Refresh: func() (interface{}, string, error) {
 			subRes, _, err := rs.cli.Accounts.EnvironmentInstance.Get(ctx, plan.SubaccountId.ValueString(), cliRes.Id)
 
+			if tfutils.IsRetriableErrorForEnvInstance(err) {
+				return nil, provisioning.StateCreating, nil
+			}
+
 			if err != nil {
 				return subRes, "", err
 			}
@@ -326,6 +330,10 @@ func (rs *subaccountEnvironmentInstanceResource) Update(ctx context.Context, req
 		Refresh: func() (interface{}, string, error) {
 			subRes, _, err := rs.cli.Accounts.EnvironmentInstance.Get(ctx, plan.SubaccountId.ValueString(), plan.Id.ValueString())
 
+			if tfutils.IsRetriableErrorForEnvInstance(err) {
+				return nil, provisioning.StateUpdating, nil
+			}
+
 			if err != nil {
 				return subRes, "", err
 			}
@@ -379,6 +387,10 @@ func (rs *subaccountEnvironmentInstanceResource) Delete(ctx context.Context, req
 
 			if comRes.StatusCode == http.StatusNotFound {
 				return subRes, "DELETED", nil
+			}
+
+			if tfutils.IsRetriableErrorForEnvInstance(err) {
+				return nil, provisioning.StateDeleting, nil
 			}
 
 			if err != nil {

--- a/internal/tfutils/retry.go
+++ b/internal/tfutils/retry.go
@@ -1,0 +1,40 @@
+package tfutils
+
+import "strings"
+
+func IsRetriableErrorForEntitlement(err error) bool {
+
+	if err == nil {
+		//If no error was raised a retry is not necessary
+		return false
+	}
+
+	if strings.Contains(err.Error(), "[Error: 30004/400]") {
+		// Error code for a locking scenario - API call must be retried
+		return true
+	} else if strings.Contains(err.Error(), "[Error: 11006/429]") {
+		// Error code when hitting a rate limit - API call must be retried
+		return true
+	} else {
+		// No retry possible as error code does not indicate a valid retry scenario
+		return false
+	}
+
+}
+
+func IsRetriableErrorForEnvInstance(err error) bool {
+
+	if err == nil {
+		//If no error was raised a retry is not necessary
+		return false
+	}
+
+	if strings.Contains(err.Error(), "Command timed out. Please try again later.") {
+		// Error 504 Gateway Timeout - API call must be retried
+		return true
+	} else {
+		// No retry possible as error code does not indicate a valid retry scenario
+		return false
+	}
+
+}

--- a/internal/tfutils/retry_test.go
+++ b/internal/tfutils/retry_test.go
@@ -1,0 +1,102 @@
+package tfutils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryEnvInstance(t *testing.T) {
+	type expects struct {
+		retryPossible bool
+	}
+
+	tests := []struct {
+		description string
+		uut         error
+		expects     expects
+	}{
+
+		{
+			description: "Random Error",
+			uut:         fmt.Errorf("Random Error"),
+			expects: expects{
+				retryPossible: false,
+			},
+		},
+		{
+			description: "Error 504 Gateway Timeout",
+			uut:         fmt.Errorf("Some generic errror text. Command timed out. Please try again later."),
+			expects: expects{
+				retryPossible: true,
+			},
+		},
+		{
+			description: "No Error",
+			uut:         nil,
+			expects: expects{
+				retryPossible: false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := IsRetriableErrorForEnvInstance(test.uut)
+
+			assert.Equal(t, test.expects.retryPossible, result)
+		})
+	}
+}
+
+func TestRetrySubaccountEntitlement(t *testing.T) {
+	type expects struct {
+		retryPossible bool
+	}
+
+	tests := []struct {
+		description string
+		uut         error
+		expects     expects
+	}{
+
+		{
+			description: "Random Error",
+			uut:         fmt.Errorf("Random Error"),
+			expects: expects{
+				retryPossible: false,
+			},
+		},
+		{
+			description: "Rate Limit Error",
+			uut:         fmt.Errorf("Some generic errror text. [Error: 30004/400]."),
+			expects: expects{
+				retryPossible: true,
+			},
+		},
+		{
+			description: "Locking Error",
+			uut:         fmt.Errorf("Some generic errror text. [Error: 11006/429]. Some more generic error text."),
+			expects: expects{
+				retryPossible: true,
+			},
+		},
+
+		{
+			description: "No Error",
+			uut:         nil,
+			expects: expects{
+				retryPossible: false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := IsRetriableErrorForEntitlement(test.uut)
+
+			assert.Equal(t, test.expects.retryPossible, result)
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add retry logic for Gateway timeouts for environment instances
* Refactor/centralize existing retry logic for entitlements
* Closes #985

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
