### PR TITLE
chore: go setup in GH Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,14 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
   call-workflow-regression-test:
-    uses: ./.github/workflows/schema-regression-test.yml  
+    uses: ./.github/workflows/schema-regression-test.yml
     secrets: inherit
     permissions:
       contents: read
       issues: write
   goreleaser:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - call-workflow-test
       - call-workflow-regression-test
     steps:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
         id: import_gpg

--- a/.github/workflows/schema-regression-test-opentofu.yml
+++ b/.github/workflows/schema-regression-test-opentofu.yml
@@ -1,6 +1,6 @@
 name: Regression Test - OpenTofu
 
-# Idea: 
+# Idea:
 # 1. Setup infrastructure with stable release of the provider in the live environment
 # 2. Switch to a local build of the provider
 # 3. Execute a tofu plan and check for deviations
@@ -28,7 +28,7 @@ jobs:
     - name: Check out Git repository
       id: checkout_repo
       uses: actions/checkout@v4
-      
+
     - name: Setup OpenTofu
       id : setup_opentofu
       uses: opentofu/setup-opentofu@v1
@@ -48,12 +48,13 @@ jobs:
       run: |
         export BTP_USERNAME=${{ secrets.BTP_USERNAME }}
         export BTP_PASSWORD=${{ secrets.BTP_PASSWORD }}
-        tofu -chdir=${{ env.PATH_TO_TFSCRIPT }} apply -var globalaccount=${{ secrets.GLOBALACCOUNT }} -auto-approve -no-color 
+        tofu -chdir=${{ env.PATH_TO_TFSCRIPT }} apply -var globalaccount=${{ secrets.GLOBALACCOUNT }} -auto-approve -no-color
 
     - name: Setup Go
       uses: actions/setup-go@v5.3.0
       with:
         go-version-file: 'go.mod'
+        cache: false
 
     - name: Install local Terraform provider
       id: build_provider
@@ -91,7 +92,7 @@ jobs:
         tofu -chdir=${{ env.PATH_TO_TFSCRIPT }} init -upgrade -no-color
 
     - name: Tofu Destroy with stable provider
-      if: always()  
+      if: always()
       id: tofu_destroy
       shell: bash
       run: |
@@ -102,8 +103,8 @@ jobs:
     - name: State deviation - find existing issue for deviation
       id: find_deviation_issue
       uses: micalevisk/last-issue-action@v2
-      if: ${{ steps.execute_deviation_check.outcome == 'failure' }} 
-      with: 
+      if: ${{ steps.execute_deviation_check.outcome == 'failure' }}
+      with:
         state: open
         labels: |
           state deviation
@@ -111,7 +112,7 @@ jobs:
 
     - name: State deviation - create or update issue
       uses: peter-evans/create-issue-from-file@v5
-      if: ${{ steps.execute_deviation_check.outcome == 'failure' }} 
+      if: ${{ steps.execute_deviation_check.outcome == 'failure' }}
       with:
         title: State deviation found
         # If issue number is empty a new issue gets created
@@ -121,13 +122,13 @@ jobs:
 
     - name: Cleanup plan output
       id: execute_plan_cleanup
-      if: always() 
+      if: always()
       shell: bash
       run: |
         rm -rf ${{ env.TEMP_PLAN_OUTPUT }}
 
     - name: State deviation - Set run to failed
-      if: ${{ steps.execute_deviation_check.outcome == 'failure' }} 
+      if: ${{ steps.execute_deviation_check.outcome == 'failure' }}
       uses: actions/github-script@v7
       with:
         script: |

--- a/.github/workflows/schema-regression-test.yml
+++ b/.github/workflows/schema-regression-test.yml
@@ -1,6 +1,6 @@
 name: Regression Test - Terraform Provider
 
-# Idea: 
+# Idea:
 # 1. Setup infrastructure with stable release of the provider in the live environment
 # 2. Switch to a local build of the provider
 # 3. Execute a terraform plan and check for deviations
@@ -29,7 +29,7 @@ jobs:
     - name: Check out Git repository
       id: checkout_repo
       uses: actions/checkout@v4
-      
+
     - name: Setup Terraform
       id : setup_terraform
       uses: hashicorp/setup-terraform@v3.1.2
@@ -49,12 +49,13 @@ jobs:
       run: |
         export BTP_USERNAME=${{ secrets.BTP_USERNAME }}
         export BTP_PASSWORD=${{ secrets.BTP_PASSWORD }}
-        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} apply -var globalaccount=${{ secrets.GLOBALACCOUNT }} -auto-approve -no-color 
+        terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} apply -var globalaccount=${{ secrets.GLOBALACCOUNT }} -auto-approve -no-color
 
     - name: Setup Go
       uses: actions/setup-go@v5.3.0
       with:
         go-version-file: 'go.mod'
+        cache: false
 
     - name: Install local Terraform provider
       id: build_provider
@@ -92,7 +93,7 @@ jobs:
         terraform -chdir=${{ env.PATH_TO_TFSCRIPT }} init -upgrade -no-color
 
     - name: Terraform Destroy with stable provider
-      if: always()  
+      if: always()
       id: terraform_destroy
       shell: bash
       run: |
@@ -103,8 +104,8 @@ jobs:
     - name: State deviation - find existing issue for deviation
       id: find_deviation_issue
       uses: micalevisk/last-issue-action@v2
-      if: ${{ steps.execute_deviation_check.outcome == 'failure' }} 
-      with: 
+      if: ${{ steps.execute_deviation_check.outcome == 'failure' }}
+      with:
         state: open
         labels: |
           state deviation
@@ -112,7 +113,7 @@ jobs:
 
     - name: State deviation - create or update issue
       uses: peter-evans/create-issue-from-file@v5
-      if: ${{ steps.execute_deviation_check.outcome == 'failure' }} 
+      if: ${{ steps.execute_deviation_check.outcome == 'failure' }}
       with:
         title: State deviation found
         # If issue number is empty a new issue gets created
@@ -122,13 +123,13 @@ jobs:
 
     - name: Cleanup plan output
       id: execute_plan_cleanup
-      if: always() 
+      if: always()
       shell: bash
       run: |
         rm -rf ${{ env.TEMP_PLAN_OUTPUT }}
 
     - name: State deviation - Set run to failed
-      if: ${{ steps.execute_deviation_check.outcome == 'failure' }} 
+      if: ${{ steps.execute_deviation_check.outcome == 'failure' }}
       uses: actions/github-script@v7
       with:
         script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,16 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
-          cache: true
-      - run: go mod download
+          cache: false
+      - run: |
+         go mod download
+         go mod tidy
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v3.7.1
         with:
           version: latest
+          skip-cache: true
 
   generate:
     if: github.event.pull_request.draft == false
@@ -56,7 +59,7 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
       - run: go generate ./...
       - name: git diff
         run: |
@@ -96,12 +99,14 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
-      - run: go mod download
+      - run: |
+         go mod download
+         go mod tidy
       - env:
           TF_ACC: "1"
         run: go test -v -cover -coverprofile=cover.out -timeout=1800s -parallel=4 ./...


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Set caching to false in GH Actions to get rid of warning of `Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: GH Action setup
```

## How to Test

* Test the code via automated test

```bash
go test ./...
```

## What to Check

Verify that the following are valid:

* Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
The fix for the open Tofu setup is available via PR #993

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

* [X] The PR is assigned to the Terraform project and a status is set (typically "in review").
* [X] The PR has the matching labels assigned to it.
* [X] The PR has a milestone assigned to it.
* [X] If the PR closes an issue, the issue is referenced.
* [X] Possible follow-up items are created and linked.
