### PR TITLE
chore: automate pr default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Purpose
 <!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
-* ...
+- ...
 
 ## Does this introduce a breaking change?
 <!-- Mark one with an "x". -->
@@ -23,26 +23,17 @@ What kind of change does this Pull Request introduce?
 
 ## How to Test
 
-* Test the code via automated test
+- Test the code via automated test
 
 ```bash
-go test ./...
-```
-
-<!-- Add additional steps if applicable -->
-* Additional test steps
-
-```
-...
+make test
 ```
 
 ## What to Check
 
 Verify that the following are valid:
 
-* Automated tests are executed successfully
-<!-- Add additional conditions if applicable -->
-* ...
+- Automated tests are executed successfully
 
 ## Other Information
 <!-- Add any other helpful information that may be needed here. -->
@@ -52,8 +43,7 @@ Verify that the following are valid:
 <!-- This checklist needs to completed by the reviewer of the PR -->
 The following organizational tasks must be completed before merging this PR:
 
-* [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
-* [ ] The PR has the matching labels assigned to it.
-* [ ] The PR has a milestone assigned to it.
-* [ ] If the PR closes an issue, the issue is referenced.
-* [ ] Possible follow-up items are created and linked.
+- [ ] The PR status on the Project board is set (typically "in review").
+- [ ] The PR has the matching labels assigned to it.
+- [ ] If the PR closes an issue, the issue is referenced.
+- [ ] Possible follow-up issues are created and linked.

--- a/.github/workflows/assign-issue-to-project.yml
+++ b/.github/workflows/assign-issue-to-project.yml
@@ -1,11 +1,8 @@
-# Automatically assign a issue/PR to the central Terraform project
-name: Add issues and PRs to central Project Board
+# Automatically assign a issue to the central Terraform project
+name: Add issues to central Project Board
 
 on:
   issues:
-    types:
-      - opened
-  pull_request:
     types:
       - opened
 

--- a/.github/workflows/set-default-values-pr.yml
+++ b/.github/workflows/set-default-values-pr.yml
@@ -1,0 +1,55 @@
+
+name: Set default values to PR
+# Add the PR to the central project (status in project is set via workflow in project)
+# Add the creator of the PR as assignee
+# Add the next available milestone to the PR
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  set-default-values:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to default project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/SAP/projects/72
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+      - name: Add creator as assignee
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        env:
+         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{github.repository}}/issues/${{github.event.number}}/assignees \
+           -f "assignees[]=${{github.actor}}"
+
+      - name: Add next milestone
+        uses: actions/github-script@v7
+        with:
+         script: |
+           const milestones = await github.rest.issues.listMilestones({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             state: "open",
+             sort: "due_on",
+             direction: "asc"
+           })
+
+           await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              milestone: milestones.data[0].number
+           });


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Automate setting of default values for PR namely:
   - Add to default project
   - Assign autor to PR
   - Set milestone to next open one
- Reduce PR template

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Project automation
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR is assigned to the Project board and a status is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] The PR has a milestone assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
