### PR TITLE
feat: add automatic replace to resource 'subscription'

### DIFF
--- a/internal/provider/resource_subaccount_subscription.go
+++ b/internal/provider/resource_subaccount_subscription.go
@@ -56,6 +56,9 @@ You must be assigned to the admin role of the subaccount.`,
 			"subaccount_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the subaccount.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 				Validators: []validator.String{
 					uuidvalidator.ValidUUID(),
 				},
@@ -63,10 +66,16 @@ You must be assigned to the admin role of the subaccount.`,
 			"app_name": schema.StringAttribute{
 				MarkdownDescription: "The unique registration name of the deployed multitenant application as defined by the app developer.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"plan_name": schema.StringAttribute{
 				MarkdownDescription: "The plan name of the application to which the consumer has subscribed.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"parameters": schema.StringAttribute{
 				MarkdownDescription: "The parameters of the subscription as a valid JSON object.",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- The resource `btp_subaccount_subscription` does not support update operations. This results in an error if Terraform would trigger a update in the execution phase
- Currently a require replace is only set for the parameters
- This could lead to issues for customers when trying to update e.g. the plan of the subscription, e. g. to first manually delete the subscription before applying the change in a newly created resource
- This PR adds the plan modifer `stringplanmodifier.RequiresReplace(),` to the schema attributes `subaccount`, `app_name` and `plan_name` to mitigate this
- Closes #1018

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
