### PR TITLE
fix: drift detection for roles and subaccount entitlement

### DIFF
--- a/docs/resources/subaccount_role.md
+++ b/docs/resources/subaccount_role.md
@@ -14,7 +14,7 @@ description: |-
 Creates a role in a subaccount.
 
 __Tip:__
-You must be assigned to the admin role of the subaccount.		
+You must be assigned to the admin role of the subaccount.
 
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/role-collections-and-roles-in-global-accounts-directories-and-subaccounts>

--- a/internal/provider/resource_directory_role.go
+++ b/internal/provider/resource_directory_role.go
@@ -159,14 +159,14 @@ func (rs *directoryRoleResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	cliRes, _, err := rs.cli.Security.Role.GetByDirectory(ctx,
+	cliRes, rawRes, err := rs.cli.Security.Role.GetByDirectory(ctx,
 		state.DirectoryId.ValueString(),
 		state.Name.ValueString(),
 		state.RoleTemplateAppId.ValueString(),
 		state.RoleTemplateName.ValueString(),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Reading Resource Role (Directory)", fmt.Sprintf("%s", err))
+		handleReadErrors(ctx, rawRes, resp, err, "Resource Role (Directory)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_role.go
+++ b/internal/provider/resource_globalaccount_role.go
@@ -88,13 +88,13 @@ func (rs *globalaccountRoleResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	cliRes, _, err := rs.cli.Security.Role.GetByGlobalAccount(ctx,
+	cliRes, rawRes, err := rs.cli.Security.Role.GetByGlobalAccount(ctx,
 		state.Name.ValueString(),
 		state.RoleTemplateAppId.ValueString(),
 		state.RoleTemplateName.ValueString(),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Reading Resource Role (Global Account)", fmt.Sprintf("%s", err))
+		handleReadErrors(ctx, rawRes, resp, err, "Resource Role (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -197,7 +197,7 @@ func (rs *subaccountEntitlementResource) Read(ctx context.Context, req resource.
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(("API Error %s Resource Entitlement (Subaccount) Read"), fmt.Sprintf("%s", err))
+		resp.Diagnostics.AddError(("API Error Resource Entitlement (Subaccount) Read"), fmt.Sprintf("%s", err))
 		return
 	}
 

--- a/internal/provider/resource_subaccount_entitlement.go
+++ b/internal/provider/resource_subaccount_entitlement.go
@@ -164,19 +164,13 @@ func (rs *subaccountEntitlementResource) Read(ctx context.Context, req resource.
 		Target:  []string{cis_entitlements.StateOK},
 		Refresh: func() (interface{}, string, error) {
 
-			entitlement, rawRes, err := rs.cli.Accounts.Entitlement.GetAssignedBySubaccount(ctx, state.SubaccountId.ValueString(), state.ServiceName.ValueString(), state.PlanName.ValueString(), isParentGlobalAccount, parentId)
+			entitlement, _, err := rs.cli.Accounts.Entitlement.GetAssignedBySubaccount(ctx, state.SubaccountId.ValueString(), state.ServiceName.ValueString(), state.PlanName.ValueString(), isParentGlobalAccount, parentId)
 
 			if tfutils.IsRetriableErrorForEntitlement(err) {
 				return nil, cis_entitlements.StateProcessing, nil
 			}
 
 			if err != nil {
-
-				if rawRes.StatusCode == 404 {
-					// Treat "Not Found" as a signal to recreate resource see https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations
-					return nil, "", fmt.Errorf("%s", "404")
-				}
-
 				return nil, "", err
 			}
 
@@ -198,12 +192,11 @@ func (rs *subaccountEntitlementResource) Read(ctx context.Context, req resource.
 	entitlement, err := readStateConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		if err.Error() == "404" {
+		if notFoundErr(err) {
 			// Treat "Not Found" as a signal to recreate resource see https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations
 			resp.State.RemoveResource(ctx)
 			return
 		}
-
 		resp.Diagnostics.AddError(("API Error %s Resource Entitlement (Subaccount) Read"), fmt.Sprintf("%s", err))
 		return
 	}
@@ -467,4 +460,11 @@ func hasPlanQuota(state subaccountEntitlementType) bool {
 	}
 
 	return true
+}
+
+func notFoundErr(err error) bool {
+	if err.Error() != "" && strings.Contains(err.Error(), "couldn't find resource") {
+		return true
+	}
+	return false
 }

--- a/internal/provider/resource_subaccount_role.go
+++ b/internal/provider/resource_subaccount_role.go
@@ -43,7 +43,7 @@ func (rs *subaccountRoleResource) Schema(_ context.Context, _ resource.SchemaReq
 		MarkdownDescription: `Creates a role in a subaccount.
 
 __Tip:__
-You must be assigned to the admin role of the subaccount.		
+You must be assigned to the admin role of the subaccount.
 
 __Further documentation:__
 <https://help.sap.com/docs/btp/sap-business-technology-platform/role-collections-and-roles-in-global-accounts-directories-and-subaccounts>`,
@@ -107,14 +107,14 @@ func (rs *subaccountRoleResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	cliRes, _, err := rs.cli.Security.Role.GetBySubaccount(ctx,
+	cliRes, rawRes, err := rs.cli.Security.Role.GetBySubaccount(ctx,
 		state.SubaccountId.ValueString(),
 		state.Name.ValueString(),
 		state.RoleTemplateAppId.ValueString(),
 		state.RoleTemplateName.ValueString(),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("API Error Reading Resource Role (Subaccount)", fmt.Sprintf("%s", err))
+		handleReadErrors(ctx, rawRes, resp, err, "Resource Role (Subaccount)")
 		return
 	}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Unify handling of drift detection when resource is manually removed from platform
- Adjustments in resources: `btp_*_role` and `btp_subaccount_entitlement`
- The handling is based on Terraform's best practises to deal with HTTP 404 statsu codes in READ operations: <https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations>
- The resource `btp_subacccount_entitlement` has a special handling as the reading does not directly return a 404, but semantically the situation can be identified
- Closes #1033 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
The regeneration of the docs lead to a change in the role docu (line break removed)

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
