### PR TITLE
docs: fix wrong example for resource provider

### DIFF
--- a/docs/resources/globalaccount_resource_provider.md
+++ b/docs/resources/globalaccount_resource_provider.md
@@ -31,9 +31,11 @@ __Further documentation:__
 ```terraform
 # register a AZURE project as resource provider
 resource "btp_globalaccount_resource_provider" "azure" {
-  id                = "my_azure_provider"
-  resource_provider = "AZURE"
-  parameters = jsonencode({
+  display_name   = "my_azure_provider"
+  provider_type  = "AZURE"
+  technical_name = "AZURE"
+  description    = "My Azure Resource Provider"
+  configuration   = jsonencode({
     region              = "westeurope"
     client_id           = "AZURECLIENTID"
     client_secret       = "AZURECLIENTSECRET"
@@ -45,9 +47,11 @@ resource "btp_globalaccount_resource_provider" "azure" {
 
 # register an AWS account as resource provider
 resource "btp_globalaccount_resource_provider" "aws" {
-  id                = "my_aws_provider"
-  resource_provider = "AWS"
-  parameters = jsonencode({
+  display_name   = "my_aws_provider"
+  provider_type  = "AWS"
+  technical_name = "AWS"
+  description    = "My AWS Resource Provider"
+  configuration   = jsonencode({
     access_key_id     = "AWSACCESSKEY"
     secret_access_key = "AWSSECRETKEY"
     vpc_id            = "vpc-test"

--- a/examples/resources/btp_globalaccount_resource_provider/resource.tf
+++ b/examples/resources/btp_globalaccount_resource_provider/resource.tf
@@ -1,8 +1,10 @@
 # register a AZURE project as resource provider
 resource "btp_globalaccount_resource_provider" "azure" {
-  id                = "my_azure_provider"
-  resource_provider = "AZURE"
-  parameters = jsonencode({
+  display_name   = "my_azure_provider"
+  provider_type  = "AZURE"
+  technical_name = "AZURE"
+  description    = "My Azure Resource Provider"
+  configuration   = jsonencode({
     region              = "westeurope"
     client_id           = "AZURECLIENTID"
     client_secret       = "AZURECLIENTSECRET"
@@ -14,9 +16,11 @@ resource "btp_globalaccount_resource_provider" "azure" {
 
 # register an AWS account as resource provider
 resource "btp_globalaccount_resource_provider" "aws" {
-  id                = "my_aws_provider"
-  resource_provider = "AWS"
-  parameters = jsonencode({
+  display_name   = "my_aws_provider"
+  provider_type  = "AWS"
+  technical_name = "AWS"
+  description    = "My AWS Resource Provider"
+  configuration   = jsonencode({
     access_key_id     = "AWSACCESSKEY"
     secret_access_key = "AWSSECRETKEY"
     vpc_id            = "vpc-test"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fix wrong example for resource `btp_globalaccount_resource_provider` to match schema
- Closes #1046

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
- Check the generated documentation that example matches schema

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
