### PR TITLE
fix: handling drift detection for subscriptions

### DIFF
--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -32,24 +32,24 @@ func handleReadErrors(ctx context.Context, rawRes btpcli.CommandResponse, cliRes
 	if rawRes.StatusCode == 404 {
 		resp.State.RemoveResource(ctx)
 		return
-	} 
-	
+	}
+
 	if strings.Contains(resLogName, "Subscription") {
-	
+
 		if obj, ok := cliRes.(saas_manager_service.EntitledApplicationsResponseObject); ok {
 			if obj.State == saas_manager_service.StateNotSubscribed {
 				resp.State.RemoveResource(ctx)
 				return
 			}
-		} else{
+		} else {
 			resp.Diagnostics.AddError(
-				"Invalid Response Object", 
+				"Invalid Response Object",
 				"Expected object of type EntitledApplicationsResponseObject for subscriptions",
 			)
 			return
 		}
 
-	} 
+	}
 
 	resp.Diagnostics.AddError(fmt.Sprintf("API Error Reading %s", resLogName), fmt.Sprintf("%s", err))
 

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -34,9 +34,11 @@ func handleReadErrors(ctx context.Context, rawRes btpcli.CommandResponse, cliRes
 		return
 	}
 
+	// special case for subscriptions as a 404 is not returned in case of unsubscribed subscriptions
 	if strings.Contains(resLogName, "Subscription") {
 
 		if obj, ok := cliRes.(saas_manager_service.EntitledApplicationsResponseObject); ok {
+			// if the state of the subscription is "NOT_SUBSCRIBED", the resource is removed from the state to trigger the recreation
 			if obj.State == saas_manager_service.StateNotSubscribed {
 				resp.State.RemoveResource(ctx)
 				return

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/SAP/terraform-provider-btp/internal/btpcli"
+	"github.com/SAP/terraform-provider-btp/internal/btpcli/types/saas_manager_service"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -25,12 +27,30 @@ func timeToValue(t time.Time) types.String {
 	return types.StringValue(t.Format(time.RFC3339))
 }
 
-func handleReadErrors(ctx context.Context, rawRes btpcli.CommandResponse, resp *resource.ReadResponse, err error, resLogName string) {
+func handleReadErrors(ctx context.Context, rawRes btpcli.CommandResponse, cliRes any, resp *resource.ReadResponse, err error, resLogName string) {
 	// Treat HTTP 404 Not Found status as a signal to recreate resource see https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations
 	if rawRes.StatusCode == 404 {
 		resp.State.RemoveResource(ctx)
-	} else {
-		resp.Diagnostics.AddError(fmt.Sprintf("API Error Reading %s", resLogName), fmt.Sprintf("%s", err))
-	}
+		return
+	} 
+	
+	if strings.Contains(resLogName, "Subscription") {
+	
+		if obj, ok := cliRes.(saas_manager_service.EntitledApplicationsResponseObject); ok {
+			if obj.State == saas_manager_service.StateNotSubscribed {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+		} else{
+			resp.Diagnostics.AddError(
+				"Invalid Response Object", 
+				"Expected object of type EntitledApplicationsResponseObject for subscriptions",
+			)
+			return
+		}
+
+	} 
+
+	resp.Diagnostics.AddError(fmt.Sprintf("API Error Reading %s", resLogName), fmt.Sprintf("%s", err))
 
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -85,7 +85,7 @@ func (p *btpcliProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("password"), path.MatchRoot("idtoken")),
-					stringvalidator.AlsoRequires(path.MatchRoot("tls_client_key"), path.MatchRoot("tls_client_certificate"),path.MatchRoot("idp")),
+					stringvalidator.AlsoRequires(path.MatchRoot("tls_client_key"), path.MatchRoot("tls_client_certificate"), path.MatchRoot("idp")),
 				},
 			},
 			"tls_client_key": schema.StringAttribute{
@@ -93,7 +93,7 @@ func (p *btpcliProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("password"), path.MatchRoot("idtoken")),
-					stringvalidator.AlsoRequires(path.MatchRoot("tls_idp_url"), path.MatchRoot("tls_client_certificate"),path.MatchRoot("idp")),
+					stringvalidator.AlsoRequires(path.MatchRoot("tls_idp_url"), path.MatchRoot("tls_client_certificate"), path.MatchRoot("idp")),
 				},
 			},
 			"tls_client_certificate": schema.StringAttribute{
@@ -101,7 +101,7 @@ func (p *btpcliProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("password"), path.MatchRoot("idtoken")),
-					stringvalidator.AlsoRequires(path.MatchRoot("tls_idp_url"), path.MatchRoot("tls_client_key"),path.MatchRoot("idp")),
+					stringvalidator.AlsoRequires(path.MatchRoot("tls_idp_url"), path.MatchRoot("tls_client_key"), path.MatchRoot("idp")),
 				},
 			},
 		},

--- a/internal/provider/resource_directory.go
+++ b/internal/provider/resource_directory.go
@@ -182,7 +182,7 @@ func (rs *directoryResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	cliRes, rawRes, err := rs.cli.Accounts.Directory.Get(ctx, state.ID.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Directory")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Directory")
 		return
 	}
 

--- a/internal/provider/resource_directory_api_credential.go
+++ b/internal/provider/resource_directory_api_credential.go
@@ -151,7 +151,7 @@ func (rs *directoryApiCredentialResource) Read(ctx context.Context, req resource
 		Name:      state.Name.ValueString(),
 	})
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Api Credential (Directory)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Api Credential (Directory)")
 		return
 	}
 

--- a/internal/provider/resource_directory_entitlement.go
+++ b/internal/provider/resource_directory_entitlement.go
@@ -159,7 +159,7 @@ func (rs *directoryEntitlementResource) Read(ctx context.Context, req resource.R
 	entitlement, rawRes, err := rs.cli.Accounts.Entitlement.GetEntitledByDirectory(ctx, state.DirectoryId.ValueString(), state.ServiceName.ValueString(), state.PlanName.ValueString())
 
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Entitlement (Directory)")
+		handleReadErrors(ctx, rawRes, entitlement, resp, err, "Resource Entitlement (Directory)")
 		return
 	}
 

--- a/internal/provider/resource_directory_role.go
+++ b/internal/provider/resource_directory_role.go
@@ -166,7 +166,7 @@ func (rs *directoryRoleResource) Read(ctx context.Context, req resource.ReadRequ
 		state.RoleTemplateName.ValueString(),
 	)
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Role (Directory)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Role (Directory)")
 		return
 	}
 

--- a/internal/provider/resource_directory_role_collection.go
+++ b/internal/provider/resource_directory_role_collection.go
@@ -137,7 +137,7 @@ func (rs *directoryRoleCollectionType) Read(ctx context.Context, req resource.Re
 
 	cliRes, rawRes, err := rs.cli.Security.RoleCollection.GetByDirectory(ctx, state.DirectoryId.ValueString(), state.Name.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Role Collection (Directory)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Role Collection (Directory)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_api_credential.go
+++ b/internal/provider/resource_globalaccount_api_credential.go
@@ -149,7 +149,7 @@ func (rs *globalaccountApiCredentialResource) Read(ctx context.Context, req reso
 		Name: state.Name.ValueString(),
 	})
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Api Credential (Global Account)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Api Credential (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_resource_provider.go
+++ b/internal/provider/resource_globalaccount_resource_provider.go
@@ -113,7 +113,7 @@ func (rs *resourceGlobalaccountProviderResource) Read(ctx context.Context, req r
 
 	cliRes, rawRes, err := rs.cli.Accounts.ResourceProvider.Get(ctx, state.Provider.ValueString(), state.TechnicalName.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Resource Provider (Global Account)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Resource Provider (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_role.go
+++ b/internal/provider/resource_globalaccount_role.go
@@ -94,7 +94,7 @@ func (rs *globalaccountRoleResource) Read(ctx context.Context, req resource.Read
 		state.RoleTemplateName.ValueString(),
 	)
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Role (Global Account)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Role (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_role_collection.go
+++ b/internal/provider/resource_globalaccount_role_collection.go
@@ -128,7 +128,7 @@ func (rs *globalaccountRoleCollectionResource) Read(ctx context.Context, req res
 
 	cliRes, rawRes, err := rs.cli.Security.RoleCollection.GetByGlobalAccount(ctx, state.Name.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Role Collection (Global Account)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Role Collection (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_security_settings.go
+++ b/internal/provider/resource_globalaccount_security_settings.go
@@ -116,7 +116,7 @@ func (rs *globalaccountSecuritySettingsResource) Read(ctx context.Context, req r
 
 	cliRes, rawRes, err := rs.cli.Security.Settings.ListByGlobalAccount(ctx)
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Security Settings (Global Account)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Security Settings (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_globalaccount_trust_configuration.go
+++ b/internal/provider/resource_globalaccount_trust_configuration.go
@@ -152,7 +152,7 @@ func (rs *globalaccountTrustConfigurationResource) Read(ctx context.Context, req
 
 	cliRes, rawRes, err := rs.cli.Security.Trust.GetByGlobalAccount(ctx, state.Origin.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Trust Configuration (Global Account)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Trust Configuration (Global Account)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -205,7 +205,7 @@ func (rs *subaccountResource) Read(ctx context.Context, req resource.ReadRequest
 
 	cliRes, rawRes, err := rs.cli.Accounts.Subaccount.Get(ctx, data.ID.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Subaccount")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Subaccount")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_api_credential.go
+++ b/internal/provider/resource_subaccount_api_credential.go
@@ -151,7 +151,7 @@ func (rs *subaccountApiCredentialResource) Read(ctx context.Context, req resourc
 		Name:       state.Name.ValueString(),
 	})
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Api Credential (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Api Credential (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_environment_instance.go
+++ b/internal/provider/resource_subaccount_environment_instance.go
@@ -208,7 +208,7 @@ func (rs *subaccountEnvironmentInstanceResource) Read(ctx context.Context, req r
 
 	cliRes, rawRes, err := rs.cli.Accounts.EnvironmentInstance.Get(ctx, state.SubaccountId.ValueString(), state.Id.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Environment Instance (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Environment Instance (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_role.go
+++ b/internal/provider/resource_subaccount_role.go
@@ -114,7 +114,7 @@ func (rs *subaccountRoleResource) Read(ctx context.Context, req resource.ReadReq
 		state.RoleTemplateName.ValueString(),
 	)
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Role (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Role (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_role_collection.go
+++ b/internal/provider/resource_subaccount_role_collection.go
@@ -137,7 +137,7 @@ func (rs *subaccountRoleCollectionResource) Read(ctx context.Context, req resour
 
 	cliRes, rawRes, err := rs.cli.Security.RoleCollection.GetBySubaccount(ctx, state.SubaccountId.ValueString(), state.Name.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Role Collection (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Role Collection (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_security_settings.go
+++ b/internal/provider/resource_subaccount_security_settings.go
@@ -125,7 +125,7 @@ func (rs *subaccountSecuritySettingsResource) Read(ctx context.Context, req reso
 	cliRes, rawRes, err := rs.cli.Security.Settings.ListBySubaccount(ctx, state.SubaccountId.ValueString())
 
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Security Settings (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Security Settings (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_service_binding.go
+++ b/internal/provider/resource_subaccount_service_binding.go
@@ -149,7 +149,7 @@ func (rs *subaccountServiceBindingResource) Read(ctx context.Context, req resour
 
 	cliRes, rawRes, err := rs.cli.Services.Binding.GetById(ctx, state.SubaccountId.ValueString(), state.Id.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Service Binding (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Service Binding (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_service_broker.go
+++ b/internal/provider/resource_subaccount_service_broker.go
@@ -134,7 +134,7 @@ func (rs *subaccountServiceBrokerResource) Read(ctx context.Context, req resourc
 
 	cliRes, rawRes, err := rs.cli.Services.Broker.GetById(ctx, state.SubaccountId.ValueString(), state.Id.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Service Broker (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Service Broker (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_service_instance.go
+++ b/internal/provider/resource_subaccount_service_instance.go
@@ -170,7 +170,7 @@ func (rs *subaccountServiceInstanceResource) Read(ctx context.Context, req resou
 
 	cliRes, rawRes, err := rs.cli.Services.Instance.GetById(ctx, state.SubaccountId.ValueString(), state.Id.ValueString())
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Service Instance (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Service Instance (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_subscription.go
+++ b/internal/provider/resource_subaccount_subscription.go
@@ -213,8 +213,8 @@ func (rs *subaccountSubscriptionResource) Read(ctx context.Context, req resource
 	timeoutsLocal := state.Timeouts
 
 	cliRes, rawRes, err := rs.cli.Accounts.Subscription.Get(ctx, state.SubaccountId.ValueString(), state.AppName.ValueString(), state.PlanName.ValueString())
-	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Subscription (Subaccount)")
+	if err != nil || cliRes.State == saas_manager_service.StateNotSubscribed {
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Subscription (Subaccount)")
 		return
 	}
 

--- a/internal/provider/resource_subaccount_trust_configuration.go
+++ b/internal/provider/resource_subaccount_trust_configuration.go
@@ -182,7 +182,7 @@ func (rs *subaccountTrustConfigurationResource) Read(ctx context.Context, req re
 	cliRes, rawRes, err := rs.cli.Security.Trust.GetBySubaccount(ctx, state.SubaccountId.ValueString(), state.Origin.ValueString())
 
 	if err != nil {
-		handleReadErrors(ctx, rawRes, resp, err, "Resource Trust Configuration (Subaccount)")
+		handleReadErrors(ctx, rawRes, cliRes, resp, err, "Resource Trust Configuration (Subaccount)")
 		return
 	}
 


### PR DESCRIPTION
## Purpose

This PR closes #1060

Since unsubscribed subscriptions returned a ```200``` status code instead of a ```404```, the ```handleReadErrors()``` inside the ```internal/provider/helper.go``` file,  does not handle the drift detection for subscriptions deleted outside terraform.

Thus a check has been added against the ```state``` attribute of subscriptions in the same function. With this in place, drift for deleted subscriptions will now be handled properly.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR status on the Project board is set (typically "in review").
- [x] The PR has the matching labels assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up issues are created and linked.
