### PR TITLE
feat: relax constraint for subdomain naming convention

### DIFF
--- a/docs/resources/subaccount.md
+++ b/docs/resources/subaccount.md
@@ -113,6 +113,10 @@ terraform import btp_subaccount.my_project 6aa64c2f-38c1-49a9-b2e8-cf9fea769b7f
 ```
 
 
+## Recommended Naming Convention for Subdomain
+
+We recommend that the subdomain should only contain letters (a-z), digits (0-9), and hyphens (not at the start or end). The provider does not prevent using other naming patterns, but it will raise a warning if the subdomain does not follow this convention.
+
 ## Restriction
 
 The resource does not support the move of the subaccount to a new parent account (directory or global account). An update of the `parent_id` attribute will cause a deletion and recreation of the resource including the resources that depend on it.

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -223,8 +223,8 @@ func (rs *subaccountResource) Create(ctx context.Context, req resource.CreateReq
 
 	// We check the subdomain value against the recommended format of the API and the BTP Administrator's guide
 	// However we cannot enforce it via the schema as the cockpit allows also deviating formats
-	rg := regexp.MustCompile("^[a-z0-9](?:[a-z0-9|-]{0,61}[a-z0-9])?$")
-	if !rg.MatchString(plan.Subdomain.ValueString()) {
+
+	if !subdomainRegex.MatchString(plan.Subdomain.ValueString()) {
 		resp.Diagnostics.AddAttributeWarning(path.Root("subdomain"), "subdomain is in a non-recommended format", "subdomain should only contain letters (a-z), digits (0-9), and hyphens (not at the start or end)")
 	}
 

--- a/internal/provider/resource_subaccount.go
+++ b/internal/provider/resource_subaccount.go
@@ -88,9 +88,6 @@ __Further documentation:__
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile("^[a-z0-9](?:[a-z0-9|-]{0,61}[a-z0-9])?$"), "must only contain letters (a-z), digits (0-9), and hyphens (not at the start or end)"),
-				},
 			},
 			"parent_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the subaccount’s parent entity. If the subaccount is located directly in the global account (not in a directory), then this is the ID of the global account.",
@@ -222,6 +219,13 @@ func (rs *subaccountResource) Create(ctx context.Context, req resource.CreateReq
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// We check the subdomain value against the recommended format of the API and the BTP Administrator's guide
+	// However we cannot enforce it via the schema as the cockpit allows also deviating formats
+	rg := regexp.MustCompile("^[a-z0-9](?:[a-z0-9|-]{0,61}[a-z0-9])?$")
+	if !rg.MatchString(plan.Subdomain.ValueString()) {
+		resp.Diagnostics.AddAttributeWarning(path.Root("subdomain"), "subdomain is in a non-recommended format", "subdomain should only contain letters (a-z), digits (0-9), and hyphens (not at the start or end)")
 	}
 
 	args := btpcli.SubaccountCreateInput{

--- a/internal/provider/resource_subaccount_test.go
+++ b/internal/provider/resource_subaccount_test.go
@@ -212,18 +212,7 @@ func TestResourceSubaccount(t *testing.T) {
 			},
 		})
 	})
-	t.Run("error path - subdomain must be valid", func(t *testing.T) {
-		resource.Test(t, resource.TestCase{
-			IsUnitTest:               true,
-			ProtoV6ProviderFactories: getProviders(nil),
-			Steps: []resource.TestStep{
-				{
-					Config:      hclResourceSubaccount("uut", "a.subaccount", "eu12", "a.subaccount"),
-					ExpectError: regexp.MustCompile(`Attribute subdomain must only contain letters \(a-z\), digits \(0-9\)`),
-				},
-			},
-		})
-	})
+
 	t.Run("error path - cli server returns error", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.HasPrefix(r.URL.Path, "/login/") {

--- a/internal/provider/type_subaccount.go
+++ b/internal/provider/type_subaccount.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -12,6 +13,8 @@ import (
 
 const EntitlementFeature = "ENTITLEMENTS"
 const AuthorizationFeature = "AUTHORIZATIONS"
+
+var subdomainRegex = regexp.MustCompile("^[a-z0-9](?:[a-z0-9|-]{0,61}[a-z0-9])?$")
 
 type subaccountType struct {
 	ID             types.String `tfsdk:"id"`

--- a/templates/resources/subaccount.md.tmpl
+++ b/templates/resources/subaccount.md.tmpl
@@ -26,6 +26,10 @@ Import is supported using the following syntax:
 {{- end }}
 
 
+## Recommended Naming Convention for Subdomain
+
+We recommend that the subdomain should only contain letters (a-z), digits (0-9), and hyphens (not at the start or end). The provider does not prevent using other naming patterns, but it will raise a warning if the subdomain does not follow this convention.
+
 ## Restriction
 
 The resource does not support the move of the subaccount to a new parent account (directory or global account). An update of the `parent_id` attribute will cause a deletion and recreation of the resource including the resources that depend on it.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Relax validation of subdomain attribute:
  - no more attribute validation vioa schema
  - warning if subdomain is not following the proposed pattern
- closes #1105

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
The hard check would be a blocker for importing subaccounts that do not follow the proposed pattern.

Now a warning is raised during create: 

![image](https://github.com/user-attachments/assets/d9cf1a32-61a3-46b5-ab4e-f42165c00270)



## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
