### PR TITLE
fix: handling of timeout block for import of subscriptions

### DIFF
--- a/docs/resources/subaccount_subscription.md
+++ b/docs/resources/subaccount_subscription.md
@@ -86,6 +86,7 @@ Optional:
 
 - `create` (String) Timeout for creating the subscription.
 - `delete` (String) Timeout for deleting the subscription.
+- `update` (String) Timeout for updating the subscription.
 
 ## Import
 


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fixes update error when importing a subscription with a timeout
- Added timeout for update to schema
- Regenerated the documentation
- closes #1132

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Due to the nature of the timeout blocks, the import of a resource with a timeout block will result in a two step operation:

- First the resource will be imported
- A in-place update of the resource will be triggered to add the timeout block to the state

The in-place update has no impact on the resource itself.


## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
