### PR TITLE
chore: align login flows to wire protocoll

### DIFF
--- a/btp/provider/datasource_whoami.go
+++ b/btp/provider/datasource_whoami.go
@@ -73,7 +73,7 @@ func (gen *whoamiDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	data.ID = types.StringValue(user.Username)
+	data.ID = types.StringValue(user.Email)
 	data.Email = types.StringValue(user.Email)
 	data.Issuer = types.StringValue(user.Issuer)
 

--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -206,9 +206,8 @@ func (v2 *v2Client) Login(ctx context.Context, loginReq *LoginRequest) (*LoginRe
 		GlobalAccountSubdomain: loginReq.GlobalAccountSubdomain,
 		IdentityProvider:       loginReq.IdentityProvider,
 		LoggedInUser: &v2LoggedInUser{
-			Username: loginResponse.Username,
-			Email:    loginResponse.Email,
-			Issuer:   loginResponse.Issuer,
+			Email:  loginResponse.Email,
+			Issuer: loginResponse.Issuer,
 		},
 		SessionId: res.Header.Get(HeaderCLISessionId),
 	}
@@ -243,9 +242,8 @@ func (v2 *v2Client) IdTokenLogin(ctx context.Context, loginReq *IdTokenLoginRequ
 		GlobalAccountSubdomain: loginReq.GlobalAccountSubdomain,
 		IdentityProvider:       loginResponse.Issuer,
 		LoggedInUser: &v2LoggedInUser{
-			Username: loginResponse.Username,
-			Email:    loginResponse.Email,
-			Issuer:   loginResponse.Issuer,
+			Email:  loginResponse.Email,
+			Issuer: loginResponse.Issuer,
 		},
 		SessionId: res.Header.Get(HeaderCLISessionId),
 	}
@@ -315,11 +313,10 @@ func (v2 *v2Client) BrowserLogin(ctx context.Context, loginReq *BrowserLoginRequ
 		GlobalAccountSubdomain: loginReq.GlobalAccountSubdomain,
 		IdentityProvider:       loginReq.CustomIdp,
 		LoggedInUser: &v2LoggedInUser{
-			Username: browserLoginPostResponse.Username,
-			Email:    browserLoginPostResponse.Email,
-			Issuer:   browserLoginPostResponse.Issuer,
+			Email:  browserLoginPostResponse.Email,
+			Issuer: browserLoginPostResponse.Issuer,
 		},
-		SessionId: browserLoginPostResponse.RefreshToken,
+		SessionId: res.Header.Get(HeaderCLISessionId),
 	}
 
 	return &browserLoginPostResponse, nil

--- a/internal/btpcli/client.go
+++ b/internal/btpcli/client.go
@@ -252,7 +252,7 @@ func (v2 *v2Client) IdTokenLogin(ctx context.Context, loginReq *IdTokenLoginRequ
 }
 
 // BrowserLogin authenticates user using SSO
-func (v2 *v2Client) BrowserLogin(ctx context.Context, loginReq *BrowserLoginRequest) (*BrowserLoginPostResponse, error) {
+func (v2 *v2Client) BrowserLogin(ctx context.Context, loginReq *BrowserLoginRequest) (*LoginResponse, error) {
 	ctx = v2.initTrace(ctx)
 
 	// TODO: After the switch to client protocol v2.49.0 the terraform provider is still providing
@@ -297,7 +297,7 @@ func (v2 *v2Client) BrowserLogin(ctx context.Context, loginReq *BrowserLoginRequ
 		return nil, err
 	}
 
-	var browserLoginPostResponse BrowserLoginPostResponse
+	var browserLoginPostResponse LoginResponse
 	err = v2.parseResponse(ctx, res, &browserLoginPostResponse, http.StatusOK, map[int]string{
 		http.StatusUnauthorized:       "Login failed. Check your credentials.",
 		http.StatusForbidden:          fmt.Sprintf("You cannot access global account '%s'. Make sure you have at least read access to the global account, a directory, or a subaccount.", loginReq.GlobalAccountSubdomain),

--- a/internal/btpcli/client_test.go
+++ b/internal/btpcli/client_test.go
@@ -75,18 +75,16 @@ func TestV2Client_Login(t *testing.T) {
 					HeaderCLISessionId: "sessionid",
 				},
 				expectResponse: &LoginResponse{
-					Issuer:   "accounts.sap.com",
-					Username: "john.doe",
-					Email:    "john.doe@test.com",
+					Issuer: "accounts.sap.com",
+					Email:  "john.doe@test.com",
 				},
 				expectClientSession: &Session{
 					SessionId:              "sessionid",
 					IdentityProvider:       "",
 					GlobalAccountSubdomain: "subdomain",
 					LoggedInUser: &v2LoggedInUser{
-						Issuer:   "accounts.sap.com",
-						Username: "john.doe",
-						Email:    "john.doe@test.com",
+						Issuer: "accounts.sap.com",
+						Email:  "john.doe@test.com",
 					},
 				},
 			},
@@ -102,18 +100,16 @@ func TestV2Client_Login(t *testing.T) {
 					HeaderCLISessionId: "sessionid",
 				},
 				expectResponse: &LoginResponse{
-					Issuer:   "customidp.accounts.ondemand.com",
-					Username: "john.doe",
-					Email:    "john.doe@test.com",
+					Issuer: "customidp.accounts.ondemand.com",
+					Email:  "john.doe@test.com",
 				},
 				expectClientSession: &Session{
 					SessionId:              "sessionid",
 					GlobalAccountSubdomain: "subdomain",
 					IdentityProvider:       "my.custom.idp",
 					LoggedInUser: &v2LoggedInUser{
-						Issuer:   "customidp.accounts.ondemand.com",
-						Username: "john.doe",
-						Email:    "john.doe@test.com",
+						Issuer: "customidp.accounts.ondemand.com",
+						Email:  "john.doe@test.com",
 					},
 				},
 			},
@@ -200,18 +196,16 @@ func TestV2Client_IdTokenLogin(t *testing.T) {
 					HeaderCLISessionId: "sessionid",
 				},
 				expectResponse: &LoginResponse{
-					Issuer:   "idp.from.idtoken",
-					Username: "john.doe",
-					Email:    "john.doe@test.com",
+					Issuer: "idp.from.idtoken",
+					Email:  "john.doe@test.com",
 				},
 				expectClientSession: &Session{
 					SessionId:              "sessionid",
 					IdentityProvider:       "idp.from.idtoken",
 					GlobalAccountSubdomain: "subdomain",
 					LoggedInUser: &v2LoggedInUser{
-						Issuer:   "idp.from.idtoken",
-						Username: "john.doe",
-						Email:    "john.doe@test.com",
+						Issuer: "idp.from.idtoken",
+						Email:  "john.doe@test.com",
 					},
 				},
 			},
@@ -298,7 +292,7 @@ func TestV2Client_BrowserLogin(t *testing.T) {
 				idp = "customidp.accounts.ondemand.com"
 			}
 
-			w.Header().Add("HeaderCLISessionId", "sessionid")
+			w.Header().Add("X-Cpcli-Sessionid", "sessionid")
 			w.WriteHeader(http.StatusOK)
 
 			_, _ = w.Write([]byte("{\"issuer\":\"" + idp + "\",\"refreshToken\":\"sessionid\",\"user\":\"john.doe\",\"mail\":\"john.doe@test.com\"}"))
@@ -328,9 +322,8 @@ func TestV2Client_BrowserLogin(t *testing.T) {
 			IdentityProvider:       "",
 			GlobalAccountSubdomain: "my-subdomain",
 			LoggedInUser: &v2LoggedInUser{
-				Issuer:   "accounts.sap.com",
-				Username: "john.doe",
-				Email:    "john.doe@test.com",
+				Issuer: "accounts.sap.com",
+				Email:  "john.doe@test.com",
 			},
 		}, uut.session)
 	})
@@ -352,9 +345,8 @@ func TestV2Client_BrowserLogin(t *testing.T) {
 			IdentityProvider:       "my.custom.idp",
 			GlobalAccountSubdomain: "my-subdomain",
 			LoggedInUser: &v2LoggedInUser{
-				Issuer:   "customidp.accounts.ondemand.com",
-				Username: "john.doe",
-				Email:    "john.doe@test.com",
+				Issuer: "customidp.accounts.ondemand.com",
+				Email:  "john.doe@test.com",
 			},
 		}, uut.session)
 	})
@@ -489,9 +481,8 @@ func TestV2Client_Execute(t *testing.T) {
 			GlobalAccountSubdomain: "globalaccount-subdomain",
 			IdentityProvider:       "my.custom.idp",
 			LoggedInUser: &v2LoggedInUser{
-				Email:    "john.doe@int.test",
-				Username: "john.doe@int.test",
-				Issuer:   "customidp.accounts.ondemand.com",
+				Email:  "john.doe@int.test",
+				Issuer: "customidp.accounts.ondemand.com",
 			},
 		}
 
@@ -515,9 +506,8 @@ func TestV2Client_Execute(t *testing.T) {
 			GlobalAccountSubdomain: "globalaccount-subdomain",
 			IdentityProvider:       "my.custom.idp",
 			LoggedInUser: &v2LoggedInUser{
-				Email:    "john.doe@int.test",
-				Username: "john.doe@int.test",
-				Issuer:   "customidp.accounts.ondemand.com",
+				Email:  "john.doe@int.test",
+				Issuer: "customidp.accounts.ondemand.com",
 			},
 		}
 
@@ -541,9 +531,8 @@ func TestV2Client_Execute(t *testing.T) {
 			GlobalAccountSubdomain: "globalaccount-subdomain",
 			IdentityProvider:       "my.custom.idp",
 			LoggedInUser: &v2LoggedInUser{
-				Email:    "john.doe@int.test",
-				Username: "john.doe@int.test",
-				Issuer:   "customidp.accounts.ondemand.com",
+				Email:  "john.doe@int.test",
+				Issuer: "customidp.accounts.ondemand.com",
 			},
 		}
 
@@ -652,9 +641,8 @@ func TestV2Client_GetLoggedInUser(t *testing.T) {
 	})
 	t.Run("someone logged in", func(t *testing.T) {
 		testUser := &v2LoggedInUser{
-			Email:    "john.doe@test.com",
-			Username: "john.doe",
-			Issuer:   "test",
+			Email:  "john.doe@test.com",
+			Issuer: "test",
 		}
 
 		uut := NewV2Client(nil)

--- a/internal/btpcli/clienttypes.go
+++ b/internal/btpcli/clienttypes.go
@@ -70,16 +70,13 @@ type BrowserLoginRequest struct {
 }
 
 type LoginResponse struct {
-	Username string `json:"user"`
-	Email    string `json:"mail"`
-	Issuer   string `json:"issuer"`
+	Email  string `json:"mail"`
+	Issuer string `json:"issuer"`
 }
 
 type BrowserLoginPostResponse struct {
-	Issuer       string `json:"issuer"`
-	RefreshToken string `json:"refreshToken"`
-	Username     string `json:"user"`
-	Email        string `json:"mail"`
+	Issuer string `json:"issuer"`
+	Email  string `json:"mail"`
 }
 
 type BrowserResponse struct {

--- a/internal/btpcli/clienttypes.go
+++ b/internal/btpcli/clienttypes.go
@@ -74,11 +74,6 @@ type LoginResponse struct {
 	Issuer string `json:"issuer"`
 }
 
-type BrowserLoginPostResponse struct {
-	Issuer string `json:"issuer"`
-	Email  string `json:"mail"`
-}
-
 type BrowserResponse struct {
 	LoginID           string `json:"loginId"`
 	SubdomainRequired bool   `json:"subdomainRequired"`

--- a/internal/btpcli/session.go
+++ b/internal/btpcli/session.go
@@ -5,9 +5,8 @@ import (
 )
 
 type v2LoggedInUser struct {
-	Username string
-	Email    string
-	Issuer   string
+	Email  string
+	Issuer string
 }
 
 type Session struct {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Align the login flows with the current version of the SAP BTP CLI wire protocoll namely:
   - Only “issuer” and “mail” are in the response for any login flow. Mapping in response and setting to Session /v2LoggedInUser struct can be removed
   - For the browser login the response mapping can be unified with the regular login flow
   - For the Browser login the SessionId must be fetched from the response header
- In additon the `whoami` data source was adjusted to use the email field as ID. As of now the ID field was empty as the field is not transfered by the CLI server upon login
- closes #1139

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Alignment to BTP CLI server
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
See (SAP internal only): https://pages.github.tools.sap/btp-cli/documentation/architecture/wire-protocol/#login-endpoint

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
