### PR TITLE
fix: validate labels for subaccount

### DIFF
--- a/btp/provider/resource_subaccount.go
+++ b/btp/provider/resource_subaccount.go
@@ -21,6 +21,7 @@ import (
 	"github.com/SAP/terraform-provider-btp/internal/btpcli"
 	"github.com/SAP/terraform-provider-btp/internal/btpcli/types/cis"
 	"github.com/SAP/terraform-provider-btp/internal/tfutils"
+	"github.com/SAP/terraform-provider-btp/internal/validation/labelvalidator"
 )
 
 func newSubaccountResource() resource.Resource {
@@ -104,6 +105,9 @@ __Further documentation:__
 				},
 				MarkdownDescription: "The set of words or phrases assigned to the subaccount.",
 				Optional:            true,
+				Validators: []validator.Map{
+					labelvalidator.ValidLabels(),
+				},
 			},
 			"beta_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Shows whether the subaccount can use beta services and applications.",

--- a/internal/validation/labelvalidator/labelvalidator.go
+++ b/internal/validation/labelvalidator/labelvalidator.go
@@ -14,7 +14,7 @@ func (v labelsValidator) Description(ctx context.Context) string {
 }
 
 func (v labelsValidator) MarkdownDescription(ctx context.Context) string {
-	return "labels must have at most 10 keys and each value is no more than 63 characters."
+	return "labels must have at most 10 keys and each value must be at most 63 characters."
 }
 
 func (v labelsValidator) ValidateMap(ctx context.Context, request validator.MapRequest, response *validator.MapResponse) {

--- a/internal/validation/labelvalidator/labelvalidator.go
+++ b/internal/validation/labelvalidator/labelvalidator.go
@@ -31,7 +31,7 @@ func (v labelsValidator) ValidateMap(ctx context.Context, request validator.MapR
 		return
 	}
 
-	// Check the number of keys. Must nit exceed 10
+	// Check the number of keys. Must not exceed 10
 	if len(labels) > 10 {
 		response.Diagnostics.AddAttributeError(
 			request.Path,

--- a/internal/validation/labelvalidator/labelvalidator.go
+++ b/internal/validation/labelvalidator/labelvalidator.go
@@ -1,0 +1,59 @@
+package labelvalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type labelsValidator struct{}
+
+func (v labelsValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v labelsValidator) MarkdownDescription(ctx context.Context) string {
+	return "labels must have at most 10 keys and each value is no more than 63 characters."
+}
+
+func (v labelsValidator) ValidateMap(ctx context.Context, request validator.MapRequest, response *validator.MapResponse) {
+	// Validation for API constraints given by:
+	// https://api.sap.com/api/APIAccountsService/path/createSubaccountLabels
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var labels map[string][]string
+	diags := request.ConfigValue.ElementsAs(ctx, &labels, false)
+	if diags.HasError() {
+		response.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Check the number of keys. Must nit exceed 10
+	if len(labels) > 10 {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			v.Description(ctx),
+			fmt.Sprintf("The labels exceeds the number of 10 keys. Currently has %d keys.", len(labels)),
+		)
+	}
+
+	// Check the length of each value string, must not exceed 63 characters
+	for key, values := range labels {
+		for _, value := range values {
+			if len(value) > 63 {
+				response.Diagnostics.AddAttributeError(
+					request.Path,
+					v.Description(ctx),
+					fmt.Sprintf("The value for key '%s' exceeds the maximum length of 63 characters.", key),
+				)
+			}
+		}
+	}
+}
+
+func ValidLabels() validator.Map {
+	return labelsValidator{}
+}

--- a/internal/validation/labelvalidator/labelvalidator_test.go
+++ b/internal/validation/labelvalidator/labelvalidator_test.go
@@ -1,0 +1,92 @@
+package labelvalidator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestLabelValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		in        types.Map
+		expErrors int
+	}
+
+	var validlabels = map[string][]string{
+		"costcenter":  {"12345"},
+		"environment": {"production"},
+		"features":    {"featureset1", "featureset2"},
+	}
+
+	validLabelsTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.StringType}, validlabels)
+
+	var invalidLabelsLength = map[string][]string{
+		"costcenter":  {"12345"},
+		"environment": {"production"},
+		"features":    {"featureset1, featureset2, featureset3, featureset4, featureset5, featureset6"},
+	}
+
+	invalidLabelsLengthTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.StringType}, invalidLabelsLength)
+
+	var invalidLabelsNumber = map[string][]string{
+		"costcenter":   {"12345"},
+		"environment":  {"production"},
+		"features":     {"featureset1", "featureset2"},
+		"costcenter2":  {"12345"},
+		"environment2": {"production"},
+		"features2":    {"featureset1", "featureset2"},
+		"costcenter3":  {"12345"},
+		"environment3": {"production"},
+		"features3":    {"featureset1", "featureset2"},
+		"costcenter4":  {"12345"},
+		"environment4": {"production"},
+		"features4":    {"featureset1", "featureset2"},
+		"costcenter5":  {"12345"},
+		"environment5": {"production"},
+		"features5":    {"featureset1", "featureset2"},
+	}
+
+	invalidLabelsNumberTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.StringType}, invalidLabelsNumber)
+
+	testCases := map[string]testCase{
+		"valid-labels": {
+			in:        validLabelsTypesMap,
+			expErrors: 0,
+		},
+		"too-many-labels": {
+			in:        invalidLabelsNumberTypesMap,
+			expErrors: 1,
+		},
+		"too-long-label": {
+			in:        invalidLabelsLengthTypesMap,
+			expErrors: 1,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			req := validator.MapRequest{
+				ConfigValue: test.in,
+			}
+			res := validator.MapResponse{}
+			ValidLabels().ValidateMap(context.TODO(), req, &res)
+
+			if test.expErrors > 0 && !res.Diagnostics.HasError() {
+				t.Fatalf("expected %d error(s), got none", test.expErrors)
+			}
+
+			if test.expErrors > 0 && test.expErrors != res.Diagnostics.ErrorsCount() {
+				t.Fatalf("expected %d error(s), got %d: %v", test.expErrors, res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+
+			if test.expErrors == 0 && res.Diagnostics.HasError() {
+				t.Fatalf("expected no error(s), got %d: %v", res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Add a custom vlaidator for labels to the resource `btp_subaccount`
- See also: https://api.sap.com/api/APIAccountsService/path/createSubaccountLabels

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
In case of a production setup the missing validation leads to issues in the flow:

- A PR is opened with a subaccount configuration that contains invalid labels. A validation via `terraform validate` or a preliminary planning via `terraform plan` will not fail.
- The PR gets merged and the apply is triggered in the main branch: now the apply will fail due to an API error because the labels are not valid.

This is too late and cumbersome to fix (another round of PR, review, merge, apply) and no way to validate if the configuration is valid before the apply is triggered.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
