### PR TITLE
docs: remove BTP CLI specific information from documentation of subscription

### DIFF
--- a/btp/provider/datasource_subaccount_subscription.go
+++ b/btp/provider/datasource_subaccount_subscription.go
@@ -36,7 +36,7 @@ func (ds *subaccountSubscriptionDataSource) Configure(_ context.Context, req dat
 
 func (ds *subaccountSubscriptionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: `Gets details of a specific multitenant application to which a subaccount is entitled to subscribe. If this application is in a different global account than the current one, you need to specify its plan with '--plan'.
+		MarkdownDescription: `Gets details of a specific multitenant application to which a subaccount is entitled to subscribe.
 
 __Tip:__
 You must be assigned to the admin or viewer role of the subaccount.`,

--- a/docs/data-sources/subaccount_subscription.md
+++ b/docs/data-sources/subaccount_subscription.md
@@ -2,14 +2,14 @@
 page_title: "btp_subaccount_subscription Data Source - terraform-provider-btp"
 subcategory: ""
 description: |-
-  Gets details of a specific multitenant application to which a subaccount is entitled to subscribe. If this application is in a different global account than the current one, you need to specify its plan with '--plan'.
+  Gets details of a specific multitenant application to which a subaccount is entitled to subscribe.
   Tip:
   You must be assigned to the admin or viewer role of the subaccount.
 ---
 
 # btp_subaccount_subscription (Data Source)
 
-Gets details of a specific multitenant application to which a subaccount is entitled to subscribe. If this application is in a different global account than the current one, you need to specify its plan with '--plan'.
+Gets details of a specific multitenant application to which a subaccount is entitled to subscribe.
 
 __Tip:__
 You must be assigned to the admin or viewer role of the subaccount.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Remove the `--plan` description from the documentation of the `btp_subaccount_subscription` data source.
- This information was taken over from the BTP CLI documentation and is nit relevant for the Terraform provider documentation.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
