### PR TITLE
fix: label validator on unknown errors

### DIFF
--- a/internal/validation/labelvalidator/labelvalidator.go
+++ b/internal/validation/labelvalidator/labelvalidator.go
@@ -68,6 +68,12 @@ func (v labelsValidator) ValidateMap(ctx context.Context, request validator.MapR
 							fmt.Sprintf("The value for key '%s' exceeds the maximum length of 63 characters.", key),
 						)
 					}
+				} else {
+					response.Diagnostics.AddAttributeError(
+						request.Path,
+						v.Description(ctx),
+						fmt.Sprintf("Unexpected element type for key '%s'.", key),
+					)
 				}
 			}
 		default:

--- a/internal/validation/labelvalidator/labelvalidator_test.go
+++ b/internal/validation/labelvalidator/labelvalidator_test.go
@@ -24,6 +24,18 @@ func TestLabelValidator(t *testing.T) {
 
 	validLabelsTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.StringType}, validlabels)
 
+	var invalidLabels = map[string][]int{
+		"costcenter":  {12345},
+	}
+
+	invalidLabelsTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.Int32Type}, invalidLabels)
+
+	var invalidLabels_LabelType = map[string]string{
+		"costcenter":  "12345",
+	}
+
+	invalidLabels_LabelTypeTypesMap, _ := types.MapValueFrom(context.TODO(), types.StringType, invalidLabels_LabelType)
+
 	var invalidLabelsLength = map[string][]string{
 		"costcenter":  {"12345"},
 		"environment": {"production"},
@@ -56,6 +68,14 @@ func TestLabelValidator(t *testing.T) {
 		"valid-labels": {
 			in:        validLabelsTypesMap,
 			expErrors: 0,
+		},
+		"invalid-labels": {
+			in: 	  invalidLabelsTypesMap,
+			expErrors: 1,
+		},
+		"invalid-labels-lableType": {
+			in: 	  invalidLabels_LabelTypeTypesMap,
+			expErrors: 1,
 		},
 		"too-many-labels": {
 			in:        invalidLabelsNumberTypesMap,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fixes error on label validation when labels are provided as variables
- Fixes #1187 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

Setup is:

- Labels are provided as variables or derived as local values from variables
- User executes the `terraform validate` command
- Error is thrown:

```bash
Error: Value Conversion Error

 An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the following to the provider developer:

 Received unknown value, however the target type cannot handle unknown values. Use the corresponding types package type or a custom type that handles
 unknown values.
```

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
