### PR TITLE
feat: Make Trust Origin Key Customisable

### DIFF
--- a/docs/resources/subaccount_trust_configuration.md
+++ b/docs/resources/subaccount_trust_configuration.md
@@ -36,6 +36,7 @@ resource "btp_subaccount_trust_configuration" "fully_customized" {
   identity_provider = "terraformint.accounts400.ondemand.com"
   name              = "my-name"
   description       = "my-description"
+  origin            = "my-origin-key"
 }
 ```
 
@@ -55,12 +56,12 @@ resource "btp_subaccount_trust_configuration" "fully_customized" {
 - `domain` (String) The tenant's domain which should be used for user logon.
 - `link_text` (String) Short string that helps users to identify the link for login.
 - `name` (String) The display name of the trust configuration.
+- `origin` (String) The origin of the identity provider.
 - `status` (String) Determines whether the identity provider is currently 'active' or 'inactive'.
 
 ### Read-Only
 
 - `id` (String, Deprecated) The origin of the identity provider.
-- `origin` (String) The origin of the identity provider.
 - `protocol` (String) The protocol used to establish trust with the identity provider.
 - `read_only` (Boolean) Shows whether the trust configuration can be modified.
 - `type` (String) The trust type.

--- a/examples/resources/btp_subaccount_trust_configuration/resource.tf
+++ b/examples/resources/btp_subaccount_trust_configuration/resource.tf
@@ -12,4 +12,5 @@ resource "btp_subaccount_trust_configuration" "fully_customized" {
   identity_provider = "terraformint.accounts400.ondemand.com"
   name              = "my-name"
   description       = "my-description"
+  origin            = "my-origin-key"
 }

--- a/internal/validation/labelvalidator/labelvalidator_test.go
+++ b/internal/validation/labelvalidator/labelvalidator_test.go
@@ -25,13 +25,13 @@ func TestLabelValidator(t *testing.T) {
 	validLabelsTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.StringType}, validlabels)
 
 	var invalidLabels = map[string][]int{
-		"costcenter":  {12345},
+		"costcenter": {12345},
 	}
 
 	invalidLabelsTypesMap, _ := types.MapValueFrom(context.TODO(), types.SetType{ElemType: types.Int32Type}, invalidLabels)
 
 	var invalidLabels_LabelType = map[string]string{
-		"costcenter":  "12345",
+		"costcenter": "12345",
 	}
 
 	invalidLabels_LabelTypeTypesMap, _ := types.MapValueFrom(context.TODO(), types.StringType, invalidLabels_LabelType)
@@ -70,11 +70,11 @@ func TestLabelValidator(t *testing.T) {
 			expErrors: 0,
 		},
 		"invalid-labels": {
-			in: 	  invalidLabelsTypesMap,
+			in:        invalidLabelsTypesMap,
 			expErrors: 1,
 		},
 		"invalid-labels-lableType": {
-			in: 	  invalidLabels_LabelTypeTypesMap,
+			in:        invalidLabels_LabelTypeTypesMap,
 			expErrors: 1,
 		},
 		"too-many-labels": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-btp/issues/1199

- Updated the origin attribute from computed-only to optional + computed.
- Added logic to include origin in the btpcli.TrustConfigurationCreateInput when defined in the plan.
- Added an explicit check to prevent mutation of the origin field. If the plan’s origin differs from the state, the provider now returns a user-friendly diagnostic error instead of attempting an update.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
