### PR TITLE
fix: deprecated attribute for subaccount roles

### DIFF
--- a/btp/provider/resource_subaccount_role.go
+++ b/btp/provider/resource_subaccount_role.go
@@ -120,7 +120,8 @@ __Further documentation:__
 							},
 						},
 						"value_required": schema.BoolAttribute{
-							MarkdownDescription: "Shows whether the value is required.",
+							MarkdownDescription: "Do not use this attribute as it is defined is defined in the security descriptor (see <https://help.sap.com/docs/btp/sap-business-technology-platform/application-security-descriptor-configuration-syntax?#loio517895a9612241259d6941dbf9ad81cb__section_pv5_5qr_xs>).",
+							DeprecationMessage:  "Remove this attribute's configuration as it is not relevant for role creation. The attribute is defined in the security descriptor (see <https://help.sap.com/docs/btp/sap-business-technology-platform/application-security-descriptor-configuration-syntax?#loio517895a9612241259d6941dbf9ad81cb__section_pv5_5qr_xs>) and not relevant for role creation.",
 							Optional:            true,
 							Computed:            true,
 						},

--- a/docs/resources/subaccount_role.md
+++ b/docs/resources/subaccount_role.md
@@ -76,7 +76,7 @@ Required:
 
 Optional:
 
-- `value_required` (Boolean) Shows whether the value is required.
+- `value_required` (Boolean, Deprecated) Do not use this attribute as it is defined is defined in the security descriptor (see <https://help.sap.com/docs/btp/sap-business-technology-platform/application-security-descriptor-configuration-syntax?#loio517895a9612241259d6941dbf9ad81cb__section_pv5_5qr_xs>).
 
 ## Import
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Marks the attribute `value_required` of the resources `btp_subaccount_role` as deprecated.
- Resaon: The attribute valueRequired is something that can be specified in the security descriptor:
https://help.sap.com/docs/btp/sap-business-technology-platform/application-security-descriptor-configuration-syntax?locale=en-US#loio517895a9612241259d6941dbf9ad81cb__section_pv5_5qr_xs
It is not relevant during role creation (apart from the fact that you may need to provide an attribute value).
- Only relevant for roles on subaccount level, attribute is not available on global account or directory level
- Keeping the value as computed in the the corresponding data source
- closes #1228

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
See https://help.sap.com/docs/btp/sap-business-technology-platform/application-security-descriptor-configuration-syntax?locale=en-US#loio517895a9612241259d6941dbf9ad81cb__section_pv5_5qr_xs for more details on the attribute definition

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
