### PR TITLE
fix: sideeffects from calculated fields of envionment instance

### DIFF
--- a/btp/provider/resource_subaccount_environment_instance.go
+++ b/btp/provider/resource_subaccount_environment_instance.go
@@ -141,6 +141,9 @@ __Further documentation:__
 			"labels": schema.StringAttribute{
 				MarkdownDescription: "The Broker-specified key-value pairs that specify attributes of an environment instance.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"last_modified": schema.StringAttribute{
 				MarkdownDescription: "The date and time when the resource was last modified in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.",
@@ -157,6 +160,9 @@ __Further documentation:__
 			"platform_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the platform for the environment instance in the corresponding service broker's catalog.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"service_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the service for the environment instance in the corresponding service broker's catalog.",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- In the resource `btp_subaccount_evionment_instance` some **calculated** fields are used for further processing e.g., for creating CF spaces. Changes in the configuration that do not change these calculated fields should not trigger an update of dependent resources. This PR mitigates this isse by introducing corresponding plan modifiers for the field `platform_id` and `labels`
- Closes #1268

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
This issue mainly appears when the BTP and CF configuration are managed in a single Terraform configuration.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
