### PR TITLE
fix: modified regression workflow for canary

### DIFF
--- a/.github/workflows/canary-regression-test.yml
+++ b/.github/workflows/canary-regression-test.yml
@@ -84,7 +84,7 @@ jobs:
         # Perform replacements in variables.tf
         sed -i 's|https://cli.btp.cloud.sap|https://canary.cli.btp.int.sap|g' "$VARS_FILE"
         sed -i 's|\bus10\b|eu12|g' "$VARS_FILE"
-        sed -i 's|terraformeds2.accounts.ondemand.com|iasprovidertestblr.accounts400.ondemand.com|g' "$VARS_FILE"
+        sed -i 's|terraformeds2.accounts.ondemand.com|iasproviderdevblr.accounts400.ondemand.com|g' "$VARS_FILE"
         sed -i 's|\bmain\b|canary-main|g' "$VARS_FILE"
 
         # Perform replacement in main.tf


### PR DESCRIPTION
## Purpose
Modified the regression workflow to work against a different global account. 
- GitHub action secrets updated and the same changes are reflected in the workflow
- Minor changes made w.r.t to the variables in the `variables.tf` file
- The workflow now runs against a different IdP in alignment with the new global account

Successful workflow execution as seen [in this run](https://github.com/SAP/terraform-provider-btp/actions/runs/20159023064)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR status on the Project board is set (typically "in review").
- [x] The PR has the matching labels assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up issues are created and linked.
