### PR TITLE
chore: duplicate the merge function

### DIFF
--- a/btp/provider/resource_subaccount_destination_generic.go
+++ b/btp/provider/resource_subaccount_destination_generic.go
@@ -207,7 +207,7 @@ func (rs *subaccountDestinationGenericResource) Read(ctx context.Context, req re
 	data, diags = destinationGenericResourceValueFrom(cliRes, data.SubaccountID, data.ServiceInstanceID, data.Name.ValueString())
 	resp.Diagnostics.Append(diags...)
 
-	data.DestinationConfiguration, err = MergeDestinationConfig(planDestinationConfiguration, data.DestinationConfiguration)
+	data.DestinationConfiguration, err = MergeGenericDestinationConfig(planDestinationConfiguration, data.DestinationConfiguration)
 	if err != nil {
 		resp.Diagnostics.AddError(ErrApiMergingDestinationConfiguration, fmt.Sprintf("%s", err))
 		return
@@ -267,7 +267,7 @@ func (rs *subaccountDestinationGenericResource) Create(ctx context.Context, req 
 
 	plan, diags = destinationGenericResourceValueFrom(cliRes, plan.SubaccountID, plan.ServiceInstanceID, name)
 	resp.Diagnostics.Append(diags...)
-	plan.DestinationConfiguration, err = MergeDestinationConfig(planDestinationConfiguration, plan.DestinationConfiguration)
+	plan.DestinationConfiguration, err = MergeGenericDestinationConfig(planDestinationConfiguration, plan.DestinationConfiguration)
 	if err != nil {
 		resp.Diagnostics.AddError(ErrApiMergingDestinationConfiguration, fmt.Sprintf("%s", err))
 		return
@@ -322,7 +322,7 @@ func (rs *subaccountDestinationGenericResource) Update(ctx context.Context, req 
 
 	plan, diags = destinationGenericResourceValueFrom(cliRes, plan.SubaccountID, plan.ServiceInstanceID, name)
 	resp.Diagnostics.Append(diags...)
-	plan.DestinationConfiguration, err = MergeDestinationConfig(planDestinationConfiguration, plan.DestinationConfiguration)
+	plan.DestinationConfiguration, err = MergeGenericDestinationConfig(planDestinationConfiguration, plan.DestinationConfiguration)
 	if err != nil {
 		resp.Diagnostics.AddError(ErrApiMergingDestinationConfiguration, fmt.Sprintf("%s", err))
 		return


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- added the merge destination function for destination generic resource
- Deduplicating this function as we will continue working with this function as the older resource will be deprecated and don't want to disturb that function anymore.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [x] The PR status on the Project board is set (typically "in review").
- [x] The PR has the matching labels assigned to it.
- [x] If the PR closes an issue, the issue is referenced.
- [x] Possible follow-up issues are created and linked.
