### PR TITLE
fix: plan modifier fails when config values are dynamic

### DIFF
--- a/btp/provider/resource_subaccount_destination_generic.go
+++ b/btp/provider/resource_subaccount_destination_generic.go
@@ -146,7 +146,9 @@ var replacePlanModifier = func(ctx context.Context, request planmodifier.StringR
 		return
 	}
 
-	if planVal.DestinationConfiguration.ValueString() == "" || stateVal.DestinationConfiguration.ValueString() == "" {
+	if planVal.DestinationConfiguration.IsNull() || stateVal.DestinationConfiguration.IsNull() ||
+		planVal.DestinationConfiguration.IsUnknown() || stateVal.DestinationConfiguration.IsUnknown() ||
+		planVal.DestinationConfiguration.ValueString() == "" || stateVal.DestinationConfiguration.ValueString() == "" {
 		return
 	}
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR handles dynamic plan changes in the custom plan modifier. In case of a dynamic setup of variables, the plan is an empty string and not NIL.
- To be safe other cases for the values are handled
- closes #1359

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
