### PR TITLE
fix: error when creating an evironment instance

### DIFF
--- a/btp/provider/resource_subaccount_environment_instance.go
+++ b/btp/provider/resource_subaccount_environment_instance.go
@@ -302,9 +302,11 @@ func (rs *subaccountEnvironmentInstanceResource) Create(ctx context.Context, req
 	// The retryable HTTP client already handles transient network and HTTP errors.
 	// However, the BTP API may still respond with "not ready" or "processing" errors after a successful request.
 	// Keeping this check ensures Terraform continues polling until the resource reaches a stable state.
+	// Update due to change of API response: Even upon CREATE the status might change to "UPDATING" before it reaches the final "OK" state.
+	// Therefore, the pending states now include both "CREATING" and "UPDATING" as well as the target states "OK", "CREATION_FAILED", and "UPDATE_FAILED".
 	createStateConf := &tfutils.StateChangeConf{
-		Pending: []string{provisioning.StateCreating},
-		Target:  []string{provisioning.StateOK, provisioning.StateCreationFailed},
+		Pending: []string{provisioning.StateCreating, provisioning.StateUpdating},
+		Target:  []string{provisioning.StateOK, provisioning.StateCreationFailed, provisioning.StateUpdateFailed},
 		Refresh: func() (any, string, error) {
 			subRes, _, err := rs.cli.Accounts.EnvironmentInstance.Get(ctx, plan.SubaccountId.ValueString(), cliRes.Id)
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- This PR updates the allowed transition states when an environment instance gets created. In contrast to what is expected the state during creation might change to `UPDATING`.
- This state transition is added to the create polling flow to prevent the creation from failing when the state changes to `UPDATING` during creation.
- closes #1392

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
