### PR TITLE
fix: state handling during polling

### DIFF
--- a/btp/provider/resource_subaccount_environment_instance.go
+++ b/btp/provider/resource_subaccount_environment_instance.go
@@ -318,11 +318,6 @@ func (rs *subaccountEnvironmentInstanceResource) Create(ctx context.Context, req
 				return subRes, "", err
 			}
 
-			// return an error if the environment instance is in a failed state to avoid inconsistent state in Terraform and to surface the error to the user
-			if subRes.State == provisioning.StateCreationFailed || subRes.State == provisioning.StateUpdateFailed {
-				return subRes, "", fmt.Errorf("environment instance is in failed state: %s", subRes.State)
-			}
-
 			return subRes, subRes.State, nil
 		},
 		Timeout:    createTimeout,
@@ -333,6 +328,12 @@ func (rs *subaccountEnvironmentInstanceResource) Create(ctx context.Context, req
 	updatedRes, err := createStateConf.WaitForStateContext(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("API Error Creating Resource Environment Instance (Subaccount)", fmt.Sprintf("%s", err))
+		return
+	}
+
+	// return an error if the environment instance is in a failed state to avoid inconsistent state in Terraform and to surface the error to the user
+	if updatedRes.(provisioning.EnvironmentInstanceResponseObject).State == provisioning.StateCreationFailed || updatedRes.(provisioning.EnvironmentInstanceResponseObject).State == provisioning.StateUpdateFailed {
+		resp.Diagnostics.AddError("API Error Creating Resource Environment Instance (Subaccount)", fmt.Sprintf("environment instance is in failed state: %s", updatedRes.(provisioning.EnvironmentInstanceResponseObject).State))
 		return
 	}
 
@@ -394,11 +395,6 @@ func (rs *subaccountEnvironmentInstanceResource) Update(ctx context.Context, req
 				return subRes, "", err
 			}
 
-			// return an error if the environment instance is in a failed state to avoid inconsistent state in Terraform and to surface the error to the user
-			if subRes.State == provisioning.StateUpdateFailed {
-				return subRes, "", fmt.Errorf("environment instance is in failed state: %s", subRes.State)
-			}
-
 			return subRes, subRes.State, nil
 		},
 		Timeout:    updateTimeout,
@@ -409,6 +405,12 @@ func (rs *subaccountEnvironmentInstanceResource) Update(ctx context.Context, req
 	updatedRes, err := updateStateConf.WaitForStateContext(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("API Error Updating Resource Environment Instance (Subaccount)", fmt.Sprintf("%s", err))
+		return
+	}
+
+	// return an error if the environment instance is in a failed state to avoid inconsistent state in Terraform and to surface the error to the user
+	if updatedRes.(provisioning.EnvironmentInstanceResponseObject).State == provisioning.StateUpdateFailed {
+		resp.Diagnostics.AddError("API Error Updating Resource Environment Instance (Subaccount)", fmt.Sprintf("environment instance is in failed state: %s", updatedRes.(provisioning.EnvironmentInstanceResponseObject).State))
 		return
 	}
 
@@ -473,11 +475,6 @@ func (rs *subaccountEnvironmentInstanceResource) Delete(ctx context.Context, req
 				return subRes, subRes.State, err
 			}
 
-			// return an error if the environment instance is in a failed state to avoid inconsistent state in Terraform and to surface the error to the user
-			if subRes.State == provisioning.StateDeletionFailed {
-				return subRes, "", fmt.Errorf("environment instance is in failed state: %s", subRes.State)
-			}
-
 			return subRes, subRes.State, nil
 		},
 		Timeout:    deleteTimeout,
@@ -485,12 +482,19 @@ func (rs *subaccountEnvironmentInstanceResource) Delete(ctx context.Context, req
 		MinTimeout: minTimeout,
 	}
 
-	_, err = deleteStateConf.WaitForStateContext(ctx)
+	updatedRes, err := deleteStateConf.WaitForStateContext(ctx)
 
 	if err != nil {
 		resp.Diagnostics.AddError("API Error Deleting Resource Environment Instance (Subaccount)", fmt.Sprintf("%s", err))
 		return
 	}
+
+	// return an error if the environment instance is in a failed state to avoid inconsistent state in Terraform and to surface the error to the user
+	if updatedRes.(provisioning.EnvironmentInstanceResponseObject).State == provisioning.StateDeletionFailed {
+		resp.Diagnostics.AddError("API Error Deleting Resource Environment Instance (Subaccount)", fmt.Sprintf("environment instance is in failed state: %s", updatedRes.(provisioning.EnvironmentInstanceResponseObject).State))
+		return
+	}
+
 }
 
 func (rs *subaccountEnvironmentInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Adjust the state hanlding during polling of environment instance creation, update and deletion to return an error if the environment instance is in a failed state (creation failed, update failed, deletion failed) to avoid inconsistent state in Terraform and to surface the error to the user.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
