### PR TITLE
fix: setting of resource identity during import

### DIFF
--- a/btp/provider/resource_subaccount_environment_instance.go
+++ b/btp/provider/resource_subaccount_environment_instance.go
@@ -258,7 +258,7 @@ func (rs *subaccountEnvironmentInstanceResource) Read(ctx context.Context, req r
 	if diags.HasError() {
 		identity = subaccountEnvironmentInstanceIdentityModel{
 			SubaccountID: state.SubaccountId,
-			Id:           state.Id,
+			Id:           updatedState.Id,
 		}
 
 		diags = resp.Identity.Set(ctx, identity)

--- a/btp/provider/resource_subaccount_service_binding.go
+++ b/btp/provider/resource_subaccount_service_binding.go
@@ -191,7 +191,7 @@ func (rs *subaccountServiceBindingResource) Read(ctx context.Context, req resour
 	if diags.HasError() {
 		identity = subaccountServiceBindingIdentityModel{
 			SubaccountID: state.SubaccountId,
-			Id:           state.Id,
+			Id:           updatedState.Id,
 		}
 
 		diags = resp.Identity.Set(ctx, identity)

--- a/btp/provider/resource_subaccount_service_broker.go
+++ b/btp/provider/resource_subaccount_service_broker.go
@@ -210,7 +210,7 @@ func (rs *subaccountServiceBrokerResource) Read(ctx context.Context, req resourc
 	if diags.HasError() {
 		identity = subaccountServiceBrokerIdentityModel{
 			SubaccountID: state.SubaccountId,
-			Id:           state.Id,
+			Id:           newState.Id,
 		}
 
 		diags = resp.Identity.Set(ctx, identity)

--- a/btp/provider/resource_subaccount_service_instance.go
+++ b/btp/provider/resource_subaccount_service_instance.go
@@ -212,7 +212,7 @@ func (rs *subaccountServiceInstanceResource) Read(ctx context.Context, req resou
 	if diags.HasError() {
 		identity = subaccountServiceInstanceIdentityModel{
 			SubaccountID: state.SubaccountId,
-			Id:           state.Id,
+			Id:           newState.Id,
 		}
 
 		diags = resp.Identity.Set(ctx, identity)

--- a/btp/provider/resource_subaccount_trust_configuration.go
+++ b/btp/provider/resource_subaccount_trust_configuration.go
@@ -215,8 +215,8 @@ func (rs *subaccountTrustConfigurationResource) Read(ctx context.Context, req re
 	diags = req.Identity.Get(ctx, &identity)
 	if diags.HasError() {
 		identity = subaccountTrustConfigurationIdentityModel{
-			SubaccountID: state.SubaccountId,
-			Origin:       state.Id,
+			SubaccountID: updatedState.SubaccountId,
+			Origin:       updatedState.Id,
 		}
 
 		diags = resp.Identity.Set(ctx, identity)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Ensure that the resource identity is set consistently in the `READ` function of the resources i.e. when a resource is imoported with resource ID and not by identity
- closes #1449

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
