### PR TITLE
fix: date format for subscriptions

### DIFF
--- a/internal/btpcli/types/saas_manager_service/time.go
+++ b/internal/btpcli/types/saas_manager_service/time.go
@@ -16,6 +16,10 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 
 	layout := "Jan 2, 2006, 3:04:05 PM"
 
+	// Normalize narrow no-break space (U+202F) to a regular space.
+	// Some locales use it as the AM/PM separator instead of a regular space.
+	s = strings.ReplaceAll(s, "\u202f", " ")
+
 	timeString, err := time.Parse(layout, s)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
On SAP internal Canary landscape users are sunning into the issue that for the resource `btp_subaccount_subscription` the following error is raised

```bash
 Error: API Error Creating Resource Subscription (Subaccount)
│
│   with btp_subaccount_subscription.hana_cloud_tools,
│   on main.tf line 28, in resource "btp_subaccount_subscription" "hana_cloud_tools":
│   28: resource "btp_subaccount_subscription" "hana_cloud_tools" {
│
│ parsing time "Mar 27, 2026, 8:36:30\xe2\x80\xafAM" as "Jan 2, 2006, 3:04:05 PM": cannot parse "\xe2\x80\xafAM" as " "
```

This is due to an uncoordinated change of teh API which suddenly started to return the date in a different format. This PR adapts the code to be able to handle both formats.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Handling of both date formats is implemented, so the code should work on both Canary and Life without any changes. The code is tested on Canary and Life.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
