### PR TITLE
chore: Add ref tag to binary check

### DIFF
--- a/.github/workflows/binary-integrity-check.yml
+++ b/.github/workflows/binary-integrity-check.yml
@@ -27,7 +27,17 @@ on:
       - 'go.sum'
       - '**.go'
   workflow_dispatch:
+    inputs:
+      RELEASE_VERSION:
+        description: 'Release version to use (e.g. 1.22.0). If omitted, the latest release tag is fetched automatically.'
+        required: false
+        type: string
   workflow_call:
+    inputs:
+      RELEASE_VERSION:
+        description: 'Release version to use. If omitted, the latest release tag is fetched automatically.'
+        required: false
+        type: string
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
 permissions:
@@ -37,6 +47,8 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ inputs.RELEASE_VERSION || '' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,6 +62,7 @@ jobs:
 
       - name: Get last Release Tag
         id: get_last_release
+        if: env.RELEASE_VERSION == ''
         run: |
           echo "RELEASE_VERSION=$(gh release view --json tagName -q '.tagName | ltrimstr("v")')" >> "$GITHUB_ENV"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
   call-workflow-binary-integrity-check:
     uses: ./.github/workflows/binary-integrity-check.yml
     secrets: inherit
+    with:
+      RELEASE_VERSION: ${{ github.ref_name }} # Pass the tag name as the release version to the binary integrity check workflow.
   goreleaser:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- By default, the release workflow works with the last release tag; however, when running against a new release, it needs to take the latest tag and not the old release

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

