### PR TITLE
chore: Removed dependency between canary and live integration tests

### DIFF
--- a/.github/workflows/integration-test-opentofu.yml
+++ b/.github/workflows/integration-test-opentofu.yml
@@ -23,7 +23,6 @@ jobs:
 
   live-main:
     name: Live Main
-    needs: canary-stable
     uses: ./.github/workflows/ot-live-integration-test-main.yml
     secrets: inherit
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,7 +23,6 @@ jobs:
 
   live-main:
     name: Live Main
-    needs: canary-stable
     uses: ./.github/workflows/tf-live-integration-test-main.yml
     secrets: inherit
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Now canary and live integrations can run in parallel with main and stable steps running sequentially internally.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Test setup
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
