### PR TITLE
docs: fix list of valid service offering environments

### DIFF
--- a/btp/provider/datasource_subaccount_service_offerings.go
+++ b/btp/provider/datasource_subaccount_service_offerings.go
@@ -80,8 +80,9 @@ You must be assigned to the admin or viewer role of the subaccount.`,
 				MarkdownDescription: "Lists services to be consumed in a Cloud Foundry or Kubernetes-native way. Valid values are: \n " +
 					getFormattedValueAsTableRow("value", "description") +
 					getFormattedValueAsTableRow("---", "---") +
-					getFormattedValueAsTableRow("`cloudfoundry`", "Cloud Foundry") +
-					getFormattedValueAsTableRow("`kubernetes`", "Kubernetes"),
+					getFormattedValueAsTableRow("`sapbtp`", "Service offerings associated with SAP BTP") +
+					getFormattedValueAsTableRow("`cloudfoundry`", "Service offerings associated with Cloud Foundry") +
+					getFormattedValueAsTableRow("`kubernetes`", "Service offerings associated with Kubernetes"),
 				Optional: true,
 			},
 			"fields_filter": schema.StringAttribute{

--- a/docs/data-sources/subaccount_service_offerings.md
+++ b/docs/data-sources/subaccount_service_offerings.md
@@ -54,8 +54,9 @@ data "btp_subaccount_service_offerings" "labeled" {
  
   | value | description | 
   | --- | --- | 
-  | `cloudfoundry` | Cloud Foundry | 
-  | `kubernetes` | Kubernetes |
+  | `sapbtp` | Service offerings associated with SAP BTP | 
+  | `cloudfoundry` | Service offerings associated with Cloud Foundry | 
+  | `kubernetes` | Service offerings associated with Kubernetes |
 - `fields_filter` (String) Filters the response based on the field query. For example, use "name eq 'my service offering name'".
 - `labels_filter` (String) Filters the response based on the label query.  For example, to list all the service offerings associated with the testing environment, use "environment eq 'test'".
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Fix documentation for `btp_service_offerings` data source
- Add valid environment filter value `sapbtp` to list of attribute
- closes #1548

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Examples are already refelcting this value, so no need to update them.

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
