### PR TITLE
chore: Fixing ga_trust_configuration for integration tests

### DIFF
--- a/tests/integration-test/canary.tfvars
+++ b/tests/integration-test/canary.tfvars
@@ -1,6 +1,6 @@
 cli_server                         = "https://canary.cli.btp.int.sap"
 region                             = "eu12"
-testing_idp                        = "iasproviderdevblr.accounts400.ondemand.com"
+# testing_idp                        = "iasproviderdevblr.accounts400.ondemand.com"
 subaccount_subdomain_extension     = "canary-main"
 globalaccount_role_template_app_id = "cis-central!b13"
 directory_role_template_app_id     = "cis-central!b13"

--- a/tests/integration-test/live.tfvars
+++ b/tests/integration-test/live.tfvars
@@ -1,6 +1,6 @@
 cli_server                         = "https://cli.btp.cloud.sap"
 region                             = "us10"
-testing_idp                        = "terraformeds2.accounts.ondemand.com"
+# testing_idp                        = "terraformeds2.accounts.ondemand.com"
 subaccount_subdomain_extension     = "live-main"
 globalaccount_role_template_app_id = "cis-central!b14"
 directory_role_template_app_id     = "cis-central!b14"

--- a/tests/integration-test/main.tf
+++ b/tests/integration-test/main.tf
@@ -68,11 +68,13 @@ resource "btp_globalaccount_role_collection_assignment" "grca_gaa" {
 # global account trust configuration
 ###
 
-resource "btp_globalaccount_trust_configuration" "gtc_idp_testing" {
-  identity_provider = var.testing_idp
-  name              = split(".", var.testing_idp)[0]
-  description       = "Custom Platform Identity Provider for Test Cases"
-}
+// The resource btp_globalaccount_trust_configuration is currently not used in the integration tests, since the creation of a custom identity provider is not possible in the live environment.
+
+# resource "btp_globalaccount_trust_configuration" "gtc_idp_testing" {
+#   identity_provider = var.testing_idp
+#   name              = split(".", var.testing_idp)[0]
+#   description       = "Custom Platform Identity Provider for Test Cases"
+# }
 
 ###
 # directories


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Temporarily commented out the globalaccount_trust_configuration resource due to an issue preventing trust configuration creation in the live environment. Once the underlying issue is resolved and trust configurations can be successfully provisioned in the live environment, this resource can be re-enabled and included.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Test setup
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
