### PR TITLE
chore: add issue creation to crossplane after release

### DIFF
--- a/.github/workflows/inform-crossplane.yml
+++ b/.github/workflows/inform-crossplane.yml
@@ -1,0 +1,44 @@
+name: Inform Crossplane Provider
+
+# Decoupled from the release workflow: runs only after "Terraform Provider Release"
+# completes successfully. Failures here never affect the release run.
+on:
+  workflow_run:
+    workflows: ["Terraform Provider Release"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  create-crossplane-issue:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue in crossplane-provider-btp
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GH_CROSSPLANE_TOKEN }}
+          script: |
+            const tag = context.payload.workflow_run.head_branch; // the pushed "v*" tag
+            const source = { owner: context.repo.owner, repo: context.repo.repo };
+            const target = { owner: "SAP", repo: "crossplane-provider-btp" };
+
+            // Fetch the release notes for the tag that triggered the release.
+            const release = await github.rest.repos.getReleaseByTag({
+              ...source,
+              tag,
+            });
+
+            const title = `[TASK] Check new Terraform provider version (BTP) ${tag}`;
+            const body = [
+              "Please check the latest release of the Terraform Provider for SAP BTP for upjet",
+              "",
+              release.data.body || "",
+            ].join("\n");
+
+            await github.rest.issues.create({
+              ...target,
+              title,
+              body,
+            });

--- a/.github/workflows/inform-crossplane.yml
+++ b/.github/workflows/inform-crossplane.yml
@@ -20,9 +20,28 @@ jobs:
         with:
           github-token: ${{ secrets.GH_CROSSPLANE_TOKEN }}
           script: |
-            const tag = context.payload.workflow_run.head_branch; // the pushed "v*" tag
             const source = { owner: context.repo.owner, repo: context.repo.repo };
             const target = { owner: "SAP", repo: "crossplane-provider-btp" };
+
+            // head_branch is unreliable for tag-push runs (can be null), so resolve
+            // the pushed "v*" tag from the commit SHA instead.
+            const sha = context.payload.workflow_run.head_sha;
+            const match = await github.paginate(
+              github.rest.repos.listTags,
+              { ...source, per_page: 100 },
+              (response, done) => {
+                const hit = response.data.find(
+                  (t) => t.commit.sha === sha && t.name.startsWith("v"),
+                );
+                if (hit) done();
+                return hit ? [hit] : [];
+              },
+            );
+            if (match.length === 0) {
+              core.setFailed(`No "v*" tag found for commit ${sha}`);
+              return;
+            }
+            const tag = match[0].name;
 
             // Fetch the release notes for the tag that triggered the release.
             const release = await github.rest.repos.getReleaseByTag({
@@ -31,11 +50,31 @@ jobs:
             });
 
             const title = `[TASK] Check new Terraform provider version (BTP) ${tag}`;
+
+            // Dedup: re-runs/retries of the release workflow must not create duplicate tasks.
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${target.owner}/${target.repo} is:issue is:open in:title "${title}"`,
+              per_page: 10,
+            });
+            const dupe = existing.data.items.find(
+              (i) => !i.pull_request && i.title === title,
+            );
+
             const body = [
               "Please check the latest release of the Terraform Provider for SAP BTP for upjet",
               "",
               release.data.body || "",
             ].join("\n");
+
+            if (dupe) {
+              console.log(`Issue already exists (#${dupe.number}), commenting instead.`);
+              await github.rest.issues.createComment({
+                ...target,
+                issue_number: dupe.number,
+                body: `Release workflow ran again for ${tag}.\n\n${body}`,
+              });
+              return;
+            }
 
             await github.rest.issues.create({
               ...target,

--- a/.github/workflows/inform-crossplane.yml
+++ b/.github/workflows/inform-crossplane.yml
@@ -67,7 +67,7 @@ jobs:
             );
 
             const body = [
-              "Please check the latest release of the Terraform Provider for SAP BTP for upjet",
+              "Please check the latest release of the Terraform Provider for SAP BTP for Upjet",
               "",
               release.data.body || "",
             ].join("\n");

--- a/.github/workflows/inform-crossplane.yml
+++ b/.github/workflows/inform-crossplane.yml
@@ -44,10 +44,16 @@ jobs:
             const tag = match[0].name;
 
             // Fetch the release notes for the tag that triggered the release.
-            const release = await github.rest.repos.getReleaseByTag({
-              ...source,
-              tag,
-            });
+            let release;
+            try {
+              release = await github.rest.repos.getReleaseByTag({
+                ...source,
+                tag,
+              });
+            } catch (err) {
+              core.setFailed(`Could not fetch release for tag ${tag}: ${err.message}`);
+              return;
+            }
 
             const title = `[TASK] Check new Terraform provider version (BTP) ${tag}`;
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- The Crossplane provider for SAP BTP uses upjet to bridge some resources from the Terraform provider for SAP BTP. Consequently, it is necessary to inform the team about a new version and let them decide (based on the release notes) if an update is needed or not.
- This PR contains the code of a Github Workflow that gets triggered after a successful release of the Terraform provider for SAP BTP. The workflow creates a issue in the repository of the Crossplane provider containing the relevant information.
- The GH Action is completely decoupled from the GH workflow of the release

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Internal Setup
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->
n/a

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
