### PR TITLE
fix: deserialize service instance parameters returned as a flat object

### DIFF
--- a/internal/btpcli/types/servicemanager/model_service_instance_parameters.go
+++ b/internal/btpcli/types/servicemanager/model_service_instance_parameters.go
@@ -7,10 +7,26 @@
 
 package servicemanager
 
+import "encoding/json"
+
+// ServiceInstanceParametersPlain models the parameter response of a service
+// instance that returns its parameters as a flat, top-level JSON object, e.g.
+//
+//	{"backend":{"api_enabled":true},"ingest_otlp":{"enabled":true}}
+//
+// The whole body IS the parameter map, so a struct tag cannot address it — the
+// map is populated via a custom UnmarshalJSON. A plain `json:"-"` tag here left
+// the field permanently empty, silently dropping instance parameters (#278).
 type ServiceInstanceParametersPlain struct {
 	Parameters map[string]any `json:"-"`
 }
 
+func (p *ServiceInstanceParametersPlain) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &p.Parameters)
+}
+
+// ServiceInstanceParametersData models the response of instances that wrap
+// their parameters in a top-level "data" object.
 type ServiceInstanceParametersData struct {
 	Parameters map[string]any `json:"data,omitempty"`
 }

--- a/internal/btpcli/types/servicemanager/model_service_instance_parameters_test.go
+++ b/internal/btpcli/types/servicemanager/model_service_instance_parameters_test.go
@@ -1,0 +1,65 @@
+package servicemanager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The Service Manager returns instance parameters as a flat, top-level JSON
+// object (verified against a live cloud-logging instance, issue #278):
+//
+//	{"backend":{"api_enabled":true,"max_data_nodes":2},"ingest_otlp":{"enabled":true}}
+//
+// ServiceInstanceParametersPlain must deserialize that whole body into
+// Parameters. Previously the field carried `json:"-"`, so it was never
+// populated and instance parameters silently vanished.
+func TestServiceInstanceParametersPlain_UnmarshalFlatBody(t *testing.T) {
+	raw := `{"backend":{"api_enabled":true,"max_data_nodes":2},"ingest_otlp":{"enabled":true}}`
+
+	var p ServiceInstanceParametersPlain
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(p.Parameters) == 0 {
+		t.Fatalf("expected parameters to be populated from flat body, got empty map: %#v", p.Parameters)
+	}
+
+	ingest, ok := p.Parameters["ingest_otlp"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected ingest_otlp object in parameters, got: %#v", p.Parameters["ingest_otlp"])
+	}
+	if ingest["enabled"] != true {
+		t.Errorf("expected ingest_otlp.enabled=true, got %#v", ingest["enabled"])
+	}
+
+	backend, ok := p.Parameters["backend"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected backend object in parameters, got: %#v", p.Parameters["backend"])
+	}
+	if backend["api_enabled"] != true {
+		t.Errorf("expected backend.api_enabled=true, got %#v", backend["api_enabled"])
+	}
+}
+
+// Instances without parameters must keep working: an empty JSON object, a JSON
+// null, and an empty body (io.EOF at the caller) must all deserialize cleanly
+// to an empty/nil map — never an error, never a panic. doGet() then treats
+// len(Parameters)==0 as "no parameters", exactly as before the fix.
+func TestServiceInstanceParametersPlain_UnmarshalWithoutParameters(t *testing.T) {
+	cases := map[string]string{
+		"empty object": `{}`,
+		"json null":    `null`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			var p ServiceInstanceParametersPlain
+			if err := json.Unmarshal([]byte(raw), &p); err != nil {
+				t.Fatalf("unmarshal of %q failed: %v", raw, err)
+			}
+			if len(p.Parameters) != 0 {
+				t.Errorf("expected empty parameters for %q, got: %#v", raw, p.Parameters)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

For `btp_subaccount_service_instance`, a `parameters`-only change on an existing instance was never detected as drift and never reached SAP BTP — even for service offerings whose parameters *are* retrievable (`instances_retrievable: true`, e.g. `cloud-logging`).

Root cause is in the parameter response deserialization. `ServiceInstanceParametersPlain` declared its map with a `json:"-"` tag:

```go
type ServiceInstanceParametersPlain struct {
    Parameters map[string]any `json:"-"`
}
```

`json:"-"` tells the decoder to *ignore* the field entirely, so it was never populated. These offerings return their parameters as a **flat, top-level JSON object**, e.g.:

```json
{"backend":{"api_enabled":true,"max_data_nodes":2},"ingest_otlp":{"enabled":true}}
```

`GetById` / `doGet` fetched that body correctly (HTTP 200, non-empty), but both parse attempts came back empty (`ServiceInstanceParametersData` expects a `data` wrapper that isn't there; `ServiceInstanceParametersPlain` has `json:"-"`). So `cliRes.Parameters` was left `""`, `Read()` kept the stale state value, and Terraform saw no diff.

## The fix

Add a custom `UnmarshalJSON` to `ServiceInstanceParametersPlain` that reads the whole body into the parameter map — the flat object *is* the parameter map, which a struct tag cannot address:

```go
func (p *ServiceInstanceParametersPlain) UnmarshalJSON(data []byte) error {
    return json.Unmarshal(data, &p.Parameters)
}
```

Instances without parameters (empty object / `null` body) still deserialize to an empty map, so `doGet`'s `len(...) != 0` guard behaves exactly as before.

## Verification

- New unit tests in `model_service_instance_parameters_test.go`:
  - flat body with parameters → deserialized correctly (was failing before the fix)
  - empty object `{}` and `null` → empty map, no error
- Verified end-to-end against a live `cloud-logging` instance with a locally-built provider:
  - **before:** `terraform import` left `parameters` empty; a subsequent plan showed a spurious `+ parameters`
  - **after:** import reads the real parameters into state; baseline plan is `No changes`; a `parameters`-only change (adding `ingest_otlp.span_passthrough`) is correctly planned as `~ parameters` in-place update

## Related issues

- Closes #829 — "Service Instance parameters are not returned" (was closed as a general API limitation; for retrievable offerings the value *is* returned and it was the provider-side deserialization dropping it)
- Addresses #1620 — "Support to return service instance parameters" (enables drift detection/reconciliation for retrievable offerings, the short-term path proposed there)
- Related #1211 — JSON parameter normalization
