### PR TITLE
fix: Resolve drift for role collection group/attribute assignments with custom IAS origins

### DIFF
--- a/btp/provider/helper.go
+++ b/btp/provider/helper.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -20,6 +21,21 @@ func originMatches(apiOrigin, stateOrigin string) bool {
 	}
 	return (stateOrigin == "ldap" && apiOrigin == "sap.default") ||
 		(stateOrigin == "sap.default" && apiOrigin == "ldap")
+}
+
+// samlOriginMatches extends originMatches for SAML attribute assignments.
+// For custom IAS tenants the idpDisplayName may differ from the origin key, so as a
+// fallback we check whether the origin key is the first hostname label of the entity ID
+// URL (e.g. origin "myidp" matches samlEntityId "https://myidp.accounts400.ondemand.com").
+func samlOriginMatches(apiOrigin, samlEntityId, stateOrigin string) bool {
+	if originMatches(apiOrigin, stateOrigin) {
+		return true
+	}
+	u, err := url.Parse(samlEntityId)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(u.Hostname()), strings.ToLower(stateOrigin)+".")
 }
 
 func stringNullIfEmpty(val string) types.String {

--- a/btp/provider/helper_origin_test.go
+++ b/btp/provider/helper_origin_test.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestOriginMatches(t *testing.T) {
+	tests := []struct {
+		apiOrigin   string
+		stateOrigin string
+		want        bool
+	}{
+		{"sap.default", "sap.default", true},
+		{"ldap", "ldap", true},
+		{"sap.default", "ldap", true},
+		{"ldap", "sap.default", true},
+		{"sap.custom", "sap.custom", true},
+		{"sap.custom", "ldap", false},
+		{"sap.custom", "sap.default", false},
+		{"", "", true},
+		{"", "ldap", false},
+	}
+
+	for _, tt := range tests {
+		got := originMatches(tt.apiOrigin, tt.stateOrigin)
+		if got != tt.want {
+			t.Errorf("originMatches(%q, %q) = %v, want %v", tt.apiOrigin, tt.stateOrigin, got, tt.want)
+		}
+	}
+}
+
+func TestSamlOriginMatches(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiOrigin    string
+		samlEntityId string
+		stateOrigin  string
+		want         bool
+	}{
+		// Direct idpDisplayName match — same as originMatches
+		{
+			name:         "exact match via idpDisplayName",
+			apiOrigin:    "sap.custom",
+			samlEntityId: "",
+			stateOrigin:  "sap.custom",
+			want:         true,
+		},
+		{
+			name:         "ldap/sap.default alias match",
+			apiOrigin:    "sap.default",
+			samlEntityId: "",
+			stateOrigin:  "ldap",
+			want:         true,
+		},
+		// Custom IAS tenant: idpDisplayName is the hostname, not the origin key
+		{
+			name:         "custom IAS tenant matched via samlEntityId hostname prefix",
+			apiOrigin:    "myidp.accounts400.ondemand.com",
+			samlEntityId: "https://myidp.accounts400.ondemand.com",
+			stateOrigin:  "myidp",
+			want:         true,
+		},
+		{
+			name:         "custom IAS tenant matched via samlEntityId hostname prefix — case insensitive",
+			apiOrigin:    "MYIDP.accounts400.ondemand.com",
+			samlEntityId: "https://MYIDP.accounts400.ondemand.com",
+			stateOrigin:  "myidp",
+			want:         true,
+		},
+		// Reproduces the exact scenario from issue #1670
+		{
+			name:         "issue 1670 — iasproviderdevblr custom origin matched via samlEntityId",
+			apiOrigin:    "iasproviderdevblr.accounts400.ondemand.com",
+			samlEntityId: "https://iasproviderdevblr.accounts400.ondemand.com",
+			stateOrigin:  "iasproviderdevblr",
+			want:         true,
+		},
+		// No match cases
+		{
+			name:         "different origin, no samlEntityId",
+			apiOrigin:    "other.accounts400.ondemand.com",
+			samlEntityId: "",
+			stateOrigin:  "myidp",
+			want:         false,
+		},
+		{
+			name:         "samlEntityId hostname belongs to a different origin",
+			apiOrigin:    "other.accounts400.ondemand.com",
+			samlEntityId: "https://other.accounts400.ondemand.com",
+			stateOrigin:  "myidp",
+			want:         false,
+		},
+		{
+			name:         "origin is prefix of a different origin — no partial match",
+			apiOrigin:    "myidpextra.accounts400.ondemand.com",
+			samlEntityId: "https://myidpextra.accounts400.ondemand.com",
+			stateOrigin:  "myidp",
+			want:         false,
+		},
+		// Edge cases
+		{
+			name:         "empty samlEntityId falls back gracefully",
+			apiOrigin:    "something-else",
+			samlEntityId: "",
+			stateOrigin:  "myidp",
+			want:         false,
+		},
+		{
+			name:         "invalid samlEntityId URL falls back gracefully",
+			apiOrigin:    "something-else",
+			samlEntityId: "://not-a-url",
+			stateOrigin:  "myidp",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := samlOriginMatches(tt.apiOrigin, tt.samlEntityId, tt.stateOrigin)
+			if got != tt.want {
+				t.Errorf("samlOriginMatches(%q, %q, %q) = %v, want %v",
+					tt.apiOrigin, tt.samlEntityId, tt.stateOrigin, got, tt.want)
+			}
+		})
+	}
+}

--- a/btp/provider/resource_directory_role_collection_assignment.go
+++ b/btp/provider/resource_directory_role_collection_assignment.go
@@ -176,13 +176,13 @@ func (rs *directoryRoleCollectionAssignmentResource) Read(ctx context.Context, r
 
 	for _, am := range cliRes.SamlAttributeAssignment {
 		if !state.Groupname.IsNull() {
-			if am.AttributeName == "Groups" && am.AttributeValue == state.Groupname.ValueString() && originMatches(am.IdentityProvider, state.Origin.ValueString()) {
+			if am.AttributeName == "Groups" && am.AttributeValue == state.Groupname.ValueString() && samlOriginMatches(am.IdentityProvider, am.SamlEntityId, state.Origin.ValueString()) {
 				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				return
 			}
 		} else {
-			if am.AttributeName == state.AttributeName.ValueString() && am.AttributeValue == state.AttributeValue.ValueString() && originMatches(am.IdentityProvider, state.Origin.ValueString()) {
+			if am.AttributeName == state.AttributeName.ValueString() && am.AttributeValue == state.AttributeValue.ValueString() && samlOriginMatches(am.IdentityProvider, am.SamlEntityId, state.Origin.ValueString()) {
 				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				return

--- a/btp/provider/resource_globalaccount_role_collection_assignment.go
+++ b/btp/provider/resource_globalaccount_role_collection_assignment.go
@@ -164,13 +164,13 @@ func (rs *globalaccountRoleCollectionAssignmentResource) Read(ctx context.Contex
 
 	for _, am := range cliRes.SamlAttributeAssignment {
 		if !state.Groupname.IsNull() {
-			if am.AttributeName == "Groups" && am.AttributeValue == state.Groupname.ValueString() && originMatches(am.IdentityProvider, state.Origin.ValueString()) {
+			if am.AttributeName == "Groups" && am.AttributeValue == state.Groupname.ValueString() && samlOriginMatches(am.IdentityProvider, am.SamlEntityId, state.Origin.ValueString()) {
 				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				return
 			}
 		} else {
-			if am.AttributeName == state.AttributeName.ValueString() && am.AttributeValue == state.AttributeValue.ValueString() && originMatches(am.IdentityProvider, state.Origin.ValueString()) {
+			if am.AttributeName == state.AttributeName.ValueString() && am.AttributeValue == state.AttributeValue.ValueString() && samlOriginMatches(am.IdentityProvider, am.SamlEntityId, state.Origin.ValueString()) {
 				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				return

--- a/btp/provider/resource_subaccount_role_collection_assignment.go
+++ b/btp/provider/resource_subaccount_role_collection_assignment.go
@@ -172,13 +172,13 @@ func (rs *subaccountRoleCollectionAssignmentResource) Read(ctx context.Context, 
 
 	for _, am := range cliRes.SamlAttributeAssignment {
 		if !state.Groupname.IsNull() {
-			if am.AttributeName == "Groups" && am.AttributeValue == state.Groupname.ValueString() && originMatches(am.IdentityProvider, state.Origin.ValueString()) {
+			if am.AttributeName == "Groups" && am.AttributeValue == state.Groupname.ValueString() && samlOriginMatches(am.IdentityProvider, am.SamlEntityId, state.Origin.ValueString()) {
 				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				return
 			}
 		} else {
-			if am.AttributeName == state.AttributeName.ValueString() && am.AttributeValue == state.AttributeValue.ValueString() && originMatches(am.IdentityProvider, state.Origin.ValueString()) {
+			if am.AttributeName == state.AttributeName.ValueString() && am.AttributeValue == state.AttributeValue.ValueString() && samlOriginMatches(am.IdentityProvider, am.SamlEntityId, state.Origin.ValueString()) {
 				diags = resp.State.Set(ctx, &state)
 				resp.Diagnostics.Append(diags...)
 				return


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Closes: https://github.com/SAP/terraform-provider-btp/issues/1670
- Fixes btp_subaccount_role_collection_assignment (and directory/globalaccount variants) always showing as "will be created" on plan when using a custom IAS origin with group_name or attribute_name. The root cause was the Read function matching the IDP by idpDisplayName only, which for custom IAS tenants contains the entity ID hostname instead of the origin key — fixed by falling back to the samlEntityId URL when the direct match fails.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->
```
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Test the code via automated test

```bash
make test
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [X] The PR status on the Project board is set (typically "in review").
- [X] The PR has the matching labels assigned to it.
- [X] If the PR closes an issue, the issue is referenced.
- [X] Possible follow-up issues are created and linked.
